### PR TITLE
Testcase for maps and fine grain memory

### DIFF
--- a/bin/build_qmcpack.sh
+++ b/bin/build_qmcpack.sh
@@ -114,16 +114,16 @@ $AOMP_CMAKE -DCMAKE_C_COMPILER=$OPENMPI_INSTALL/bin/mpicc \
 -DCMAKE_CXX_COMPILER=$OPENMPI_INSTALL/bin/mpicxx \
 -DOMPI_CC=$AOMP/bin/clang -DOMPI_CXX=$AOMP/bin/clang++ \
 -DQMC_MPI=1 \
--DCMAKE_C_FLAGS="-march=native" \
--DCMAKE_CXX_FLAGS="-march=native -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU" \
+-DCMAKE_C_FLAGS="-march=native -g -O0" \
+-DCMAKE_CXX_FLAGS="-march=native -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU -g -O0" \
 -DQMC_MIXED_PRECISION=1 -DENABLE_OFFLOAD=ON -DOFFLOAD_TARGET="amdgcn-amd-amdhsa" \
 -DENABLE_TIMERS=1 \
 ..
 fi
 
 echo
-echo make -j$NUM_THREADS
-make -j$NUM_THREADS
+echo make VERBOSE=1 -j$NUM_THREADS
+make VERBOSE=1 -j$NUM_THREADS
 
 echo 
 echo "DONE!  Build is in $build_folder. To test:"

--- a/test/smoke-fails/mix_fine_grain_and_maps/Makefile
+++ b/test/smoke-fails/mix_fine_grain_and_maps/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.defs
+
+TESTNAME     = simple_ptr
+TESTSRC_MAIN = simple_ptr.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/mix_fine_grain_and_maps/simple_ptr.cpp
+++ b/test/smoke-fails/mix_fine_grain_and_maps/simple_ptr.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+
+#pragma omp requires unified_shared_memory
+
+int main() {
+  int *a = (int *) malloc(sizeof(int));
+  bool is_set = false;
+  
+  // a is passed by-value to kernel with unified_shared_memory; set to nullptr without
+  #pragma omp target map(tofrom: is_set)
+  {
+    if (a != nullptr)
+      is_set = true;
+    else
+      is_set = false;
+  }
+
+  if (!is_set)
+    std::cout << "a not set\n";
+
+  return 0;
+}


### PR DESCRIPTION
Add testcase showing that mixing requires unified_shared_memory and explicit maps yields a runtime error when accessing a mapped scalar. Is this behavior expected? It is certainly not what we hoped for.