### PR TITLE
Add simple test case for SWDEV-321838

### DIFF
--- a/test/smoke-fails/Makefile
+++ b/test/smoke-fails/Makefile
@@ -54,6 +54,7 @@ TESTS_DIR = \
     flang-321412 \
     flang-321847 \
     flang-321838 \
+    flang-321838-2 \
     flang-flags-308205 \
     flang_atomic_hint \
     flang_dev_write \

--- a/test/smoke-fails/flang-321838-2/Makefile
+++ b/test/smoke-fails/flang-321838-2/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-321838-2
+TESTSRC_MAIN = flang-321838-2.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-321838-2/flang-321838-2.f90
+++ b/test/smoke-fails/flang-321838-2/flang-321838-2.f90
@@ -1,0 +1,14 @@
+subroutine test(arr_size)
+   implicit none
+   integer, intent(in) :: arr_size
+   integer, dimension(arr_size) :: arr
+
+   !$omp target teams private(arr)
+      arr(:) = 0
+   !$omp end target teams
+end subroutine test
+
+program main
+   implicit none
+   call test(10)
+end program main


### PR DESCRIPTION
    Testcase is causing the segfault during runtime.
    When in subroutine the target teams program is
    called with f90 array assigment, (which size is
    subroutine argument) the assignment segfaults.