### PR TITLE
Add test for failing to compile a simple global constructor

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -85,6 +85,7 @@ TESTS_DIR = \
     reduc_map_prob \
     schedule \
     simd \
+    simple_ctor \
     slices \
     snap_red \
     stream \

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -39,7 +39,7 @@ echo "                   A non-zero exit code means a failure occured." >> check
 echo "Tests that need to be visually inspected: devices, pfspecify, pfspecify_str, stream" >> check-smoke.txt
 echo "***********************************************************************************" >> check-smoke.txt
 
-known_fails="targ_static target_teams_reduction tasks"
+known_fails="targ_static target_teams_reduction tasks simple_ctor"
 
 if [ "$SKIP_FAILURES" == 1 ] ; then
   skip_tests=$known_fails

--- a/test/smoke/simple_ctor/Makefile
+++ b/test/smoke/simple_ctor/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.defs
+
+TESTNAME     = simple_ctor
+TESTSRC_MAIN = simple_ctor.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke/simple_ctor/simple_ctor.cpp
+++ b/test/smoke/simple_ctor/simple_ctor.cpp
@@ -1,0 +1,12 @@
+#pragma omp declare target
+
+// tries to cast without taking addrspace into consideration, crashes
+__attribute__((used))
+struct t
+{
+  t() {}
+} o;
+
+#pragma omp end declare target
+
+int main() {}


### PR DESCRIPTION
Building the deviceRTL as openmp fails on compiling an object which has a simple global constructor

Discovered in passing that an empty target region doesn't compile either, but that's true for nvptx/trunk. Raised https://bugs.llvm.org/show_bug.cgi?id=48509 to track.