### PR TITLE
[smoke] - fix virtfuncl issues on mainline.

### DIFF
--- a/test/smoke/virtfunc1/Makefile
+++ b/test/smoke/virtfunc1/Makefile
@@ -1,11 +1,15 @@
 include ../../Makefile.defs
 
-TESTNAME     = virtunc1
-TESTSRC_MAIN = virtunc1.cpp
+TESTNAME     = virtfunc1
+TESTSRC_MAIN = virtfunc1.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
-
-CLANG        = clang++ -D__HIP_PLATFORM_AMD__=1 -L $(AOMP)/../hip/lib -l amdhip64
+VERS = $(shell $(AOMP)/bin/clang --version | grep -oP '(?<=clang version )[0-9.]+')
+ifeq ($(shell expr $(VERS) \>= 12.0), 1)
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib
+  LLIB = -L$(AOMPHIP)/lib
+endif
+CLANG        = clang++ -D__HIP_PLATFORM_AMD__=1 $(LLIB) -lamdhip64 $(RPTH)
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke/virtfunc1/virtfunc1.cpp
+++ b/test/smoke/virtfunc1/virtfunc1.cpp
@@ -1,0 +1,59 @@
+#include <cstdio>
+#include "hip/hip_runtime.h"
+
+struct b {
+#if 0
+  __host__
+  __device__
+#endif
+  virtual void my_print() {
+    printf("Hello\n");
+  }
+};
+
+struct d : b {
+#if 0
+  __host__ 
+  __device__
+#endif
+  virtual void my_print() override {
+    printf("World\n");
+  }
+};
+
+
+
+int main() {
+
+    constexpr int num_objects = 2;
+    void** buffers{nullptr};
+    hipHostMalloc(&buffers, num_objects * sizeof(void*));
+    for (auto i = 0; i < num_objects; ++i) {
+      hipMalloc(buffers + i, sizeof(d));
+    }
+    
+    #pragma omp target teams distribute parallel for is_device_ptr(buffers)
+    for (int i = 0; i < num_objects; ++i) {
+        if (i % 2 == 0) {
+            new(*(buffers + i)) b();
+        }
+        else {
+            new(*(buffers + i)) d();
+        }
+    }
+
+    #pragma omp target teams distribute parallel for is_device_ptr(buffers)
+    for (int i = 0; i < num_objects; ++i) {
+        static_cast<b*>(*(buffers + i))->my_print();
+    }
+#pragma omp target 
+    {
+      printf("last region\n");
+    }
+
+    for (auto i = 0; i < num_objects; ++i) {
+        hipFree(*(buffers + i));
+    }
+    hipHostFree(buffers);
+    return 0;
+}


### PR DESCRIPTION
Mainline testing was reporting the inability to find
libamdhip64.so. Use AOMPHIP and rpath to resolve issue.
Update test name in Makefile and source file.