### PR TITLE
Add rpath to the hip tests to lock in libs, hipcc dos it, clang -x do…

### DIFF
--- a/examples/hip/matrixmul/Makefile
+++ b/examples/hip/matrixmul/Makefile
@@ -74,8 +74,8 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
   CFLAGS +=-x cuda -I$(CUDA)/include -std=c++11
 else
   AOMPHIP ?= $(AOMP)
-  HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip  $(HIPLIBS) -lamdhip64
+  HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib  -Wl,-rpath,$(AOMPHIP)/lib
+  CFLAGS += -x hip  $(HIPLIBS) -lamdhip64 -std=c++11
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/examples/hip/vectorAdd/Makefile
+++ b/examples/hip/vectorAdd/Makefile
@@ -77,7 +77,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
   CFLAGS +=-x cuda -I$(CUDA)/include
 else
   AOMPHIP ?= $(AOMP)
-  HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
+  HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib  -Wl,-rpath,$(AOMPHIP)/lib
   CFLAGS = -x hip -std=c++11 $(HIPLIBS) -lamdhip64
 endif
 

--- a/test/hip-openmp/aomp_hip_launch_test/Makefile
+++ b/test/hip-openmp/aomp_hip_launch_test/Makefile
@@ -77,7 +77,7 @@ else
   PLATFORM = -D__HIP_PLATFORM_HCC__=1
 endif
 
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11 -lamdhip64
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11 -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 OMP_TARGET_FLAGS = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$(AOMP_GPU) --save-temps 
 CC=$(AOMP)/bin/clang
 

--- a/test/hip-openmp/hip_pthread/Makefile
+++ b/test/hip-openmp/hip_pthread/Makefile
@@ -78,7 +78,7 @@ endif
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
 AOMPHIP ?= $(AOMP)
 HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11  $(HIPLIBS) -lamdhip64
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread -std=c++11  $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = 

--- a/test/hip-openmp/hip_std_thread/Makefile
+++ b/test/hip-openmp/hip_std_thread/Makefile
@@ -78,7 +78,7 @@ endif
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
 AOMPHIP ?= $(AOMP)
 HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread $(HIPLIBS) -lamdhip64
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -lpthread $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = 

--- a/test/hip-openmp/kern_latency/Makefile
+++ b/test/hip-openmp/kern_latency/Makefile
@@ -80,7 +80,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/hip-openmp/matmul_hip_omp_printf_fails/Makefile
+++ b/test/hip-openmp/matmul_hip_omp_printf_fails/Makefile
@@ -80,7 +80,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/hip-openmp/matrixmul_omp_copy/Makefile
+++ b/test/hip-openmp/matrixmul_omp_copy/Makefile
@@ -80,7 +80,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/hip-openmp/matrixmul_omp_for/Makefile
+++ b/test/hip-openmp/matrixmul_omp_for/Makefile
@@ -80,7 +80,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/hip-openmp/matrixmul_omp_target/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target/Makefile
@@ -77,7 +77,7 @@ endif
 
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
 AOMPHIP ?= $(AOMP)
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -target $(AOMP_CPUTARGET) -fopenmp -lamdhip64 -I $(AOMPHIP)/include
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -target $(AOMP_CPUTARGET) -fopenmp -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib -I $(AOMPHIP)/include
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = -fopenmp-targets=$(TRIPLE) -Xopenmp-target=$(TRIPLE) -march=$(AOMP_GPU)
 

--- a/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
@@ -78,7 +78,7 @@ endif
 #  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
 AOMPHIP ?= $(AOMP)
 HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -target $(AOMP_CPUTARGET)  $(HIPLIBS) -lamdhip64
+HIPFLAGS = -x hip $(PLATFORM) -O2 --offload-arch=$(AOMP_GPU) -target $(AOMP_CPUTARGET)  $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 #  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
 OMP_TARGET_FLAGS = -fopenmp-targets=$(TRIPLE) -Xopenmp-target=$(TRIPLE) -march=$(AOMP_GPU) -target $(AOMP_CPUTARGET)
 

--- a/test/hip-openmp/matrixmul_omp_task/Makefile
+++ b/test/hip-openmp/matrixmul_omp_task/Makefile
@@ -78,7 +78,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/hip-openmp/omp_hip/Makefile
+++ b/test/hip-openmp/omp_hip/Makefile
@@ -80,7 +80,7 @@ ifeq (sm_,$(findstring sm_,$(TARGETS)))
 else
   AOMPHIP ?= $(AOMP)
   HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
-  CFLAGS += -x hip $(HIPLIBS) -lamdhip64
+  CFLAGS += -x hip $(HIPLIBS) -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 
 # ----- Demo compile and link in one step, no object code saved

--- a/test/smoke/OmpHipMallocManaged/Makefile
+++ b/test/smoke/OmpHipMallocManaged/Makefile
@@ -8,8 +8,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 ITERS ?= -DITERS=1
 LARGE ?= -DLARGE=0
 USE_MALLOC ?= -DUSE_MALLOC=0
+AOMPHIP ?= $(AOMP)
 
-CLANG        = clang++ -lamdhip64 $(USE_MALLOC) $(LARGE) $(ITERS)
+CLANG        = clang++ -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib $(USE_MALLOC) $(LARGE) $(ITERS)
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 ifeq ($(EPSDB),1)

--- a/test/smoke/hip_device_compile/Makefile
+++ b/test/smoke/hip_device_compile/Makefile
@@ -8,7 +8,8 @@ ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
 CFLAGS = -x cuda -I/usr/local/cuda/include --offload-arch=${AOMP_GPU} -std=c++11
 LINK_FLAGS =  -L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,/usr/local/cuda/targets/x86_64-linux/lib
 else
-CFLAGS = -x hip --offload-arch=${AOMP_GPU} -std=c++11 -lamdhip64
+AOMPHIP ?= $(AOMP)
+CFLAGS = -x hip --offload-arch=${AOMP_GPU} -std=c++11 -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 endif
 OMP_FLAGS    =
 

--- a/test/smoke/hip_rocblas/Makefile
+++ b/test/smoke/hip_rocblas/Makefile
@@ -7,7 +7,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 OMP_FLAGS    =  --offload-arch=${AOMP_GPU}
 CFLAGS       = -x hip -I /opt/rocm/rocblas/include/ --offload-arch=${AOMP_GPU} -std=c++11
-LINK_FLAGS =  -L /opt/rocm/rocblas/lib -lrocblas -Wl,-rpath,/opt/rocm/rocblas/lib -lamdhip64
+OMPHIP ?= $(AOMP)
+LINK_FLAGS =  -L /opt/rocm/rocblas/lib -lrocblas -Wl,-rpath,/opt/rocm/rocblas/lib -lamdhip64  -Wl,-rpath,$(AOMPHIP)/lib
 
 ifeq ($(EPSDB),1)
 OMP_BIN      = /opt/rocm/bin/hipcc


### PR DESCRIPTION
…es not in aomp12