### PR TITLE
Update check-smoke Makefile target.

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -51,7 +51,7 @@ verify-log: run
 check: $(TESTNAME)
 	path=`pwd`; \
 	base=`basename $$path`; \
-	if   ($(SMOKE_TIMEOUT) ./$(TESTNAME)> /dev/null 2>&1); then \
+	if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) ./$(TESTNAME) $(ARGS) > /dev/null 2>&1); then \
 		echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		echo  "" >> ../check-smoke.txt; \
 		echo $$base $$test_num  >> ../passing-tests.txt; \

--- a/test/smoke/flang-tracekernel/Makefile
+++ b/test/smoke/flang-tracekernel/Makefile
@@ -1,6 +1,6 @@
 include ../../Makefile.defs
 
-ROCM         ?= $(AOMP)/
+ROCM         ?= $(AOMP)
 TESTNAME     = flangtrace
 TESTSRC_MAIN = flangtrace.f90
 TESTSRC_AUX  = hiptrace.f90
@@ -14,6 +14,9 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
+RUNENV += PATH=$(ROCM)/bin:$(PATH) LIBOMPTARGET_KERNEL_TRACE=2
+RUNPROF = rocprof --roctx-trace --sys-trace
+
 include ../Makefile.rules
 run:
-	PATH=$(ROCM)/bin:$(PATH) LIBOMPTARGET_KERNEL_TRACE=2 rocprof --roctx-trace --sys-trace ./$(TESTNAME)
+	$(RUNENV) $(RUNPROF) ./$(TESTNAME)

--- a/test/smoke/gdb_teams/Makefile
+++ b/test/smoke/gdb_teams/Makefile
@@ -15,7 +15,9 @@ CC           = $(OMP_BIN) $(VERBOSE)
 include ../Makefile.rules
 
 AOMPROCM ?= $(AOMP)
+RUNPROF   = $(AOMPROCM)/bin/rocgdb
+ARGS      = -x cmd_script -q
 
 run:
-	$(AOMPROCM)/bin/rocgdb ./gdb_teams -x cmd_script -q
+	$(RUNPROF) $(TESTNAME) $(ARGS)
 

--- a/test/smoke/teams512-info/Makefile
+++ b/test/smoke/teams512-info/Makefile
@@ -13,6 +13,7 @@ include ../../Makefile.defs
 
 TESTNAME = teams512-info
 TESTSRC  = teams512-info.c
+RUNENV   += LIBOMPTARGET_KERNEL_TRACE=1
 
 CFLAGS = -O3 $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET) -march=$(AOMP_GPU)
 
@@ -29,7 +30,6 @@ $(TESTNAME): $(TESTSRC)
 	$(CCENV) $(CC) $(CFLAGS) -DGPUINFO $(LFLAGS) $^ -o $@
 
 run: $(TESTNAME)
-	LIBOMPTARGET_KERNEL_TRACE=1 \
 	$(RUNENV) ./$(TESTNAME)
 
 #  ----   Demo compile and link in two steps, object saved

--- a/test/smoke/vasp1/Makefile
+++ b/test/smoke/vasp1/Makefile
@@ -4,6 +4,7 @@ TESTNAME     = vasp1
 TESTSRC_MAIN = vasp1.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -13,6 +14,5 @@ CC           = $(OMP_BIN) $(VERBOSE)
 include ../Makefile.rules
 
 run: $(TESTNAME)
-	LIBOMPTARGET_KERNEL_TRACE=1 \
 	$(RUNENV) ./$(TESTNAME) 1
 

--- a/test/smoke/wgs64/Makefile
+++ b/test/smoke/wgs64/Makefile
@@ -4,6 +4,7 @@ TESTNAME     = wgs64
 TESTSRC_MAIN = wgs64.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 CLANG        = clang -mllvm  -amdgpu-dump-hsa-metadata -save-temps
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -13,6 +14,6 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	LIBOMPTARGET_KERNEL_TRACE=1 ./$(TESTNAME)
+	./$(TESTNAME)
 	fgrep -s '.max_flat_workgroup_size: 256' wgs64-openmp-amdgcn-amd-amdhsa-*.s
 


### PR DESCRIPTION
Some smoke tests have additional options that need passing.
Make use of RUNENV and RUNPROF so that the check_smoke.sh
script returns the proper code for those tests.