### PR TITLE
this patch applies to rocm-device-libs to tell it to build both asanr…

### DIFF
--- a/bin/patches/patch-control-file.txt
+++ b/bin/patches/patch-control-file.txt
@@ -8,3 +8,4 @@ RAJAPerf: rajaperf.patch
 rocr-runtime: rocr-runtime.patch
 roct-thunk-interface: roct-thunk-interface.patch
 rocm-compilersupport: rocm-compilersupport.patch
+rocm-device-libs: rocm-device-libs.patch

--- a/bin/patches/rocm-device-libs.patch
+++ b/bin/patches/rocm-device-libs.patch
@@ -1,0 +1,48 @@
+diff --git a/asanrtl/CMakeLists.txt b/asanrtl/CMakeLists.txt
+index f1ed020..24f1c13 100644
+--- a/asanrtl/CMakeLists.txt
++++ b/asanrtl/CMakeLists.txt
+@@ -16,3 +16,5 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
+ 
+ opencl_bc_lib(NAME asanrtl SOURCES ${sources})
++set(CLANG_OCL_FLAGS ${CLANG_OCL_FLAGS} -D__BUILD_FOR_OPENMP)
++opencl_bc_lib(NAME asanrtl_omp SOURCES ${sources})
+diff --git a/asanrtl/src/report.cl b/asanrtl/src/report.cl
+index 1b0a64f..4fbb5c1 100644
+--- a/asanrtl/src/report.cl
++++ b/asanrtl/src/report.cl
+@@ -17,12 +17,19 @@
+ 
+ #define OPT_NONE __attribute__((optnone))
+ 
++#ifndef __BUILD_FOR_OPENMP
++#define __HOSTCALL_ASAN_WRAPPER __ockl_sanitizer_report
++#else
++extern void __hostrpc_sanitizer_report(ulong, ulong, ulong, ulong, ulong, ulong, ulong, ulong);
++#define __HOSTCALL_ASAN_WRAPPER __hostrpc_sanitizer_report
++#endif
++
+ #define REPORT_IMPL(caller_pc, addr, is_write, size, no_abort)                          \
+     uptr read      = is_write;                                                          \
+     if (no_abort)                                                                       \
+         read       |= 0xFFFFFFFF00000000;                                               \
+                                                                                         \
+-    __ockl_sanitizer_report(addr, caller_pc, WORKGROUP_ID(x), WORKGROUP_ID(y),          \
++    __HOSTCALL_ASAN_WRAPPER(addr, caller_pc, WORKGROUP_ID(x), WORKGROUP_ID(y),          \
+                           WORKGROUP_ID(z), __ockl_get_local_linear_id(), read, size);   \
+ 
+ 
+diff --git a/cmake/OCL.cmake b/cmake/OCL.cmake
+index 4e324e8..a605d15 100644
+--- a/cmake/OCL.cmake
++++ b/cmake/OCL.cmake
+@@ -85,7 +85,7 @@ macro(opencl_bc_lib)
+     get_filename_component(fname_we "${file}" NAME_WE)
+     get_filename_component(fext "${file}" EXT)
+     if (fext STREQUAL ".cl")
+-      set(output "${CMAKE_CURRENT_BINARY_DIR}/${fname_we}${BC_EXT}")
++      set(output "${CMAKE_CURRENT_BINARY_DIR}/${name}_${fname_we}${BC_EXT}")
+       add_custom_command(OUTPUT "${output}"
+         COMMAND $<TARGET_FILE:clang> ${inc_options} ${CLANG_OCL_FLAGS}
+           -emit-llvm -Xclang -mlink-builtin-bitcode -Xclang "${irif_lib_output}"


### PR DESCRIPTION
…tl.bc and asanrtl_omp.bc.  The only difference is that asanrtl_omp.bc calls __hostrpc_sanitizer_report instead of __ockl_sanitizer_report