### PR TITLE
Add test case for omp locks (will hang with current implementation)

### DIFF
--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -34,7 +34,7 @@ echo "                   A non-zero exit code means a failure occured." >> check
 echo "Tests that need to be visually inspected: devices, pfspecify, pfspecify_str, stream" >> check-smoke.txt
 echo "***********************************************************************************" >> check-smoke.txt
 
-known_fails="red_bug_51 reduction_array_section target_teams_reduction tasks"
+known_fails="red_bug_51 reduction_array_section target_teams_reduction tasks omp_lock"
 
 if [ "$SKIP_FAILURES" == 1 ] ; then
   skip_tests=$known_fails

--- a/test/smoke/omp_lock/Makefile
+++ b/test/smoke/omp_lock/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.defs
+
+TESTNAME     = omp_lock
+TESTSRC_MAIN = omp_lock.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke/omp_lock/omp_lock.c
+++ b/test/smoke/omp_lock/omp_lock.c
@@ -1,0 +1,67 @@
+#include <omp.h>
+#include <stdio.h>
+
+#define THREADS 512
+#define WARPSIZE 64
+
+#pragma omp declare target
+omp_lock_t lock;
+#pragma omp end declare target
+
+int main() {
+
+  int error = 0;
+  unsigned count = 0;          // incremented within target region
+  unsigned expected_count = 0; // incremented on host
+
+#pragma omp target
+  omp_init_lock(&lock);
+
+
+  // The lock implementation picks a thread from the warp to avoid the
+  // deadlock that results if multiple threads try to CAS-loop at once
+
+  // The lower/upper construct checks various active warp patterns
+
+  const int edges[] = {0, 1, 32, 62, 63};
+  const int N = sizeof(edges) / sizeof(edges[0]);
+  for (int l = 0; l < N; l++) {
+    for (int u = 0; u < N; u++) {
+      int lower = edges[l];
+      int upper = edges[u];
+      if (lower > upper)
+        continue;
+
+      expected_count += THREADS / WARPSIZE;
+
+#pragma omp target parallel num_threads(THREADS) map(tofrom : error, count)
+      {
+        int lane_id = omp_ext_get_lane_id();
+        if (lane_id >= lower && lane_id <= upper) {
+
+          omp_set_lock(&lock); // mutex acts on a per warp basis
+
+          if (omp_ext_get_lane_id() == lower) {
+            // Increment once per warp
+            count++;
+          }
+
+          if (!omp_test_lock(&lock)) {
+            error = 1;
+          }
+
+          omp_unset_lock(&lock);
+        }
+      }
+    }
+  }
+
+#pragma omp target
+  omp_destroy_lock(&lock);
+
+  if (count != expected_count) {
+    error = 1;
+  }
+
+  return error;
+}


### PR DESCRIPTION
The boundary checking is to catch a lock implementation which just uses lane(0) to do the cas, which fails if that lane happens to be inactive.

Assumes the mutex is per warp, which is the closest we can get to per thread. That's not necessarily what the user will expect, but as the current implementation of locks is an immediate deadlock that would still be an improvement.

See also #50 