### PR TITLE
SWDEV-317842 Add test case for incorrect usage of OpenMP

### DIFF
--- a/test/smoke-fails/flang-317842/Makefile
+++ b/test/smoke-fails/flang-317842/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-317842
+TESTSRC_MAIN = flang-317842.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-317842/flang-317842.f90
+++ b/test/smoke-fails/flang-317842/flang-317842.f90
@@ -1,0 +1,16 @@
+real function double_dot(a,b) result(dot)
+  implicit none
+
+  real, intent(in) :: a(:,:), b(:,:)
+
+  integer :: i,j
+
+  !$omp target teams distribute parallel do reduction(+:dot)
+  do j = 1,size(a,dim=2)
+    !$omp parallel do reduction(+:dot)
+    do i = 1,size(a,dim=1)
+      dot = a(i,j)*b(i,j)
+    enddo
+  enddo
+
+end function


### PR DESCRIPTION
Test case is incorrect because of doubled the
'parallel do' clause on nested loops. The compiler should
give appropriate diagnostic error.

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>