### PR TITLE
[smoke] Add calls to allocator in devicertl

### DIFF
--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -93,6 +93,7 @@ TESTS_DIR = \
     issue_flang_libomp \
     issue_001 \
     issue_002 \
+    kmpc_alloc \
     kokkos_log2 \
     launch_latency \
     liba_bundled \

--- a/test/smoke/kmpc_alloc/Makefile
+++ b/test/smoke/kmpc_alloc/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = kmpc_alloc
+TESTSRC_MAIN = kmpc_alloc.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke/kmpc_alloc/kmpc_alloc.cpp
+++ b/test/smoke/kmpc_alloc/kmpc_alloc.cpp
@@ -1,0 +1,35 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C" {
+void *__kmpc_impl_malloc(size_t) {
+  printf("Called malloc on host, error\n");
+  exit(1);
+}
+void __kmpc_impl_free(void *) {
+  printf("Called free on host, error\n");
+  exit(1);
+}
+}
+
+// Call the kmpc_impl malloc/free hooks from devicertl
+
+#pragma omp declare target
+extern "C" {
+void *__kmpc_impl_malloc(size_t);
+void __kmpc_impl_free(void *);
+}
+#pragma omp end declare target
+
+int main() {
+#pragma omp target device(0)
+  {
+    void *p = __kmpc_impl_malloc(128);
+    for (unsigned i = 0; i < 128; i++) {
+      *(char *)p = i;
+    }
+    __kmpc_impl_free(p);
+  }
+  return 0;
+}


### PR DESCRIPTION
Mostly checks that we can call functions in the devicertl, as opposed to the ones with the same name on the host. Order of definition and declaration seems to be important.

Will fail on trunk as alloc returns null (so the write to it should crash)