### PR TITLE
Update repo forall workflow.

### DIFF
--- a/bin/clone_aomp.sh
+++ b/bin/clone_aomp.sh
@@ -102,8 +102,8 @@ if [[ "$AOMP_VERSION" == "13.1" ]] || [[ $AOMP_MAJOR_VERSION -gt 13 ]] ; then
       cat $tmpfile
       rm $tmpfile
    else
-      echo $repobindir/repo forall -p -g unlocked -c $thisdir/repo_forall_cmds gitpull
-      $repobindir/repo forall -p -g unlocked -c $thisdir/repo_forall_cmds gitpull
+      echo $repobindir/repo forall -p -g unlocked -c \'git pull\'
+      $repobindir/repo forall -p -g unlocked -c 'git pull'
    fi
    rc=$?
    exit $rc

--- a/bin/repo_forall_cmds
+++ b/bin/repo_forall_cmds
@@ -111,10 +111,7 @@ if [ -Z $repocmd ] ; then
 fi
 
 rc=0
-if [[ "$repocmd" == "gitpull" ]] ; then
-    echo calling git pull in directory $PWD
-    git pull
-elif [[ "$repocmd" == "gitcheckout" ]] ; then
+if [[ "$repocmd" == "gitcheckout" ]] ; then
     echo git checkout $REPO_RREV
     git checkout $REPO_RREV
 elif [[ "$repocmd" == "find_newer_branches" ]] ; then

--- a/init_aomp_repos.sh
+++ b/init_aomp_repos.sh
@@ -89,4 +89,16 @@ if [ $? != 0 ] ; then
    exit 1
 fi
 
+# build_rocr.sh expects directory rocr-runtime which is a subdir of hsa-runtime
+# Link in the open source hsa-runtime as "src" directory
+if [ -d $AOMP_REPOS/hsa-runtime ] ; then
+   if [ ! -L $AOMP_REPOS/rocr-runtime/src ] ; then
+      echo "Fixing rocr-runtime with correct link to hsa-runtime/opensrc/hsa-runtime src"
+      mkdir -p $AOMP_REPOS/rocr-runtime
+      cd $AOMP_REPOS/rocr-runtime
+      echo ln -sf $AOMP_REPOS/hsa-runtime/opensrc/hsa-runtime src
+      ln -sf $AOMP_REPOS/hsa-runtime/opensrc/hsa-runtime src
+   fi
+fi
+
 exit 0


### PR DESCRIPTION
- Add symbolic link creation for hsa-runtime to init_aomp_repos.sh.
- Remove gitpull option from repo_for_all_cmds as we can invoke
    repo forall directly in clone_aomp.sh