### PR TITLE
Add -std=c++11 flag to tests that need it, compiler should not set th…

### DIFF
--- a/examples/cloc/vector_copy_hip/Makefile
+++ b/examples/cloc/vector_copy_hip/Makefile
@@ -6,7 +6,7 @@ ifeq ($(AOMP),)
   AOMP = /usr/lib/aomp
 endif
 
-CFLAGS = -c -std=c++11 -D__HIP_PLATFORM_HCC__ -I$(AOMP)/../include
+CFLAGS = -c -std=c++11 -D__HIP_PLATFORM_HCC__ -I$(AOMP)/../include -I$(AOMP)/include
 # Set the rpath to pick up AOMP libs in case rocm was installed.
 LFLAGS = -L$(AOMP)/lib -lhip_hcc -Wl,-rpath,$(AOMP)/lib
 # find the current gpu, default to vega10 if unknown
@@ -18,14 +18,14 @@ OBJ_FILES := $(addprefix obj/, $(notdir $(CXX_FILES:.cpp=.o)))
 all: $(TEST_NAME) $(HIP_FILE).hsaco
 
 $(TEST_NAME): $(OBJ_FILES) $(COMMON_OBJ_FILES)
-	$(AOMP)/bin/clang++ $(OBJ_FILES) $(LFLAGS) -o $(TEST_NAME)
+	$(AOMP)/bin/clang++ $(OBJ_FILES) $(LFLAGS) -o $(TEST_NAME) -std=c++11
 
 $(HIP_FILE).hsaco:
-	$(AOMP)/bin/cloc.sh -mcpu $(MYGPU) $(HIP_FILE).cu
+	$(AOMP)/bin/cloc.sh -mcpu $(MYGPU) $(HIP_FILE).cu -std=c++11
 
 obj/%.o: %.cpp
 	mkdir -p obj
