### PR TITLE
Add first test for omp_target_is_high_bw_memory API call

### DIFF
--- a/test/usm/omp_is_high_bw/Makefile
+++ b/test/usm/omp_is_high_bw/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = omp_is_high_bw
+TESTSRC_MAIN = omp_is_high_bw.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/usm/omp_is_high_bw/omp_is_high_bw.cpp
+++ b/test/usm/omp_is_high_bw/omp_is_high_bw.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+
+#include <omp.h>
+
+// fit a and b perfectly inside a single page
+#define N 4096/4
+
+using namespace std;
+
+#pragma omp requires unified_shared_memory
+
+int main() {
+  bool err = false;
+  int n = N;
+  int *a = (int *)malloc(n*sizeof(int));
+  int *b = (int *)malloc(n*sizeof(int));
+
+  #pragma omp target data map(a[:n])
+  {
+    // a[0:n] is coarse grain
+    err = err || !omp_target_is_high_bw_memory(a, n*sizeof(int));
+    if (!err) cout << "1. correct\n";
+    // a[0:2*n] is not all coarse grain, as n = pageSize
+    err = err || omp_target_is_high_bw_memory(a, n*sizeof(int)*2);
+    if (!err) cout << "2. correct\n";
+    // b was not mapped: it is in fine grain memory
+    err = err || omp_target_is_high_bw_memory(b, n*sizeof(int));
+    if (!err) cout << "3. correct\n";
+  }
+
+  if(err) cout << "Something went wrong\n";
+  else cout << "All good\n";
+
+  #pragma omp target
+  {
+    printf("Hello, world!\n");
+  }
+
+  return err;
+}


### PR DESCRIPTION
Please note that the test has an unnecessary target region in it. Without that, clang will not emit the register_requires call to the openmp runtime that sets up the flags in libomptarget.