### PR TITLE
Remove usage of ROCM_PATH in favor of ROCM_LLVM for fortran/openmp ex…

### DIFF
--- a/examples/fortran/bigloop/Makefile
+++ b/examples/fortran/bigloop/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,18 +34,18 @@
 TESTNAME =bigloop
 FILETYPE =f95
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ifeq ($(TARGETS),)
 TARGETS =-march=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS = -O3 -m64 -i8 -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET)
 
@@ -97,7 +97,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                           value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                           value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator   value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "            value: $(TARGETS)"

--- a/examples/fortran/declare_target/Makefile
+++ b/examples/fortran/declare_target/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,17 +34,17 @@
 TESTNAME =declare_target
 FILETYPE =f95
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
 
 ifeq ($(TARGETS),)
 TARGETS =-march=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS = -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET)
 
@@ -94,7 +94,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                            value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "              value: $(TARGETS)"

--- a/examples/fortran/gdb_simple/Makefile
+++ b/examples/fortran/gdb_simple/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,18 +34,18 @@
 TESTNAME =gdb_simple
 FILETYPE =f95
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ifeq ($(TARGETS),)
 TARGETS =-march=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS = -g -O2 -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET)
 
@@ -95,7 +95,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                            value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "              value: $(TARGETS)"

--- a/examples/fortran/helloAcceptance/Makefile
+++ b/examples/fortran/helloAcceptance/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,18 +34,18 @@
 TESTNAME =hello
 FILETYPE =f90
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ifeq ($(TARGETS),)
 TARGETS =-march=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS =-fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET)
 
@@ -92,7 +92,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                            value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "              value: $(TARGETS)"

--- a/examples/fortran/helloworld/Makefile
+++ b/examples/fortran/helloworld/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,18 +34,18 @@
 TESTNAME =helloworld
 FILETYPE =f90
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ifeq ($(TARGETS),)
 TARGETS =--offload-arch=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS =
 
@@ -92,7 +92,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                            value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "              value: $(TARGETS)"

--- a/examples/fortran/helloworld/Makefile
+++ b/examples/fortran/helloworld/Makefile
@@ -1,7 +1,5 @@
 #-----------------------------------------------------------------------
 #  ROCM_LLVM:       Defaults to /opt/rocm/llvm
-#  ROCM_GPU:        Auto detected via rocm_agent_enumerator
-#  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
 #  make run
 #
@@ -35,17 +33,8 @@ TESTNAME =helloworld
 FILETYPE =f90
 
 ROCM_LLVM ?= /opt/rocm/llvm
-ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
-ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_LLVM)/bin/clang
-
-ifeq ($(TARGETS),)
-TARGETS =--offload-arch=$(ROCM_GPU)
-endif
-
-FORT   =$(ROCM_LLVM)/bin/flang
+FORT   = $(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS =
 
@@ -93,9 +82,6 @@ help:
 	@echo
 	@echo "Environment Variables:"
 	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
-	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
-	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
-	@echo "              value: $(TARGETS)"
 	@echo
 	@echo "Link Flags:"
 	@echo "  Link flags: $(LFLAGS)"

--- a/examples/fortran/simple_offload/Makefile
+++ b/examples/fortran/simple_offload/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -34,18 +34,18 @@
 TESTNAME =simple_offload
 FILETYPE =f95
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ifeq ($(TARGETS),)
 TARGETS =-march=$(ROCM_GPU)
 endif
 
-FORT   =$(ROCM_PATH)/bin/flang
+FORT   =$(ROCM_LLVM)/bin/flang
 LFLAGS = 
 FFLAGS = -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET)
 
@@ -95,7 +95,7 @@ help:
 	@echo "  make help 		// this help"
 	@echo
 	@echo "Environment Variables:"
-	@echo "  ROCM_PATH default: /opt/rocm/llvm                            value: $(ROCM_PATH)"
+	@echo "  ROCM_LLVM default: /opt/rocm/llvm                            value: $(ROCM_LLVM)"
 	@echo "  ROCM_GPU  default: auto detected by rocm_agent_enumerator    value: $(ROCM_GPU)"
 	@echo "  TARGETS   default: --offload-arch=$(ROCM_GPU)"
 	@echo "              value: $(TARGETS)"

