### PR TITLE
to test run_epsdb_aomp_test on AOMP standalone build we need to find …

### DIFF
--- a/bin/run_epsdb_aomp_test.sh
+++ b/bin/run_epsdb_aomp_test.sh
@@ -16,7 +16,11 @@ set -x
 # in lots of tests. This set to 0, disables the new TMM.
 #export LIBOMPTARGET_MEMORY_MANAGER_THRESHOLD=0
 
-export AOMPROCM=$AOMP/..
+if [ -f $AOMP/bin/rocm_agent_enumerator ] ; then
+   export AOMPROCM=$AOMP
+else
+   export AOMPROCM=$AOMP/..
+fi
 
 
 # Try using rocm_agent_enumerator for device id.


### PR DESCRIPTION
…rocm-agent-enumerator in $AOMP/bin first.  Otherwise the parent directory does not contain a bin with it.