### PR TITLE
Fixed hard coded path to CUDA

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -109,7 +109,7 @@ fi
 if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    NVPTXGPUS_DEFAULT="30,32,35,50,60,61"
    if [ -f $CUDA/version.txt ] ; then
-      if [ `head -1 /usr/local/cuda/version.txt | cut -d " " -f 3 | cut -d "." -f 1` -ge 9 ] ; then
+      if [ `head -1 $CUDA/version.txt | cut -d " " -f 3 | cut -d "." -f 1` -ge 9 ] ; then
          NVPTXGPUS_DEFAULT+=",70"
       fi
    fi


### PR DESCRIPTION
Change the path used in `head` with the relative path that users are able to change. The new path mirrors the path checked in the preceding `if`.