### PR TITLE
No longer need to patch rocr cmakelists

### DIFF
--- a/bin/patches/rocr-runtime.patch
+++ b/bin/patches/rocr-runtime.patch
@@ -1,15 +1,3 @@
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9de7842..139ec52 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -268,7 +268,7 @@ if(${IMAGE_SUPPORT})
- endif()
- 
- ## Link dependencies.
--target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE hsakmt::hsakmt )
-+target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE hsakmt::hsakmt -L${HSAKMT_LIB_PATH} -lhsakmt -Wl,-rpath,${HSAKMT_LIB_PATH} )
- target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE elf::elf dl pthread rt )
- 
  ## Set the VERSION and SOVERSION values
 diff --git a/src/core/inc/amd_memory_region.h b/src/core/inc/amd_memory_region.h
 index f534261..1db6a98 100644


### PR DESCRIPTION
The rocr cmake now finds hsakmt using find_package(REQUIRED), which suffices to use the simpler target_link_libraries ( ${CORE_RUNTIME_TARGET} PRIVATE hsakmt::hsakmt ). Therefore don't need to patch it.

This changes two things. hsakmt is now linked against hsa once instead of twice. The rpath is now set once, in build_rocr, instead of also via the patch.

If we drop the rpath from build_rocr, hsa still locates hsakmt as they're now installed next to one another and R*PATH contains $ORIGIN. However, dropping that changes the elf from rpath to runpath, which is out of scope for this patch.