### PR TITLE
Fix flags use of hardcoded gfx906, remove OFFLOAD_DEBUG=1

### DIFF
--- a/test/smoke/flags/options.txt
+++ b/test/smoke/flags/options.txt
@@ -1,7 +1,7 @@
-OFFLOAD_DEBUG=1 flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
+flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
+flags.c -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
+flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
 flags.c -fopenmp -save-temps -target ${AOMP_CPUTARGET} -fopenmp-targets=${AOMP_CPUTARGET}
 flags.c -fopenmp -save-temps -target ${AOMP_CPUTARGET}
 flags.c -fopenmp -save-temps  -fopenmp-targets=${AOMP_CPUTARGET}

--- a/test/smoke/flags/options.txt
+++ b/test/smoke/flags/options.txt
@@ -1,4 +1,4 @@
-flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
+-OFFLOAD_DEBUG=1 flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
 flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
 flags.c -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}
 flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=${AOMP_GPU}


### PR DESCRIPTION
from
Re: [CRAYA-169] /opt/rocm-3.7.0/share/aomp/tests/smoke/flags/options.txt has march=gfx906 hardcoded on machine with MI60 nodes and MI100 nodes 