### PR TITLE
Add a test that checks that wtime exists, and is not deduplicated

### DIFF
--- a/test/smoke/omp_wtime/Makefile
+++ b/test/smoke/omp_wtime/Makefile
@@ -1,0 +1,12 @@
+include ../Makefile.defs
+
+TESTNAME     = omp_wtime
+TESTSRC_MAIN = omp_wtime.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke/omp_wtime/omp_wtime.c
+++ b/test/smoke/omp_wtime/omp_wtime.c
@@ -1,0 +1,15 @@
+#include <omp.h>
+
+int main()
+{
+  double time0, time1;
+#pragma omp target map(from: time0, time1)
+  {
+    // calls to wtime should not be folded together
+   time0 = omp_get_wtime();
+   time1 = omp_get_wtime();
+  }
+
+   double delta = time1 - time0;
+   return delta == 0.; // success if they differ
+}


### PR DESCRIPTION
Test is motivated by noticing that using wtime on older architectures will cause a link error. That will be fixed shortly.