### PR TITLE
Add test for omp_target_alloc under usm mode. It uses device memory a…

### DIFF
--- a/test/smoke/target_alloc_usm/Makefile
+++ b/test/smoke/target_alloc_usm/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+TESTNAME     = target_alloc_usm
+TESTSRC_MAIN = target_alloc_usm.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+
+run:
+	HSA_XNACK=1 ./$(TESTNAME) 2>&1 | tee $@.log

--- a/test/smoke/target_alloc_usm/target_alloc_usm.cpp
+++ b/test/smoke/target_alloc_usm/target_alloc_usm.cpp
@@ -1,0 +1,27 @@
+#include <cstdio>
+#include <omp.h>
+
+#define N 123456
+
+#pragma omp requires unified_shared_memory
+
+int main() {
+  int n = N;
+  double * a = (double *)omp_target_alloc(n*sizeof(double), 0);
+  double * b = new double[n];
+
+  #pragma omp target teams distribute parallel for map(b[:n]) device(1)
+  for(int i = 0; i < n; i++)
+    a[i] = b[i];
+
+  // check
+  int err = 0;
+  for(int i = 0; i < n; i++)
+    if (a[i] != b[i]) {
+      err++;
+      printf("Error at %d: should be %lf, got %lf\n", i, (double)i, a[i]);
+      if (err > 10) break;
+    }
+
+  return err;
+}


### PR DESCRIPTION
…nd makes the memory such allocated accessible by all device and host agents, i.e. any thread on the system can accessed that memory.