### PR TITLE
Added 4 tests to validate workgroup size launch parameter

### DIFF
--- a/test/smoke-fails/no-loop-2/Makefile
+++ b/test/smoke-fails/no-loop-2/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = no_loop_2
+TESTSRC_MAIN = no_loop_2.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-gpu-threads-per-team=512
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/no-loop-2/no_loop_2.c
+++ b/test/smoke-fails/no-loop-2/no_loop_2.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <omp.h>
+
+#pragma omp declare target
+int foo(int i) { return i+1; }
+#pragma omp end declare target
+
+int main()
+{
+  int N = 1000000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  int j;
+#pragma omp target teams distribute parallel for
+  {
+    for (j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int k = 0; k< N; k++)
+      a[k]=b[k];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int k = 0; k< N; k++) {
+      a[k]=b[k];
+      foo(k);
+    }
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int k = 0; k< N; k++) {
+      a[k]=b[k];
+      omp_get_num_teams();
+    }
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int k = 0; k< N; k++) {
+#pragma omp simd      
+      for (int p = 0; p < N; p++)
+	a[k]=b[k];
+    }
+  }
+  
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:4 ConstWGSize:512  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:4 ConstWGSize:512  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:4 ConstWGSize:512  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:512  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:512  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)

--- a/test/smoke-fails/workgroup_size/Makefile
+++ b/test/smoke-fails/workgroup_size/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size
+TESTSRC_MAIN = workgroup_size.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/workgroup_size/workgroup_size.c
+++ b/test/smoke-fails/workgroup_size/workgroup_size.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with default options
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:257  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:257  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)

--- a/test/smoke-fails/workgroup_size_option1/Makefile
+++ b/test/smoke-fails/workgroup_size_option1/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size_option1
+TESTSRC_MAIN = workgroup_size_option1.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=1024
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/workgroup_size_option1/workgroup_size_option1.c
+++ b/test/smoke-fails/workgroup_size_option1/workgroup_size_option1.c
@@ -1,0 +1,73 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with -fopenmp-gpu-threads-per-team=1024
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:257  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:1024  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X1024)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:257  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:1024  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X1024)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)

--- a/test/smoke-fails/workgroup_size_option2/Makefile
+++ b/test/smoke-fails/workgroup_size_option2/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = workgroup_size_option2
+TESTSRC_MAIN = workgroup_size_option2.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=128
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/workgroup_size_option2/workgroup_size_option2.c
+++ b/test/smoke-fails/workgroup_size_option2/workgroup_size_option2.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main() {
+  int num_threads = 0;
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+  int c[N];
+
+  int i;
+
+#pragma omp target map(from: num_threads)
+  {
+    num_threads = omp_get_num_threads();
+  }
+  printf("num_threads = %d\n", num_threads);
+  
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams
+  {
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+#pragma omp distribute parallel for
+    for (int j = 0; j< N; j++)
+      c[j]=b[j];
+  }
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for thread_limit(64)
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] || c[i] != b[i]) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d c[%d]=%d\n", i, a[i], i, c[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+// Compiled with -fopenmp-gpu-threads-per-team=128
+// Option specified workgroup size < default of 256 not honored at this point
+
+/// CHECK: DEVID: 0 SGN:1 ConstWGSize:257  args: 1 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 257)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:3 ConstWGSize:257  args: 7 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID: 0 SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 64)


### PR DESCRIPTION
The test workgroup_size uses default options.
2 tests use the option -fopenmp-gpu-threads-per-team.
1 uses the above option along with ignore-env-vars option.