--- a/examples/openmp/declare_variant_if/Makefile
+++ b/examples/openmp/declare_variant_if/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,12 +16,12 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ROCM_GPUTARGET = amdgcn-amd-amdhsa
 
@@ -30,7 +30,7 @@ CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGE
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -72,7 +72,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"

--- a/examples/openmp/host_function/Makefile
+++ b/examples/openmp/host_function/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,12 +16,12 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 ROCM_GPUTARGET = amdgcn-amd-amdhsa
 
@@ -30,7 +30,7 @@ CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGE
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -86,7 +86,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"

--- a/examples/openmp/reduction/Makefile
+++ b/examples/openmp/reduction/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,19 +16,19 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 # Sorry, clang openmp requires these complex options
 CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET) -march=$(ROCM_GPU)
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -84,7 +84,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"

--- a/examples/openmp/veccopy/Makefile
+++ b/examples/openmp/veccopy/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,19 +16,19 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 # Sorry, clang openmp requires these complex options
 CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET) -march=$(ROCM_GPU)
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -84,7 +84,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm bin is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm bin is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"

--- a/examples/openmp/vmul_template/Makefile
+++ b/examples/openmp/vmul_template/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,19 +16,19 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang++
+CC              = $(ROCM_LLVM)/bin/clang++
 
 # Sorry, clang openmp requires these complex options
 CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET) -march=$(ROCM_GPU)
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -84,7 +84,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"

--- a/examples/openmp/vmulsum/Makefile
+++ b/examples/openmp/vmulsum/Makefile
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------
-#  ROCM_PATH:       Defaults to /opt/rocm/llvm
+#  ROCM_LLVM:       Defaults to /opt/rocm/llvm
 #  ROCM_GPU:        Auto detected via rocm_agent_enumerator
 #  ROCM_GPUTARGET:  Defaults to amdgcn-amd-amdhsa
 #
@@ -16,19 +16,19 @@ ifeq ($(UNAMEP),ppc64le)
   ROCM_CPUTARGET = ppc64le-linux-gnu
 endif
 
-ROCM_PATH ?= /opt/rocm/llvm
+ROCM_LLVM ?= /opt/rocm/llvm
 ROCM_GPUTARGET ?= amdgcn-amd-amdhsa
 
-INSTALLED_GPU  = $(shell $(ROCM_PATH)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
+INSTALLED_GPU  = $(shell $(ROCM_LLVM)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
 ROCM_GPU       ?= $(INSTALLED_GPU)
-CC              = $(ROCM_PATH)/bin/clang
+CC              = $(ROCM_LLVM)/bin/clang
 
 # Sorry, clang openmp requires these complex options
 CFLAGS = -O3 -target $(ROCM_CPUTARGET) -fopenmp -fopenmp-targets=$(ROCM_GPUTARGET) -Xopenmp-target=$(ROCM_GPUTARGET) -march=$(ROCM_GPU)
 
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
-  CCENV  = env LIBRARY_PATH=$(ROCM_PATH)/lib-debug
+  CCENV  = env LIBRARY_PATH=$(ROCM_LLVM)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
@@ -89,7 +89,7 @@ help:
 	@echo
 	@echo "Environment variables used by this Makefile:"
 	@echo "  ROCM_GPU=<GPU>       Target GPU, e.g gfx906"
-	@echo "  ROCM_PATH=<dir>      Where llvm is located"
+	@echo "  ROCM_LLVM=<dir>      Where llvm is located"
 	@echo "  EXTRA_CFLAGS=<args>  extra arguments for compiler"
 	@echo "  OFFLOAD_DEBUG=n      if n=1, compile and run in Debug mode"
 	@echo "  VERBOSE=n            if n=1, add verbose output"


### PR DESCRIPTION
…amples.