### PR TITLE
[DO NOT MERGE] Added 3 tests to validate workgroup size launch parameter

### DIFF
--- a/test/smoke/workgroup_size/Makefile
+++ b/test/smoke/workgroup_size/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size
+TESTSRC_MAIN = workgroup_size.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke/workgroup_size/workgroup_size.c
+++ b/test/smoke/workgroup_size/workgroup_size.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with default options
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:257  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:257  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)

--- a/test/smoke/workgroup_size_option1/Makefile
+++ b/test/smoke/workgroup_size_option1/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size_option1
+TESTSRC_MAIN = workgroup_size_option1.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=1024
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke/workgroup_size_option1/workgroup_size_option1.c
+++ b/test/smoke/workgroup_size_option1/workgroup_size_option1.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with -fopenmp-gpu-threads-per-team=1024
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:961  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 961)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:1024  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X1024)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:961  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 961)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:1024  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X1024)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)

--- a/test/smoke/workgroup_size_option2/Makefile
+++ b/test/smoke/workgroup_size_option2/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size_option2
+TESTSRC_MAIN = workgroup_size_option2.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=128
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke/workgroup_size_option2/workgroup_size_option2.c
+++ b/test/smoke/workgroup_size_option2/workgroup_size_option2.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with -fopenmp-gpu-threads-per-team=128
+// Option specified workgroup size < default of 256 not honored at this point
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:257  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:257  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)


### PR DESCRIPTION
This can be merged only after the patch implementing the new option is pushed.

The first test workgroup_size uses default options.
The other 2 tests use the option -fopenmp-gpu-threads-per-team.

All 3 tests use FileCheck to validate the workgroup size used during kernel launch.