### PR TITLE
Change uses of uname to be more portable by using the -m option.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -60,7 +60,7 @@ if [ -f /usr/local/cmake/bin/cmake ] ; then
 else
   AOMP_CMAKE=${AOMP_CMAKE:-cmake}
 fi
-AOMP_PROC=`uname -p`
+AOMP_PROC=`uname -m`
 if [ "$AOMP_PROC" == "unknown" ] ; then
    AOMP_PROC=`uname -a | awk '{print $(NF-1)}'`
 fi

--- a/bin/build-deb-aomp.sh
+++ b/bin/build-deb-aomp.sh
@@ -44,7 +44,7 @@ DEBFULLNAME="Greg Rodgers"
 DEBEMAIL="Gregory.Rodgers@amd.com"
 export DEBFULLNAME DEBEMAIL
 
-DEBARCH=`uname -p`
+DEBARCH=`uname -m`
 RPMARCH=$DEBARCH
 if [ "$DEBARCH" == "x86_64" ] ; then 
    DEBARCH="amd64"

--- a/examples/cloc/vector_copy_hip_omp/Makefile
+++ b/examples/cloc/vector_copy_hip_omp/Makefile
@@ -2,7 +2,7 @@
 TEST_NAME=vector_copy
 CU_FILE=vector_copy
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/hip/matrixmul/Makefile
+++ b/examples/hip/matrixmul/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/hip/vectorAdd/Makefile
+++ b/examples/hip/vectorAdd/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =vectorAdd
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/declare_variant_if/Makefile
+++ b/examples/openmp/declare_variant_if/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = declare_variant_if 
 TESTSRC  = declare_variant_if.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/host_function/Makefile
+++ b/examples/openmp/host_function/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = host_function
 TESTSRC  = host_function.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/host_varfn_function/Makefile
+++ b/examples/openmp/host_varfn_function/Makefile
@@ -7,7 +7,7 @@
 TESTNAME = host_varfn_function
 TESTSRC  = host_varfn_function.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/reduction/Makefile
+++ b/examples/openmp/reduction/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = reduction
 TESTSRC  = reduction.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/veccopy/Makefile
+++ b/examples/openmp/veccopy/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = veccopy
 TESTSRC  = veccopy.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/vmul_template/Makefile
+++ b/examples/openmp/vmul_template/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = vmul_template
 TESTSRC  = vmul_template.cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/openmp/vmulsum/Makefile
+++ b/examples/openmp/vmulsum/Makefile
@@ -12,7 +12,7 @@
 TESTNAME = vmulsum
 TESTSRC  = main.c vsum.c vmul.c
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/examples/raja/vecadd/Makefile
+++ b/examples/raja/vecadd/Makefile
@@ -9,7 +9,7 @@
 TESTNAME = vecadd
 TESTSRC  = vecadd.cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/f18bin/f18_common_vars
+++ b/f18bin/f18_common_vars
@@ -52,7 +52,7 @@ CUDAINCLUDE=${CUDAINCLUDE:-$CUDA/include}
 CUDABIN=${CUDABIN:-$CUDA/bin}
 
 F18_CMAKE=${F18_CMAKE:-cmake}
-F18_PROC=`uname -p`
+F18_PROC=`uname -m`
 if [ "$F18_PROC" == "unknown" ] ; then
    F18_PROC=`uname -a | awk '{print $(NF-1)}'`
 fi

