### PR TITLE
Support building via ninja for llvm-project

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -537,6 +537,7 @@ function help_build_aomp(){
      AOMP_REPOS       $HOME/git/aomp11    Location of all aomp repos
      BUILD_TYPE       Release             The CMAKE build type
      BUILD_AOMP       same as AOMP_REPOS  Set a different build location than AOMP_REPOS
+     AOMP_USE_NINJA   0                   Use ninja if possible
   
   To build a debug version of the compiler, run this command before the build:
      export BUILD_TYPE=debug

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -177,12 +177,8 @@ fi
 echo
 echo " -----Running make ---- " 
 
-BUILD_SYSTEM="make"
-if [ -z $AOMP_USE_NINJA ] ; then
-    BUILD_SYSTEM="ninja"
-fi
 # Workaround for race condition in the build of compiler-rt
-for prebuild in $(${BUILD_SYSTEM} --build . help | sed -n '/-version-list/s/^... //p') ; do
+for prebuild in $(${AOMP_CMAKE} --build . --target help | sed -n '/-version-list/s/^... //p') ; do
   ${AOMP_CMAKE} --build . -j$NUM_THREADS $prebuild
 done
 
@@ -195,7 +191,7 @@ fi
 
 if [ "$1" == "install" ] ; then
    echo " -----Installing to $INSTALL_PROJECT ---- "
-   $SUDO ${AOMP_CMAKE} --build . -j $NUM_THREADS install
+   $SUDO ${AOMP_CMAKE} --build . -j $NUM_THREADS --target install
    if [ $? != 0 ] ; then
       echo "ERROR make install failed "
       exit 1


### PR DESCRIPTION
On the basis of the value of AOMP_USE_NINJA env variable, build_project.sh will use ninja (when =1) or make (when not defined)