### PR TITLE
Add testcase for SWDEV-322947

### DIFF
--- a/test/smoke-fails/Makefile
+++ b/test/smoke-fails/Makefile
@@ -59,6 +59,7 @@ TESTS_DIR = \
     flang-321838 \
     flang-321838-2 \
     flang-322945 \
+    flang-322947 \
     flang-flags-308205 \
     flang_atomic_hint \
     flang_dev_write \

--- a/test/smoke-fails/flang-322947/Makefile
+++ b/test/smoke-fails/flang-322947/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-322947
+TESTSRC_MAIN = flang-322947.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-322947/flang-322947.f90
+++ b/test/smoke-fails/flang-322947/flang-322947.f90
@@ -1,0 +1,23 @@
+program test
+    type field2DReal
+       real, dimension(:), pointer :: array => null()
+    end type field2DReal
+
+    type (field2DReal) :: head
+    real, dimension(:), pointer :: arr
+    integer :: i, use_gpu = 1
+    allocate(head%array(128));
+    arr => head%array
+
+!$omp target teams distribute if(use_gpu) 
+    do i=1,128
+        arr(i) = i
+    end do
+
+!$omp target exit data map(from:head%array)
+
+    do i=1,128
+        print *, head%array(i)
+    end do
+
+end program test


### PR DESCRIPTION
    compilation errors with `if` clause when the exit data
    is present