### PR TITLE
Add test for SWDEV-317868

### DIFF
--- a/test/smoke-fails/flang-317868/Makefile
+++ b/test/smoke-fails/flang-317868/Makefile
@@ -1,0 +1,13 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-317868
+TESTSRC_MAIN = flang-317868.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS   += -E
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-317868/flang-317868.f90
+++ b/test/smoke-fails/flang-317868/flang-317868.f90
@@ -1,0 +1,3 @@
+#include "foo.f90"
+program main
+end program main

--- a/test/smoke-fails/flang-317868/foo.f90
+++ b/test/smoke-fails/flang-317868/foo.f90
@@ -1,0 +1,1 @@
+!You shouldn't see me twice


### PR DESCRIPTION
    Using preprocessor flag "-E" with omp target
    offload causing the output to duplicate