### PR TITLE
Build rocr after project, libdevice as 3.7 depends on them

### DIFF
--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -88,7 +88,7 @@ else
    if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
       # There is no good external repo for the opencl runtime but we only need the headers for build_vdi.sh
       # So build_ocl.sh is currently not called.
-      components="roct rocr project libdevice extras openmp pgmath flang flang_runtime comgr rocminfo vdi hipvdi ocl "
+      components="roct project libdevice rocr extras openmp pgmath flang flang_runtime comgr rocminfo vdi hipvdi ocl "
       if [ "$AOMP_BUILD_DEBUG" == "1" ] ; then
 	  components="$components rocdbgapi rocgdb"
       fi


### PR DESCRIPTION
I'm hoping that rocr can lose the dependency on libdevice. It is going to need to be built with clang for the foreseeable future.

I haven't checked whether trunk clang suffices yet. This order will, if I read the cmake correctly, lead to using the just-built clang for the device parts of rocr.