### PR TITLE
Add testcase for SWDEV-324643

### DIFF
--- a/test/smoke-fails/Makefile
+++ b/test/smoke-fails/Makefile
@@ -63,6 +63,7 @@ TESTS_DIR = \
     flang-321838-2 \
     flang-322945 \
     flang-322947 \
+    flang-324643 \
     flang-flags-308205 \
     flang_atomic_hint \
     flang_dev_write \

--- a/test/smoke-fails/flang-324643/Makefile
+++ b/test/smoke-fails/flang-324643/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-324643
+TESTSRC_MAIN = flang-324643.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-324643/flang-324643.f90
+++ b/test/smoke-fails/flang-324643/flang-324643.f90
@@ -1,0 +1,23 @@
+program minimal
+  use iso_c_binding
+
+  implicit none
+
+  TYPE descriptor_t
+    INTEGER, ALLOCATABLE :: nsp(:)
+  END TYPE
+
+  INTEGER, ALLOCATABLE :: nsp2(:)
+
+
+  TYPE(descriptor_t) :: desc
+
+  ! Fails with
+  !F90-F-0000-Internal compiler error. gen_sptr(): unexpected storage type       6  (unexpected_storage_type.f90: 23)
+  !F90-F-0000-Internal compiler error. gen_sptr(): unexpected storage type       6  (unexpected_storage_type.f90: 23)
+  ! Works
+  !!$omp target update to(nsp2)
+  !$omp target update to(desc%nsp)
+
+
+end program minimal


### PR DESCRIPTION
    Placing a deferred shape array inside a derived type produces
    a compiler error when using OpenMP offloading.
    The compiler error does not occur if the deferred shape
    array lives outside the derived type.