### PR TITLE
Fix race condition with printf smoke test verification.

### DIFF
--- a/test/smoke/printf_parallel_for_target/expected.txt
+++ b/test/smoke/printf_parallel_for_target/expected.txt
@@ -1,14 +1,18 @@
-CPU Parallel: Hello.
-CPU Parallel: Hello.
-Target Master Thread: Hello from 0
-Target Master Thread: Hello from 0
-First Target Parallel: Hello.
-First Target Parallel: Hello.
-First Target Parallel: Hello.
-First Target Parallel: Hello.
-End Parallel Master Thread: Hello from 0
-End Parallel Master Thread: Hello from 0
-Second Target Parallel: Hello.
-Second Target Parallel: Hello.
-Second Target Parallel: Hello.
-Second Target Parallel: Hello.
+0 - 1. On Host: CPU Parallel
+0 - 2. On Target: Begin Target
+0 - 3. On Target: First Parallel Section
+0 - 3. On Target: First Parallel Section
+0 - 4. On Target: End First Parallel Section. Master Thread ID: 0
+0 - 5. On Target: Second Parallel Section
+0 - 5. On Target: Second Parallel Section
+0 - 6. On Target: End Second Parallel Section. Master Thread ID: 0
+0 - 7. On Host: End Target
+1 - 1. On Host: CPU Parallel
+1 - 2. On Target: Begin Target
+1 - 3. On Target: First Parallel Section
+1 - 3. On Target: First Parallel Section
+1 - 4. On Target: End First Parallel Section. Master Thread ID: 0
+1 - 5. On Target: Second Parallel Section
+1 - 5. On Target: Second Parallel Section
+1 - 6. On Target: End Second Parallel Section. Master Thread ID: 0
+1 - 7. On Host: End Target

--- a/test/smoke/printf_parallel_for_target/printf_parallel_for_target.c
+++ b/test/smoke/printf_parallel_for_target/printf_parallel_for_target.c
@@ -1,40 +1,27 @@
 #include <omp.h>
 #include <stdio.h>
 int main() {
-  int verbose = 0;
-  if(getenv("VERBOSE_PRINT")){
-    // Note: verbose mode does not verify output as printf thread output and addresses will differ each run.
-    verbose = 1;
-    printf("Using verbose print...printing pointer addresses.\n");
-  }
-    
-  #pragma omp parallel for                                                                                                                                                
+  #pragma omp parallel for
   for (int j = 0; j < 2; j++) {
-    if(verbose)
-      printf("CPU Parallel: Hello from %d\n", omp_get_thread_num());
-    else
-      printf("CPU Parallel: Hello.\n");
-  #pragma omp target
+    int host_thread= omp_get_thread_num();
+    printf("%d - 1. On Host: CPU Parallel\n", host_thread);
+  #pragma omp target map(host_thread)
   {
     int p = 20;
-    printf("Target Master Thread: Hello from %d\n", omp_get_thread_num());
+    printf("%d - 2. On Target: Begin Target\n", host_thread);
     #pragma omp parallel for
     for (int i = 0; i < 2; i++) {
       int d = 0;
-      if(verbose)
-        printf("First Target Parallel: Hello from %d %p %p\n", omp_get_thread_num(), &d, &p);
-      else
-        printf("First Target Parallel: Hello.\n");
+        printf("%d - 3. On Target: First Parallel Section\n", host_thread);
     }
-    if(verbose)
-      printf("End Parallel Master Thread: Hello from %d %p\n", omp_get_thread_num(), &p);
-    else
-      printf("End Parallel Master Thread: Hello from %d\n", omp_get_thread_num());
+    printf("%d - 4. On Target: End First Parallel Section. Master Thread ID: %d\n", host_thread, omp_get_thread_num());
     #pragma omp parallel for
     for (int i = 0; i < 2; i++) {
-      printf("Second Target Parallel: Hello.\n");
+      printf("%d - 5. On Target: Second Parallel Section\n", host_thread);
     }
+    printf("%d - 6. On Target: End Second Parallel Section. Master Thread ID: %d\n", host_thread, omp_get_thread_num());
   }
+    printf("%d - 7. On Host: End Target\n", host_thread);
   }
   return 0;
 }

--- a/test/smoke/printf_parallel_for_target/verify_output.c
+++ b/test/smoke/printf_parallel_for_target/verify_output.c
@@ -2,21 +2,13 @@
 #include <stdio.h>
 
 int main(){
-  int verbose = 0;
-  if(getenv("VERBOSE_PRINT"))
-    verbose = 1;
-
-  if(!verbose){
-    int errors = system("diff expected.txt run.log");
-    //system("diffrun.log");
-    if (errors){
-      printf("\nFail! Run.log does not match expected output.\n");
-      return 1;
-    }
+  system("echo Sorted Log:");
+  system("sort -n run.log -o sorted.log; cat sorted.log");
+  int errors = system("diff expected.txt sorted.log");
+  if (errors){
+    printf("\nFail! Run.log does not match expected output.\n");
+    return 1;
   }
-  if(!verbose)
-    printf("Passed!\n");
-  else
-    printf("\nVERBOSE_PRINT does not verify output. Return 0 by default.\n");
+  printf("Passed!\n");
   return 0;
 }


### PR DESCRIPTION
Creates a sorted.log and sorts by Thread ID then Statement ID for verification.
Any missing lines will be considered a failure.
Also removed verbose option to simplify test.