-	$(AOMP)/bin/clang++ $(CFLAGS) -o $@ $<
+	$(AOMP)/bin/clang++ $(CFLAGS) -o $@ $< -std=c++11
 
 clean:
 	rm -rf obj/*o *.hsaco *.ll $(TEST_NAME)

--- a/examples/hip/device_lib/Makefile
+++ b/examples/hip/device_lib/Makefile
@@ -40,7 +40,7 @@ writeIndex: writeIndex.hip lib_mylib.a libbc-_mylib-amdgcn.a   lib_myomplib.a
 	@echo " ----------  3 Build HIP application using both SDLs ----------------" 
 	@echo
 	@echo " 3. Create HIP app using both _mylib and _myomplib SDLs. 		$@"
-	$(HIPCC) -L$(PWD) -l_myomplib -l_mylib writeIndex.hip -o $@
+	$(HIPCC) -L$(PWD) -l_myomplib -l_mylib writeIndex.hip -o $@ -std=c++11
 
 inc_arrayval.o: inc_arrayval.c
 	@echo

--- a/examples/hip/matrixmul/Makefile
+++ b/examples/hip/matrixmul/Makefile
@@ -71,9 +71,9 @@ CC       =$(AOMP)/bin/clang++
 # Add cudart only if we have an Nvidia sm_ target
 ifeq (sm_,$(findstring sm_,$(TARGETS)))
   LFLAGS +=-L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,$(CUDA)/targets/$(UNAMEP)-linux/lib
-  CFLAGS +=-x cuda -I$(CUDA)/include
+  CFLAGS +=-x cuda -I$(CUDA)/include -std=c++11
 else
-  CFLAGS = -x hip
+  CFLAGS = -x hip -std=c++11
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/examples/hip/vectorAdd/Makefile
+++ b/examples/hip/vectorAdd/Makefile
@@ -73,10 +73,10 @@ LFLAGS   =-L$(AOMP)/lib
 
 # Add cudart only if we have an Nvidia sm_ target
 ifeq (sm_,$(findstring sm_,$(TARGETS)))
-  LFLAGS +=-L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,$(CUDA)/targets/$(UNAMEP)-linux/lib
+  LFLAGS +=-L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,$(CUDA)/targets/$(UNAMEP)-linux/lib -std=c++11
   CFLAGS +=-x cuda -I$(CUDA)/include
 else
-  CFLAGS = -x hip
+  CFLAGS = -x hip -std=c++11
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/examples/hip/writeIndex/Makefile
+++ b/examples/hip/writeIndex/Makefile
@@ -30,7 +30,7 @@ CC   =$(AOMP)/bin/hipcc
 
 # --- Demo compile and link in one step, no object code saved
 writeIndex: writeIndex.cpp kernel.cpp
-	$(CC) $^ -o $@
+	  $(CC) $^ -o $@ -std=c++11
 run: writeIndex
 	LD_LIBRARY_PATH=$(AOMP)/lib ./writeIndex
 

--- a/test/hip-openmp/aomp_hip_launch_test/Makefile
+++ b/test/hip-openmp/aomp_hip_launch_test/Makefile
@@ -75,7 +75,7 @@ else
   PLATFORM = -D__HIP_PLATFORM_HCC__=1
 endif
 
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11
 OMP_TARGET_FLAGS = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$(AOMP_GPU) --save-temps 
 CC=$(AOMP)/bin/clang
 

--- a/test/hip-openmp/hip_pthread/Makefile
+++ b/test/hip-openmp/hip_pthread/Makefile
@@ -76,7 +76,7 @@ else
 endif
 
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = 
 

--- a/test/hip-openmp/hip_std_thread/Makefile
+++ b/test/hip-openmp/hip_std_thread/Makefile
@@ -62,7 +62,7 @@ ifeq ($(AOMP_GPU),)
 AOMP_GPU = $(shell $(AOMP)/bin/mygpu -d gfx900) #get installed card, if unknown return gfx900
 endif
 
-CC = $(AOMP)/bin/clang++
+CC = $(AOMP)/bin/clang++ -std=c++11
 
 # Add cudart only if we have an Nvidia sm_ target
 # We have not tested CUDA+OpenMP target offload
@@ -76,7 +76,7 @@ else
 endif
 
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread 
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = 
 

--- a/test/hip-openmp/kern_latency/Makefile
+++ b/test/hip-openmp/kern_latency/Makefile
@@ -67,7 +67,7 @@ ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(AOMP_GPU)
 endif
 
-CC       =$(AOMP)/bin/clang++
+CC       =$(AOMP)/bin/clang++ -std=c++11
 #CFLAGS   =-O3 --target=$(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target amdgcn-amd-amdhsa #--offload-arch=$(AOMP_GPU)
 #CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
 CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp

--- a/test/hip-openmp/matrixmul_omp_copy/Makefile
+++ b/test/hip-openmp/matrixmul_omp_copy/Makefile
@@ -67,7 +67,7 @@ ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(AOMP_GPU)
 endif
 
-CC       =$(AOMP)/bin/clang++
+CC       =$(AOMP)/bin/clang++ -std=c++11
 #CFLAGS   =-O3 --target=$(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target amdgcn-amd-amdhsa #--offload-arch=$(AOMP_GPU)
 #CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
 CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp

--- a/test/hip-openmp/matrixmul_omp_for/Makefile
+++ b/test/hip-openmp/matrixmul_omp_for/Makefile
@@ -67,7 +67,7 @@ ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(AOMP_GPU)
 endif
 
-CC       =$(AOMP)/bin/clang++
+CC       =$(AOMP)/bin/clang++ -std=c++11
 #CFLAGS   =-O3 --target=$(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target amdgcn-amd-amdhsa #--offload-arch=$(AOMP_GPU)
 #CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
 CFLAGS   = -O3 -target $(AOMP_CPUTARGET) -fopenmp

--- a/test/hip-openmp/matrixmul_omp_target/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target/Makefile
@@ -62,7 +62,7 @@ ifeq ($(AOMP_GPU),)
 AOMP_GPU = $(shell $(AOMP)/bin/mygpu -d gfx900) #get installed card, if unknown return gfx900
 endif
 
-CC = $(AOMP)/bin/clang++
+CC = $(AOMP)/bin/clang++ -std=c++11
 
 # Add cudart only if we have an Nvidia sm_ target
 # We have not tested CUDA+OpenMP target offload

--- a/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
@@ -62,7 +62,7 @@ ifeq ($(AOMP_GPU),)
 AOMP_GPU = $(shell $(AOMP)/bin/mygpu -d gfx900) #get installed card, if unknown return gfx900
 endif
 
-CC = $(AOMP)/bin/clang++
+CC = $(AOMP)/bin/clang++ -std=c++11
 
 # Add cudart only if we have an Nvidia sm_ target
 # We have not tested CUDA+OpenMP target offload

--- a/test/hip-openmp/matrixmul_omp_task/Makefile
+++ b/test/hip-openmp/matrixmul_omp_task/Makefile
@@ -65,7 +65,7 @@ ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(AOMP_GPU)
 endif
 
-CC       =$(AOMP)/bin/clang++
+CC       =$(AOMP)/bin/clang++ -std=c++11
 #CFLAGS   =-O3 --target=$(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target amdgcn-amd-amdhsa #--offload-arch=$(AOMP_GPU)
 #CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
 CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp

--- a/test/hip-openmp/omp_hip/Makefile
+++ b/test/hip-openmp/omp_hip/Makefile
@@ -67,7 +67,7 @@ ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(AOMP_GPU)
 endif
 
-CC       =$(AOMP)/bin/clang++
+CC       =$(AOMP)/bin/clang++ -std=c++11
 #CFLAGS   =-O3 --target=$(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target amdgcn-amd-amdhsa #--offload-arch=$(AOMP_GPU)
 #CFLAGS   =-x hip -O3 -target $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx900
 CFLAGS   = -O3 -target $(AOMP_CPUTARGET) -fopenmp

--- a/test/smoke/hip_device_compile/Makefile
+++ b/test/smoke/hip_device_compile/Makefile
@@ -5,10 +5,10 @@ TESTSRC_MAIN = hip_device_compile.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
-CFLAGS = -x cuda -I/usr/local/cuda/include --offload-arch=${AOMP_GPU}
+CFLAGS = -x cuda -I/usr/local/cuda/include --offload-arch=${AOMP_GPU} -std=c++11
 LINK_FLAGS =  -L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,/usr/local/cuda/targets/x86_64-linux/lib
 else
-CFLAGS = -x hip --offload-arch=${AOMP_GPU}
+CFLAGS = -x hip --offload-arch=${AOMP_GPU} -std=c++11
 endif
 OMP_FLAGS    =
 

--- a/test/smoke/hip_rocblas/Makefile
+++ b/test/smoke/hip_rocblas/Makefile
@@ -6,7 +6,7 @@ TESTSRC_MAIN = hip_rocblas.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 OMP_FLAGS    =  --offload-arch=${AOMP_GPU}
-CFLAGS       = -x hip -I /opt/rocm/rocblas/include/ --offload-arch=${AOMP_GPU} 
+CFLAGS       = -x hip -I /opt/rocm/rocblas/include/ --offload-arch=${AOMP_GPU} -std=c++11
 LINK_FLAGS =  -L /opt/rocm/rocblas/lib -lrocblas -Wl,-rpath,/opt/rocm/rocblas/lib
 
 CLANG        = clang++


### PR DESCRIPTION
…is flag itself - gerrit review

Review feedback from patch #6 http://gerrit-git.amd.com/c/lightning/ec/llvm-project/+/358446 observed that AOMP added flagsg -std=c++11 explicitly and to compiles and should not do this. Users/tests should request the proper c++ support flag when warranted.

i have modified all the smoke and hip tests that need to explicitly set the flag . 