### PR TITLE
Move NUM_THREADS to aomp_common_vars

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -66,6 +66,15 @@ fi
 GFXLIST=${GFXLIST:-"gfx700 gfx701 gfx801 gfx803 gfx900 gfx902 gfx906"}
 export GFXLIST
 
+# Calculate the number of threads to use for make
+NUM_THREADS=
+if [ ! -z `which "getconf"` ]; then
+   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
+   if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
+      NUM_THREADS=$(( NUM_THREADS / 4))
+   fi
+fi
+
 # These are the web sites where the AOMP git repos are pulled from
 GITROC="https://github.com/radeonopencompute"
 GITROCDEV="https://github.com/ROCm-Developer-Tools"

--- a/bin/build_atmi.sh
+++ b/bin/build_atmi.sh
@@ -75,11 +75,6 @@ else
    HSACMAKEOPTS=""
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-    NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-fi
-
 export LLVM_DIR=$AOMP_INSTALL_DIR
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then 
 

--- a/bin/build_clang.sh
+++ b/bin/build_clang.sh
@@ -70,15 +70,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_CLANG/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_comgr.sh
+++ b/bin/build_comgr.sh
@@ -65,11 +65,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_COMGR/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-    NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-fi
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then 
 
    echo " " 

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -103,15 +103,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_EXTRAS/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-
-fi
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
   if [ -d "$BUILD_DIR/build/extras" ] ; then

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -63,15 +63,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_FLANG/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_flang_runtime.sh
+++ b/bin/build_flang_runtime.sh
@@ -63,15 +63,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_FLANG/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_hcc.sh
+++ b/bin/build_hcc.sh
@@ -109,21 +109,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_HCC/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 4))
-      echo
-      echo
-      echo "---------------------------------  $NUM_THREADS JOBS --------------------------"
-      echo
-      echo
-   fi
-fi
-
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    #  When build_hcc.sh is run with no args, start fresh and clean out the build directory.
    echo 

--- a/bin/build_hip.sh
+++ b/bin/build_hip.sh
@@ -109,15 +109,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_HIP/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-
-fi
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
   if [ -d "$BUILD_DIR/build/hip" ] ; then

--- a/bin/build_libdevice.sh
+++ b/bin/build_libdevice.sh
@@ -52,18 +52,6 @@ if [ ! -d $AOMP_INSTALL_DIR/lib ] ; then
   exit 1
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-   # having problems on arm so ...
-   if  [ "$AOMP_PROC" == "aarch64" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 4))
-   fi
-fi
-
 export LLVM_BUILD HSA_DIR
 export PATH=$LLVM_BUILD/bin:$PATH
 

--- a/bin/build_lld.sh
+++ b/bin/build_lld.sh
@@ -65,15 +65,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_LLD/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_llvm.sh
+++ b/bin/build_llvm.sh
@@ -98,15 +98,6 @@ if [ $? != 0 ] ; then
 fi
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -72,11 +72,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_OPENMP/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-    NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-fi
-
 GCCMIN=7
 if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    if [ -f $CUDABIN/nvcc ] ; then

--- a/bin/build_pgmath.sh
+++ b/bin/build_pgmath.sh
@@ -64,15 +64,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_FLANG/testfile
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -94,15 +94,6 @@ if [ $? != 0 ] ; then
 fi
 fi
 
-# Calculate the number of threads to use for make
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-   if [ "$AOMP_PROC" == "ppc64le" ] ; then
-      NUM_THREADS=$(( NUM_THREADS / 2))
-   fi
-fi
-
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 

--- a/bin/build_rocr.sh
+++ b/bin/build_rocr.sh
@@ -71,11 +71,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_ROCM/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-    NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-fi
-
 cd $AOMP_REPOS/$AOMP_ROCR_REPO_NAME
 echo patch -p1 $thisdir/rocr-runtime.patch
 patch -p1 < $thisdir/rocr-runtime.patch

--- a/bin/build_roct.sh
+++ b/bin/build_roct.sh
@@ -65,11 +65,6 @@ if [ "$1" == "install" ] ; then
    $SUDO rm $INSTALL_ROCT/testfile
 fi
 
-NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-    NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
-fi
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then 
 
    echo " " 


### PR DESCRIPTION
 Move NUM_THREADS to aomp_common_vars

NUM_THREADS was sometimes divided by 2 for non-x64 arch, and in a couple of cases by 4. This patch folds all of that into a common path of divide by 4, please comment if that's considered a step too far.

Motivation for this diff is to facilitate a local patch that overrides NUM_THREADS to a larger value in order to compile across a couple of computers.