### PR TITLE
Add test for archives of bundles on command line.

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -20,6 +20,7 @@ TESTS_DIR = \
     issue_001 \
     issue_002 \
     liba_bundled \
+    liba_bundled_cmdline \
     math_sqrt_float \
     nativetests \
     nested_loop \

--- a/test/smoke/liba_bundled_cmdline/Makefile
+++ b/test/smoke/liba_bundled_cmdline/Makefile
@@ -1,0 +1,35 @@
+include ../Makefile.defs
+
+TESTNAME        = liba_bundled
+TESTSRC_MAIN    = main.c
+TESTSRC_AUX     = MyDeviceLib/libMyDeviceLib.a
+TESTSRC_ALL     = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG           = clang
+OMP_BIN         = $(AOMP)/bin/$(CLANG)
+CC              = $(OMP_BIN) $(VERBOSE)
+EXTRA_LDFLAGS   =
+EXTRA_OMP_FLAGS =
+
+ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+  GPUTYPE = nvptx
+else
+  GPUTYPE = amdgcn
+endif
+
+ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+run ::
+	echo "This does not run on nvptx yet"
+clean ::
+	echo "This does not run on nvptx yet"
+else
+
+# Build the host and device libraries
+MyDeviceLib/libMyDeviceLib.a : MyDeviceLib/Makefile MyDeviceLib/func_1v.c MyDeviceLib/func_2v.c MyDeviceLib/func_3v.c
+	AOMP_GPU=$(AOMP_GPU) make -C MyDeviceLib libMyDeviceLib.a
+
+clean ::
+	make -C MyDeviceLib clean
+
+include ../Makefile.rules
+endif

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
@@ -1,0 +1,69 @@
+#===--------- libm/Makefile -----------------------------------------------===
+#
+#                The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+#===----------------------------------------------------------------------===
+#
+# Makefile:  Makefile to build static device library as archive of bc files
+#            written by Greg Rodgers
+#
+
+LIB       = MyDeviceLib
+LIBSRC1   = func_1v
+LIBSRC2   = func_2v
+LIBSRC3   = func_3v
+
+# --- Standard Makefile check for AOMP installation ---
+ifeq ("$(wildcard $(AOMP))","")
+  ifneq ($(AOMP),)
+    $(warning AOMP not found at $(AOMP))
+  endif
+  AOMP = $(HOME)/rocm/aomp
+  ifeq ("$(wildcard $(AOMP))","")
+    $(warning AOMP not found at $(AOMP))
+    AOMP = /opt/rocm/aomp
+    ifeq ("$(wildcard $(AOMP))","")
+      $(warning AOMP not found at $(AOMP))
+      $(error Please install AOMP or correctly set env-var AOMP)
+    endif
+  endif
+endif
+# --- End Standard Makefile check for AOMP installation ---
+AOMP_GPU ?= gfx900
+CC        = $(AOMP)/bin/clang
+UNAMEP    = $(shell uname -p)
+HOST_TARGET = $(UNAMEP)-pc-linux-gnu
+
+ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+  TRIPLE  = nvptx64-nvidia-cuda
+  ARCH    = nvptx
+else
+  TRIPLE  = amdgcn-amd-amdhsa
+  ARCH    = amdgcn
+endif
+
+TMPDIR   ?= ./build
+CFLAGS  = -c -target $(HOST_TARGET) -fopenmp -fopenmp-targets=$(TRIPLE) \
+            -Xopenmp-target=$(TRIPLE) \
+            -march=$(AOMP_GPU) -O2
+
+#   ---------------------  create bundle library -------------------
+#
+lib$(LIB).a : $(TMPDIR)/$(LIBSRC1).o $(TMPDIR)/$(LIBSRC2).o $(TMPDIR)/$(LIBSRC3).o
+	ar r $@ $^
+
+$(TMPDIR)/$(LIBSRC1).o: $(LIBSRC1).c
+	$(CC) $(CFLAGS) $^ -o $@
+$(TMPDIR)/$(LIBSRC2).o: $(LIBSRC2).c
+	$(CC) $(CFLAGS) $^ -o $@
+$(TMPDIR)/$(LIBSRC3).o: $(LIBSRC3).c
+	$(CC) $(CFLAGS)  $^ -o $@
+
+clean:
+	rm -f $(TMPDIR)/*.bc $(TMPDIR)/*.ll $(TMPDIR)/*.o *.a
+	rmdir $(TMPDIR)
+
+$(shell mkdir -p $(TMPDIR))

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_1v.c
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_1v.c
@@ -1,0 +1,7 @@
+void func_1v(float* in, float* out, unsigned n){
+  unsigned i;
+  #pragma omp target teams distribute parallel for map(to: in[0:n]) map(from: out[0:n])
+  for(i=0; i<n; ++i){
+    out[i]=2*in[i];
+  }
+}

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_2v.c
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_2v.c
@@ -1,0 +1,7 @@
+void func_2v(float* in, float* out, unsigned n){
+  unsigned i;
+  #pragma omp target teams distribute parallel for map(to: in[0:n]) map(from: out[0:n])
+  for(i=0; i<n; ++i){
+    out[i]=in[i]/2;
+  }
+}

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_3v.c
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/func_3v.c
@@ -1,0 +1,7 @@
+void func_3v(float* in, float* out, unsigned n){
+  unsigned i;
+  #pragma omp target teams distribute parallel for map(to: in[0:n]) map(from: out[0:n])
+  for(i=0; i<n; ++i){
+    out[i]=in[i]+in[i];
+  }
+}

--- a/test/smoke/liba_bundled_cmdline/main.c
+++ b/test/smoke/liba_bundled_cmdline/main.c
@@ -1,0 +1,55 @@
+#include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+
+#define N 1000
+#define Eps 1e-7
+
+#pragma omp declare target
+void func_1v(float*, float*, unsigned);
+void func_2v(float*, float*, unsigned);
+void func_3v(float*, float*, unsigned);
+#pragma omp end declare target
+
+int main(){
+  float a[N], t1[N], t2[N], s = 0;
+  unsigned i;
+  unsigned nErr = 0;
+
+  srand((unsigned int)time(NULL));
+  #pragma omp parallel for
+  for(i=0; i<N; ++i){
+    a[i]=rand()%100;
+  }
+
+  func_1v(a,t1,N);
+  func_3v(a,t2,N);
+
+  #pragma omp parallel for reduction(+:s)
+  for(i=0; i<N; ++i) s += t1[i];
+  if(s < Eps){
+    printf("Check 0: All elemets are zeros!\n");
+    return -1;
+  }
+
+  for(i=0; i<N; ++i){
+    if(fabs(t1[i]-t2[i]) >= Eps){
+      ++nErr;
+      printf("Check 1: error at %d: %e >= %e\n",i,fabs(t1[i]-t2[i]),Eps);
+    }
+  }
+
+  func_2v(t1,t2,N);
+
+  for(i=0; i<N; ++i){
+    if(fabs(a[i]-t2[i]) >= Eps){
+      ++nErr;
+      printf("Check 2: error at %d: %e >= %e\n",i,fabs(a[i]-t2[i]),Eps);
+    }
+  }
+
+  if(!nErr) printf("Success\n");
+
+  return nErr;
+}


### PR DESCRIPTION
Just a modified liba_bundled without the -L and -l options, and only provide the archive on the command line. Only works for amdgcn for now.