### PR TITLE
Make wtime test more robust

### DIFF
--- a/test/smoke/omp_wtime/omp_wtime.c
+++ b/test/smoke/omp_wtime/omp_wtime.c
@@ -8,6 +8,10 @@ int main()
   {
     // calls to wtime should not be folded together
    time0 = omp_get_wtime();
+#if defined(__AMDGCN__)
+   // nvptx has a nanosleep, but only for >= sm_70
+   __builtin_amdgcn_s_sleep(1000);
+#endif
    time1 = omp_get_wtime();
   }
 


### PR DESCRIPTION
100 was sufficient for vega20, 1000 still executes in 0.1s. Delay only needs to exceed the resolution of the clock.