### PR TITLE
Add support for using rocm_agent_enumerator to obtain device id.

### DIFF
--- a/bin/run_epsdb_aomp_test.sh
+++ b/bin/run_epsdb_aomp_test.sh
@@ -16,12 +16,20 @@ export LIBOMPTARGET_MEMORY_MANAGER_THRESHOLD=0
 
 export AOMPROCM=$AOMP/..
 
+# Try using rocm_agent_enumerator for device id.
+# Regex skips first result 'gfx000' and selects second id.
+export AOMP_GPU=$($AOMPROCM/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
+
 # mygpu will eventually relocate to /opt/rocm/bin, support both cases for now.
-if [ -a $AOMP/bin/mygpu ]; then
-  export AOMP_GPU=`$AOMP/bin/mygpu`
-#  export EXTRA_OMP_FLAGS=--rocm-path=$AOMP/
+if [ "$AOMP_GPU" != "" ]; then
+  echo "AOMP_GPU set with rocm_agent_enumerator."
 else
-  export AOMP_GPU=`$AOMP/../bin/mygpu`
+  echo "AOMP_GPU is empty, use mygpu."
+  if [ -a $AOMP/bin/mygpu ]; then
+    export AOMP_GPU=$($AOMP/bin/mygpu)
+  else
+    export AOMP_GPU=$($AOMP/../bin/mygpu)
+  fi
 fi
 
 echo AOMP_GPU = $AOMP_GPU

--- a/test/smoke/Makefile.defs
+++ b/test/smoke/Makefile.defs
@@ -27,7 +27,13 @@ ifeq ($(UNAMEP),ppc64le)
   AOMP_CPUTARGET = ppc64le-linux-gnu
 endif
 
-INSTALLED_GPU  = $(shell $(AOMP)/bin/mygpu -d gfx900) # Default AOMP_GPU is gfx900 which is vega
+# If AOMP env variable contains opt use rocm_agent_enumerator for device id.
+ifeq (opt,$(findstring opt,$(AOMP)))
+  INSTALLED_GPU  = $(shell $(AOMP)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
+else
+  INSTALLED_GPU  = $(shell $(AOMP)/bin/mygpu -d gfx900) # Default AOMP_GPU is gfx900 which is vega
+endif
+
 AOMP_GPU       ?= $(INSTALLED_GPU)
 CC              = $(AOMP)/bin/clang
 CUDA           ?= /usr/local/cuda


### PR DESCRIPTION
This is only used when the AOMP environment variable contains opt.
Otherwise, mygpu is used.