### PR TITLE
Update tests with teams runtime APIs omp_get_num_teams() and omp_get_team_num().

### DIFF
--- a/test/smoke/teams_notarget_get_num_teams/teams_notarget_get_num_teams.c
+++ b/test/smoke/teams_notarget_get_num_teams/teams_notarget_get_num_teams.c
@@ -3,7 +3,6 @@
 #include <omp.h>
 
 #define N 10000
-#define MAX_TEAMS 64
 int main() {
   int n = N;
   int team_id, cur_teams;
@@ -26,12 +25,20 @@ int main() {
               if (err > 10) break;
           }
       }
-      // If we have bigger number than MAX_TEAMS in num_teams() clause we will
-      // get omp_get_num_teams() as MAX_TEAMS.
-      if ( ((cur_teams > MAX_TEAMS) && (cur_teams != MAX_TEAMS)) && (cur_teams != teams_sizes[j]) ) {
-          printf("omp_get_num_teams() : %d but we tried to set num_teams(%d)\n", cur_teams, teams_sizes[j]);
+      // omp_get_num_teams() will always return value less than or equal to
+      // value passed in num_teams() clause.
+      if ( cur_teams > teams_sizes[j] ) {
+          printf("Error : omp_get_num_teams() : %d but we tried to set"
+			  " num_teams(%d)\n", cur_teams, teams_sizes[j]);
 	  err++;
       }
+  }
+  cur_teams = omp_get_num_teams();
+  // omp_get_num_teams() value should be 1 when outside of teams region.
+  if ( cur_teams != 1 ) {
+      printf("Error : omp_get_num_teams() : %d but should return 1 when"
+		      " outside of teams region.\n", cur_teams);
+      err++;
   }
   return err;
 }

--- a/test/smoke/teams_notarget_get_team_num/teams_notarget_get_team_num.c
+++ b/test/smoke/teams_notarget_get_team_num/teams_notarget_get_team_num.c
@@ -30,10 +30,17 @@ int main() {
 
   for (int i = 0; i < TOTAL_TEAMS; i++) {
       if (team_counts[i] != N/TOTAL_TEAMS) {
-          printf("Team id : %d is not shared with equal work. It is shared with %d iterations\n", i, team_counts[i]);
+          printf("Team id : %d is not shared with equal work. It is shared"
+			  " with %d iterations\n", i, team_counts[i]);
 	  err++;
       }
   }
-
+  team_id = omp_get_team_num();
+  // omp_get_team_num() should return 0 when called outside of teams region.
+  if (team_id != 0) {
+      printf("omp_get_team_num() : %d expected 0 when omp_get_team_num()"
+		      " called outside of teams region\n", team_id);
+      err++;
+  }
   return err;
 }


### PR DESCRIPTION
Updated host only teams tests as per meeting discussion.
	modified:   teams_notarget_get_num_teams/teams_notarget_get_num_teams.c
	modified:   teams_notarget_get_team_num/teams_notarget_get_team_num.c