### PR TITLE
Added modified makefile run command to check type of kernel for flang-313307

### DIFF
--- a/test/smoke-fails/flang-313307/Makefile
+++ b/test/smoke-fails/flang-313307/Makefile
@@ -10,3 +10,6 @@ OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE) 
 
 include ../Makefile.rules
+
+run:
+	LIBOMPTARGET_KERNEL_TRACE=1 ./$(TESTNAME) 2>&1 | grep -q  SGN:1


### PR DESCRIPTION
Flang should generate generic (SGN:1) kernel for this test case.

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>