### PR TITLE
OMPD: demo script modifications

### DIFF
--- a/test/hip-openmp/matrixmul_omp_for/do_debug
+++ b/test/hip-openmp/matrixmul_omp_for/do_debug
@@ -1,14 +1,10 @@
 #!/bin/bash
 bldcmd="$AOMP/bin/hipcc -O0 -g -ggdb  -fopenmp matrixmul.cpp -o matrixmul"
-gdbcmd="$AOMP/bin/rocgdb -x $AOMP/lib-debug/ompd/__init__.py ./matrixmul -ex \"ompd init\" -ex \"set confirm off\" \
-	-ex \"set breakpoint pending on\" -ex \"b matrixMul\" -ex \"c\" -ex \"bt\" -ex \"thr\" -ex \"show architecture\" \
-	-ex \"x/10i \$pc\" -ex \"i share\" \
-	-ex \"ompd threads\" -ex \"thr 1\" -ex \"bt\" -ex \"ompd bt on continued\" -ex \"bt\" \
-	-ex \"thr 4\" -ex \"bt\" -ex \"q\""
 #cgdb=`which cgdb` && [ "$cgdb" != "" ] && gdbcmd="$cgdb -d $gdbcmd"
 
 export LD_LIBRARY_PATH=$AOMP/lib-debug:$AOMP/lib
 export OMP_DEBUG=enabled
+export OMP_NUM_THREADS=3
 
 echo
 echo $bldcmd
@@ -17,10 +13,6 @@ echo
 echo $gdbcmd
 echo
 #$gdbcmd
-$AOMP/bin/rocgdb -x $AOMP/lib-debug/ompd/__init__.py ./matrixmul -ex "ompd init" -ex "set confirm off" \
-	-ex "set breakpoint pending on" -ex "b matrixMul" -ex "c" -ex "bt" -ex "thr" -ex "show architecture" \
-	-ex "x/10i \$pc" -ex "i share" \
-	-ex "ompd threads" -ex "thr 1" -ex "bt" -ex "ompd bt on continued" -ex "bt" \
-	-ex "thr 4" -ex "bt" -ex "q"
+$AOMP/bin/rocgdb -x  "$AOMP/lib-debug/ompd/__init__.py" ./matrixmul -ex "source do_debug_command_file"
 
 

--- a/test/hip-openmp/matrixmul_omp_for/do_debug_command_file
+++ b/test/hip-openmp/matrixmul_omp_for/do_debug_command_file
@@ -1,0 +1,46 @@
+# Set trace-commands to 'on' to have the commands printed out prefixed with a + before getting executed
+set trace-commands on
+ompd init
+set confirm off
+set breakpoint pending on
+# Place a temporary breakpoint in the parallel for region inside randomizeMatrix()
+# This should be breakpoint number 3
+tbreak matrixmul.cpp:90 thread 1
+# Place a temporary breakpoint inside the hip kernel
+tbreak matrixMul
+# Commands to be run when we hit the breakpoint in randomizeMatrix()
+commands 3
+bt
+ompd bt on continued
+set trace-commands off
+# This should display the context of the nested parallel regions
+bt
+set trace-commands on
+# Show the hierarchy of parallel regions
+ompd parallel
+# Display the values of the ICVs
+ompd icvs
+ompd bt off
+# End of commands to be executed at Breakpoint 3 (matrixmul.cpp:89)
+end
+c
+# We should have hit the breakpoint in the hip kernel
+# Commands below to demonstrate that we are in the hip kernel
+bt
+thr
+show architecture
+x/5i $pc
+i share
+ompd threads
+# Switch focus to the master thread
+thr 1
+bt
+ompd bt on continued
+set trace-commands off
+bt
+set trace-commands on
+ompd parallel
+ompd icvs
+q
+
+

--- a/test/hip-openmp/matrixmul_omp_for/matrixmul.cpp
+++ b/test/hip-openmp/matrixmul_omp_for/matrixmul.cpp
@@ -24,6 +24,7 @@
 
 #include "hip/hip_runtime.h"
 #include <stdio.h>
+#include <omp.h>
 
 #define N 3
 #define M 3
@@ -84,6 +85,8 @@ void printHipError(hipError_t error) {
 }
 
 void randomizeMatrix(int *matrix, int Rows, int Cols) {
+  omp_set_num_threads(2);
+#pragma omp parallel for
   for (int i = 0; i < Rows * Cols; ++i)
     matrix[i] = rand() % 10;
 }
@@ -157,15 +160,15 @@ int main() {
 
     if (matrixAAllocated && matrixBAllocated && matrixCAllocated) {
       bool copiedSrcMatA=false, copiedSrcMatB=false;
-//#pragma omp task shared(copiedSrcMatA)
+#pragma omp task shared(copiedSrcMatA)
       copiedSrcMatA = hipCallSuccessful(hipMemcpy(deviceSrcMatA, hostSrcMatA,
                                                      N * M * sizeof(int),
                                                      hipMemcpyHostToDevice));
-//#pragma omp task shared(copiedSrcMatB)
+#pragma omp task shared(copiedSrcMatB)
       copiedSrcMatB = hipCallSuccessful(hipMemcpy(deviceSrcMatB, hostSrcMatB,
                                                      M * P * sizeof(int),
                                                      hipMemcpyHostToDevice));
-//#pragma omp taskwait
+#pragma omp taskwait
       if (copiedSrcMatA && copiedSrcMatB) {
         dim3 dimGrid(N, P);
         matrixMul<<<dimGrid, 1, 0, 0>>>(deviceSrcMatA, deviceSrcMatB,


### PR DESCRIPTION
Changes include: 

1. Modifying the script to take in commands from a commands file: do_debug_command_file.
2. Adding the commands file: do_debug_command_file
3. Using "set trace-commands on/off" to turn the display of commands being executed on/off
4. Using the new plugin commands  -- "ompd parallel" and "ompd icvs"
5. Modifying matrixmul.cpp to add nested parallel regions