### PR TITLE
Add test cases for comparing *.ll code generated by flang and clang

### DIFF
--- a/test/smoke-fails/clang-ifaces/Makefile
+++ b/test/smoke-fails/clang-ifaces/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = clang-ifaces
+TESTSRC_MAIN = clang-ifaces.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS += -O0
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/clang-ifaces/clang-ifaces.c
+++ b/test/smoke-fails/clang-ifaces/clang-ifaces.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(){
+    int a[256];
+    int b[256];
+    int c;
+    int d;
+    int e[256];
+    int f;
+
+#pragma omp target teams distribute parallel for map(tofrom: a)
+for (int i =0; i <256; i++)
+{
+    a[i] =i;
+}
+
+#pragma omp target teams distribute map(tofrom: b)
+for(int i = 0; i <256; i++)
+{
+    b[i]= i;
+}
+
+#pragma omp target parallel map(tofrom: c)
+{
+    c = 2;
+}
+#pragma omp target teams map(tofrom: d)
+{
+   d = 3;
+}
+
+#pragma omp target parallel for map(tofrom: e)
+for (int i =0; i <256; i++)
+{
+    e[i] =i;
+}
+
+#pragma omp target map(tofrom: f)
+{
+    f = 4;
+}
+return 0;
+}
+
+

--- a/test/smoke-fails/flang-ifaces/Makefile
+++ b/test/smoke-fails/flang-ifaces/Makefile
@@ -1,0 +1,13 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-ifaces
+TESTSRC_MAIN = flang-ifaces.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE) 
+OMP_FLAGS += -O0
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-ifaces/flang-ifaces.f90
+++ b/test/smoke-fails/flang-ifaces/flang-ifaces.f90
@@ -1,0 +1,39 @@
+program main
+   integer :: a(256)
+   integer :: b(256)
+   integer :: c
+   integer :: d
+   integer :: e(256)
+   integer :: f
+   integer :: i
+   !$omp target teams distribute parallel do map(tofrom: a)
+   DO i = 1, 256
+         a(i) = i
+   END DO 
+   !$omp end target teams distribute parallel do
+
+   !$omp target teams distribute map(tofrom: b)
+   DO i = 1, 256
+         b(i) = i
+   END DO 
+   !$omp end target teams distribute
+
+   !$omp target parallel map(tofrom: c)
+         c = 2
+   !$omp end target parallel
+
+   !$omp target teams map(tofrom: d)
+         d = 3
+   !$omp end target teams
+
+   !$omp target parallel do map(tofrom: e)
+    DO i = 1, 256
+         e(i) = i
+    END DO
+   !$omp end target parallel do 
+
+   !$omp target map(tofrom : f)
+        f = 4
+   !$omp end target
+
+end program main


### PR DESCRIPTION
Check if Flang can generate similar code as Clang does for similar target pragmas.

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>