--- a/test/hip-openmp/aomp_hip_launch_test/Makefile
+++ b/test/hip-openmp/aomp_hip_launch_test/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =hiplaunch
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/hip_bandwidth/Makefile
+++ b/test/hip-openmp/hip_bandwidth/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =bit_extract
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/hip_pthread/Makefile
+++ b/test/hip-openmp/hip_pthread/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =bit_extract
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/hip_std_thread/Makefile
+++ b/test/hip-openmp/hip_std_thread/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =bit_extract
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/kern_latency/Makefile
+++ b/test/hip-openmp/kern_latency/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =kern_latency
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matmul_hip_omp_printf_fails/Makefile
+++ b/test/hip-openmp/matmul_hip_omp_printf_fails/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matrixmul_omp_copy/Makefile
+++ b/test/hip-openmp/matrixmul_omp_copy/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matrixmul_omp_for/Makefile
+++ b/test/hip-openmp/matrixmul_omp_for/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matrixmul_omp_target/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
+++ b/test/hip-openmp/matrixmul_omp_target_multifile/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/matrixmul_omp_task/Makefile
+++ b/test/hip-openmp/matrixmul_omp_task/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/hip-openmp/omp_hip/Makefile
+++ b/test/hip-openmp/omp_hip/Makefile
@@ -32,7 +32,7 @@
 TESTNAME =matrixmul
 FILETYPE =cpp
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/omp5/Makefile.defs
+++ b/test/omp5/Makefile.defs
@@ -21,7 +21,7 @@ ifneq ($(TIMEOUT),)
   TKILL= timeout $(TIMEOUT)
 endif
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/smoke/Makefile.defs
+++ b/test/smoke/Makefile.defs
@@ -21,7 +21,7 @@ ifneq ($(TIMEOUT),)
   TKILL= timeout $(TIMEOUT)
 endif
 
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu

--- a/test/smoke/flags/run_options.sh
+++ b/test/smoke/flags/run_options.sh
@@ -14,7 +14,7 @@ debug_regex="(OFFLOAD_DEBUG=([0-9]))"
 # Regex to search for Nvidia cards
 target_regex="(-fopenmp-[a-z]*=[a-z,-]*).*(-Xopenmp-[a-z]*=[a-z,-]*)"
 
-UNAMEP=`uname -p`
+UNAMEP=`uname -m`
 AOMP_CPUTARGET=${UNAMEP}-pc-linux-gnu
 if [[ $UNAMEP == "ppc64le" ]] ; then
    AOMP_CPUTARGET=ppc64le-linux-gnu

--- a/test/smoke/liba_bundled/MyDeviceLib/Makefile
+++ b/test/smoke/liba_bundled/MyDeviceLib/Makefile
@@ -34,7 +34,7 @@ endif
 # --- End Standard Makefile check for AOMP installation ---
 AOMP_GPU ?= gfx900
 CC        = $(AOMP)/bin/clang
-UNAMEP    = $(shell uname -p)
+UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 
 ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))

--- a/test/smoke/liba_bundled_cmdline/Makefile
+++ b/test/smoke/liba_bundled_cmdline/Makefile
@@ -13,7 +13,7 @@ EXTRA_OMP_FLAGS =
 
 # --- End Standard Makefile check for AOMP installation ---
 CC        = $(AOMP)/bin/clang
-UNAMEP    = $(shell uname -p)
+UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 
 ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
@@ -34,7 +34,7 @@ endif
 # --- End Standard Makefile check for AOMP installation ---
 AOMP_GPU ?= gfx900
 CC        = $(AOMP)/bin/clang
-UNAMEP    = $(shell uname -p)
+UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 
 ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))

--- a/test/smoke/liba_bundled_cmdline/MyHostLib/Makefile
+++ b/test/smoke/liba_bundled_cmdline/MyHostLib/Makefile
@@ -33,7 +33,7 @@ ifeq ("$(wildcard $(AOMP))","")
 endif
 # --- End Standard Makefile check for AOMP installation ---
 CC        = $(AOMP)/bin/clang
-UNAMEP    = $(shell uname -p)
+UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 
 TMPDIR   ?= ./build

--- a/test/smoke/teams512-info/Makefile
+++ b/test/smoke/teams512-info/Makefile
@@ -31,7 +31,7 @@ endif
 INSTALLED_GPU  = $(shell $(AOMP)/bin/mygpu -d gfx900)# Default AOMP_GPU is gfx900 which is vega
 AOMP_GPU       ?= $(INSTALLED_GPU)
 CC              = $(AOMP)/bin/clang
-UNAMEP = $(shell uname -p)
+UNAMEP = $(shell uname -m)
 AOMP_CPUTARGET = $(UNAMEP)-pc-linux-gnu
 ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu


### PR DESCRIPTION
Fix for issue #138. Part 2 coming in aomp-extras. Tested smoke, examples, hip-openmp.