### PR TITLE
Updated march in flags test.

### DIFF
--- a/test/smoke/flags/options.txt
+++ b/test/smoke/flags/options.txt
@@ -1,7 +1,7 @@
-OFFLOAD_DEBUG=1 flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
-flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx906
+OFFLOAD_DEBUG=1 flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
+flags.c -isystem/home/estewart/rocm/aomp/include  -O2  -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
+flags.c -target ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
+flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
 flags.c -fopenmp -save-temps -target ${AOMP_CPUTARGET} -fopenmp-targets=${AOMP_CPUTARGET}
 flags.c -fopenmp -save-temps -target ${AOMP_CPUTARGET}
 flags.c -fopenmp -save-temps  -fopenmp-targets=${AOMP_CPUTARGET}

--- a/test/smoke/flags/run_options.sh
+++ b/test/smoke/flags/run_options.sh
@@ -4,13 +4,14 @@
 # The Makefile will run this script twice when using 'make run'
 # First run is to compile, second is to run for output in run.log.
 
-#Input file
+# Input file
 file="options.txt"
-#Regex to search for "march=gfxXXX or sm_XX"
-march_regex="(march=[a-z]+[0-9]*_?[0-9]+)"
-#Regex to search for OFFLOAD_DEBUG
+# Regex to search for "march=gfxXXX or sm_XX"
+# run_options will set march to be either AOMP_GPU or auto-dect with mygpu utility
+march_regex="(march=AOMP_GPU_or_auto_detect)"
+# Regex to search for OFFLOAD_DEBUG
 debug_regex="(OFFLOAD_DEBUG=([0-9]))"
-#Regex to search for Nvidia cards
+# Regex to search for Nvidia cards
 target_regex="(-fopenmp-[a-z]*=[a-z,-]*).*(-Xopenmp-[a-z]*=[a-z,-]*)"
 
 UNAMEP=`uname -p`
@@ -20,14 +21,14 @@ if [[ $UNAMEP == "ppc64le" ]] ; then
 fi
 
 path=$(pwd) && base=$(basename $path)
-#Read file, replace march with correct GPU, add Nvidia options if necessary and keep track of execution number
+# Read file, replace march with correct GPU, add Nvidia options if necessary and keep track of execution number
 test_num=0;
 while read -r line; do
   ((test_num++))
-  #GPU is involved
+  # GPU is involved
   if [[ "$line" =~ $march_regex ]]; then
     march_match=${BASH_REMATCH[1]}
-    #Remove march from command and replace with correct version
+    # Remove march from command and replace with correct version
     line=${line/"-$march_match"}
     mygpu=$AOMP_GPU
     if [ -z $mygpu ]; then
@@ -40,14 +41,14 @@ while read -r line; do
       fi
     fi
 
-    #Check for OFFLOAD_DEBUG
+    # Check for OFFLOAD_DEBUG
     if [[ "$line" =~ $debug_regex ]]; then
       debug_match=${BASH_REMATCH[1]}
       line=${line/"$debug_match"}
       export $debug_match
     fi
 
-    #NVIDIA system, add nvptx targets, cuda, and remove amdgcn targets. This is done for testing purpose to avoid rewriting original amd command.
+    # NVIDIA system, add nvptx targets, cuda, and remove amdgcn targets. This is done for testing purpose to avoid rewriting original amd command.
     if [[ "$mygpu" == *"sm"* ]]; then
       if [[ "$line" =~ $target_regex ]]; then
         target_match="${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
@@ -56,7 +57,7 @@ while read -r line; do
         cuda_args="-L/usr/local/cuda/targets/${UNAMEP}-linux/lib -lcudart"
       fi
     fi
-    #GPU compilation or run, send variables to make
+    # GPU compilation or run, send variables to make
     if [[ $1 != "run" ]]; then
       make --no-print-directory make_options="$line" nvidia_targets="$nvidia_args" march="-march=$mygpu" cuda="$cuda_args" compile
     fi
@@ -66,7 +67,7 @@ while read -r line; do
     if [ $? -ne 0 ]; then
       echo "$base $test_num: Make Failed" >> ../make-fail.txt
     fi
-  else #Host compilation or run, GPU not detected on input line, no need to pass other variables to make
+  else # Host compilation or run, GPU not detected on input line, no need to pass other variables to make
     if [[ $1 != "run" ]]; then
       make --no-print-directory make_options="$line" compile
     fi
@@ -74,7 +75,7 @@ while read -r line; do
       make --no-print-directory make_options="$line" test_num=$test_num check
     fi
   fi
-  #Host not successfull
+  # Host not successfull
   if [ $? -ne 0 ]; then
     echo "$base $test_num: Make Failed" >> ../make-fail.txt
   else
@@ -82,7 +83,7 @@ while read -r line; do
   fi
   echo ""
 
-  #reset OFFLOAD_DEBUG
+  # Reset OFFLOAD_DEBUG
   reset_debug=$OFFLOAD_DEBUG
   if [ -z $reset_Debug ]; then
     export OFFLOAD_DEBUG=0


### PR DESCRIPTION
The options.txt file now has march=AOMP_GPU_or_auto_detect instead of a hardcoded gpu.
Even though the initial hardcoded march was replaced with the proper gpu by the run_options.sh script
this was not very obvious.

Updated comments in run_options.sh.