### PR TITLE
Add -O2 to flang-teams-gdb

### DIFF
--- a/test/smoke/flang-teams-gdb/Makefile
+++ b/test/smoke/flang-teams-gdb/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = flang-teams1.f90
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS      = -ggdb
+CFLAGS      = -ggdb -O2
 
 FLANG        = flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)


### PR DESCRIPTION
Without -O2 flag we cannot compile test case. The compilation error
is presented below:

error: flang-teams1.f90:8:1: in function __nv_MAIN__TARGET_F1L7_1_ void
(i64*, i64*): unsupported call to variadic function omp_get_num_teams

Signed-off-by: Dominik Adamski <Dominik.Adamski@amd.com>