### PR TITLE
Add test for mixing hip and openmp when using xnack (usm mode).

### DIFF
--- a/test/hip-openmp/xnack/Makefile
+++ b/test/hip-openmp/xnack/Makefile
@@ -1,0 +1,85 @@
+#-----------------------------------------------------------------------
+#
+#  Makefile: Cuda clang demo Makefile for both amdgcn and nvptx targets.
+#            amdgcn targets begin with gfx. nvptx targets begin with sm_
+#
+#  Run "make help" to see how to use this Makefile
+#
+#-----------------------------------------------------------------------
+# MIT License
+# Copyright (c) 2017 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+include ../../Makefile.defs
+
+TESTNAME =vecadd
+FILETYPE =cpp
+
+CC = $(AOMP)/bin/clang++ -std=c++11
+
+# Add cudart only if we have an Nvidia sm_ target
+# We have not tested CUDA+OpenMP target offload
+ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
+  LFLAGS = -L$(CUDA)/targets/$(UNAMEP)-linux/lib -lcudart -Wl,-rpath,$(CUDA)/targets/$(UNAMEP)-linux/lib
+  TRIPLE = nvptx64-nvidia-cuda
+  PLATFORM = -D__HIP_PLATFORM_NVCC__=1
+else
+  TRIPLE = amdgcn-amd-amdhsa
+  PLATFORM = -D__HIP_PLATFORM_HCC__=1
+endif
+
+#  These HIPFLAGS provide HIP+OpenMP for CPU only. No target offload
+HIPLIBS = -L $(AOMPHIP)/hip -L $(AOMPHIP)/lib
+VERS = $(shell $(AOMP)/bin/clang --version | grep -oP '(?<=clang version )[0-9.]+')
+ifeq ($(shell expr $(VERS) \>= 12.0), 1)
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib
+endif
+HIPFLAGS = -x hip $(PLATFORM) --offload-arch=$(AOMP_GPU) $(AOMP_CPUTARGET)  $(HIPLIBS) -lamdhip64 $(RPTH) -O0 -g # -O2
+#  These OMP_TARGET_FLAGS added to HIPFLAGS provide HIP+OpenMP with GPU target offload
+OMP_TARGET_FLAGS = -fopenmp-targets=$(TRIPLE) -Xopenmp-target=$(TRIPLE) -march=$(AOMP_GPU) $(AOMP_CPUTARGET)
+
+CFLAGS = -fopenmp -O0 -g #-O2
+
+# ----- Demo compile and link in one step, no object code saved
+$(TESTNAME): hiptarg.o omptarg.o $(TESTNAME).o
+	$(CC) $(CFLAGS) $(LFLAGS) $^ -o $@ $(HIPFLAGS) $(OMP_TARGET_FLAGS) $(HIPLIBS) -lamdhip64
+
+run: $(TESTNAME)
+	timeout 10 ./$(TESTNAME)
+
+hiptarg.o: hiptarg.cpp
+	$(CC) $(HIPFLAGS) $(CFLAGS) -o $@ $^ -c
+
+omptarg.o: omptarg.cpp
+	$(CC) $(OMP_TARGET_FLAGS) $(CFLAGS) -o $@ $^ -c
+
+#  ----   Demo compile and link in two steps, object saved
+$(TESTNAME).o: hiptarg.o omptarg.o $(TESTNAME).$(FILETYPE)
+	$(CC) -c $(CFLAGS) $^ 
+
+obin:	$(TESTNAME).o 
+	$(CC) $(LFLAGS) $^ -o obin
+
+run_obin: obin 
+	./obin
+
+include ../Makefile.HelpClean 

--- a/test/hip-openmp/xnack/hiptarg.cpp
+++ b/test/hip-openmp/xnack/hiptarg.cpp
@@ -1,0 +1,47 @@
+// MIT License
+//
+// Copyright (c) 2017 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "hip/hip_runtime.h"
+#include <stdio.h>
+
+__global__ void vecAdd(int *da, int *dc, int n) {
+  for(int i = 0; i < n; i++)
+    dc[i] = da[i];
+}
+
+void hiptarg_test(int *a, int *c, int n) {
+  int *da, *dc;
+
+  hipMalloc(&da, n*sizeof(int));
+  hipMalloc(&dc, n*sizeof(int));
+
+  hipMemcpy(da, a, n*sizeof(int), hipMemcpyHostToDevice);
+
+  printf("Calling HIP\n");
+  vecAdd<<<1, 1, 0, 0>>>(da, dc, n);
+
+  hipDeviceSynchronize();
+  hipMemcpy(c, dc, n*sizeof(int), hipMemcpyDeviceToHost);
+
+}

--- a/test/hip-openmp/xnack/omptarg.cpp
+++ b/test/hip-openmp/xnack/omptarg.cpp
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2017 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <omp.h>
+#include <stdio.h>
+
+#pragma omp requires unified_shared_memory
+
+void targetVecAdd(int *b, int *c, int n) {
+#pragma omp target teams distribute parallel for
+   for(int i = 0; i < n; i++)
+     c[i] += b[i];
+}
+
+void omptarg_test(int *b, int *c, int n) {
+  printf("\n\nCalling OMP \n");
+  targetVecAdd(b, c, n);
+}

--- a/test/hip-openmp/xnack/vecadd.cpp
+++ b/test/hip-openmp/xnack/vecadd.cpp
@@ -1,0 +1,61 @@
+// MIT License
+//
+// Copyright (c) 2017 Advanced Micro Devices, Inc. All Rights Reserved.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use, copy,
+// modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+// BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <omp.h>
+#include <stdio.h>
+
+#define N 1021
+
+extern void hiptarg_test(int *a, int *c, int n);
+extern void omptarg_test(int *b, int *c, int n);
+
+void init_test(int *a, int *b, int n) {
+  for(int i = 0; i < n; i++) {
+    a[i] = i;
+    b[i] = i+1;
+  }
+}
+
+int check_test(int *a, int *b, int *c, int n) {
+  int err = 0;
+  for(int i = 0; i < n; i++)
+    if(c[i] != a[i] + b[i]) {
+      err++;
+      printf("%d: c = %d (expected %d)\n", i, c[i], a[i]+b[i]);
+      if (err > 10) return err;
+  }   
+
+  return err;
+}
+
+int main() {
+  int *a = (int*) malloc(N*sizeof(int));
+  int *b = (int*) malloc(N*sizeof(int));
+  int *c = (int*) malloc(N*sizeof(int));
+
+  init_test(a, b, N);
+  hiptarg_test(a, c, N);
+  omptarg_test(b, c, N);
+  return check_test(a, b, c, N);
+}


### PR DESCRIPTION
Add test for USM mode when mixing hip and openmp but only openmp requires hw support for xnack