### PR TITLE
Mix fine grain and maps

### DIFF
--- a/test/smoke-fails/mix_fine_grain_and_maps/Makefile
+++ b/test/smoke-fails/mix_fine_grain_and_maps/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.defs
+
+TESTNAME     = simple_ptr
+TESTSRC_MAIN = simple_ptr.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/mix_fine_grain_and_maps/simple_ptr.cpp
+++ b/test/smoke-fails/mix_fine_grain_and_maps/simple_ptr.cpp
@@ -1,0 +1,23 @@
+#include <iostream>
+
+#pragma omp requires unified_shared_memory
+
+int main() {
+  int *a = (int *) malloc(sizeof(int));
+  bool is_set = false;
+
+  // a is passed by-value to kernel with unified_shared_memory; set to nullptr without
+  // map of is_set should be respected
+  #pragma omp target map(tofrom: is_set)
+  {
+    if (a != nullptr)
+      is_set = true;
+    else
+      is_set = false;
+  }
+
+  if (!is_set)
+    std::cout << "a not set\n";
+
+  return 0;
+}


### PR DESCRIPTION
This testcase mixes accesses to fine grain memory in a target region with a mapped scalar. It does not currently work, but this is what we would like to have: when a map is used, then use default behavior; when a map is not used, then use fine grain memory.