### PR TITLE
smoke: Add new failing test reduction_shared_array

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -70,6 +70,7 @@ TESTS_DIR = \
     reduction_team \
     reduction_teams \
     reduction_teams_distribute_parallel \
+    reduction_shared_array \
     reduc_map_prob \
     schedule \
     simd \

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -39,7 +39,7 @@ echo "                   A non-zero exit code means a failure occured." >> check
 echo "Tests that need to be visually inspected: devices, pfspecify, pfspecify_str, stream" >> check-smoke.txt
 echo "***********************************************************************************" >> check-smoke.txt
 
-known_fails="reduction_array_section targ_static target_teams_reduction tasks data_share2 global_allocate complex2 flang_omp_map omp_get_initial slices slices printf_parallel_for_target"
+known_fails="reduction_array_section targ_static target_teams_reduction tasks data_share2 global_allocate complex2 flang_omp_map omp_get_initial slices slices printf_parallel_for_target reduction_shared_array"
 
 if [ "$SKIP_FAILURES" == 1 ] ; then
   skip_tests=$known_fails

--- a/test/smoke/reduction_shared_array/Makefile
+++ b/test/smoke/reduction_shared_array/Makefile
@@ -1,0 +1,15 @@
+include ../Makefile.defs
+
+# test compiles fine with TEMPS=1
+TESTNAME     = reduction_shared_array
+TESTSRC_MAIN = reduction_shared_array.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke/reduction_shared_array/reduction_shared_array.c
+++ b/test/smoke/reduction_shared_array/reduction_shared_array.c
@@ -1,0 +1,28 @@
+#include <omp.h>
+#include <stdio.h>
+
+#define ITERS 4096
+
+int main() {
+  #pragma omp target
+  {
+    int globalized[256];
+
+    #pragma omp parallel for
+    for (int i = 0; i < 256; i++) {
+      globalized[i] = 0;
+    }
+    #pragma omp parallel for reduction(+:globalized)
+    for (int i = 0; i < ITERS; i++) {
+      globalized[i % 256] += i;
+    }
+
+    printf("%d", globalized[0]);
+    for (int i = 1; i < 256; i++) {
+      printf(" %d", globalized[i]);
+    }
+    printf("\n");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Compiler crashes on this smoke test for amdgcn. It is working fine for nvptx.

Crash message: clang-11: /home/estewart/git/aomp11/amd-llvm-project/llvm/lib/IR/Constants.cpp:2095: static llvm::Constant* llvm::ConstantExpr::get(unsigned int, llvm::Constant*, llvm::Constant*, unsigned int, llvm::Type*): Assertion `C1->getType() == C2->getType() && "Operand types in binary constant expression should match"' failed