### PR TITLE
Correct readlink in build scripts.

### DIFF
--- a/bin/build-deb-aomp.sh
+++ b/bin/build-deb-aomp.sh
@@ -8,30 +8,13 @@
 #                      You must also have sudo access to build the debs.
 #                      You will be prompted for your password for sudo. 
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
-# --- End standard header ----
+# --- end standard header ----
+
 . /etc/lsb-release
 RELSTRING=`echo $DISTRIB_ID$DISTRIB_RELEASE | tr -d "."`
 echo RELSTRING=$RELSTRING

--- a/bin/build-deb-aomp.sh
+++ b/bin/build-deb-aomp.sh
@@ -29,7 +29,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- End standard header ----
 . /etc/lsb-release

--- a/bin/build-rpm.sh
+++ b/bin/build-rpm.sh
@@ -2,29 +2,12 @@
 #
 #  build-rpm.sh: Build the rpm for SLES15 SP1 or RHEL 7
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
+# --- end standard header ----
 
 osname=$(cat /etc/os-release | grep -e ^NAME=)
 rpmname="Not_Found"

--- a/bin/build-rpm.sh
+++ b/bin/build-rpm.sh
@@ -23,7 +23,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 
 osname=$(cat /etc/os-release | grep -e ^NAME=)

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -23,7 +23,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -2,28 +2,10 @@
 # 
 #   build_aomp.sh : Build all AOMP components 
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_comgr.sh
+++ b/bin/build_comgr.sh
@@ -2,28 +2,12 @@
 #
 #  build_comgr.sh:  Script to build the code object manager for aomp
 #
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
+# --- end standard header ----
 
 INSTALL_COMGR=${INSTALL_COMGR:-$AOMP_INSTALL_DIR}
 

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -32,28 +32,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -53,7 +53,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_fixups.sh
+++ b/bin/build_fixups.sh
@@ -27,7 +27,7 @@ thisdir=$(getdname $0)
 if [[ "$AOMP_STANDALONE_BUILD" == 0 ]] ; then
   . $AOMP_REPOS/aomp/bin/aomp_common_vars
 else
-  [ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+  [ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
   . $thisdir/aomp_common_vars
 fi
 # --- end standard header ----

--- a/bin/build_fixups.sh
+++ b/bin/build_fixups.sh
@@ -3,33 +3,11 @@
 #   build_fixups.sh : make some fixes to the installation.
 #                     We eventually need to remove this hack.
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-if [[ "$AOMP_STANDALONE_BUILD" == 0 ]] ; then
-  . $AOMP_REPOS/aomp/bin/aomp_common_vars
-else
-  [ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
-  . $thisdir/aomp_common_vars
-fi
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
+. $thisdir/aomp_common_vars
 # --- end standard header ----
 
 # Copy examples 

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -5,27 +5,9 @@
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_flang_runtime.sh
+++ b/bin/build_flang_runtime.sh
@@ -5,27 +5,9 @@
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipamd.sh
+++ b/bin/build_hipamd.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipamd.sh
+++ b/bin/build_hipamd.sh
@@ -27,29 +27,9 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipfort.sh
+++ b/bin/build_hipfort.sh
@@ -48,7 +48,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipfort.sh
+++ b/bin/build_hipfort.sh
@@ -27,28 +27,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipvdi.sh
+++ b/bin/build_hipvdi.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_hipvdi.sh
+++ b/bin/build_hipvdi.sh
@@ -28,28 +28,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_libdevice.sh
+++ b/bin/build_libdevice.sh
@@ -3,28 +3,10 @@
 #  File: build_libdevice.sh
 #        build the rocm-device-libs libraries in $AOMP/lib/libdevice
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_libdevice.sh
+++ b/bin/build_libdevice.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_ocl.sh
+++ b/bin/build_ocl.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_ocl.sh
+++ b/bin/build_ocl.sh
@@ -28,28 +28,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -3,29 +3,10 @@
 #  build_openmp.sh:  Script to build the AOMP runtime libraries and debug libraries.  
 #                This script will install in location defined by AOMP env variable
 #
-# --- Start standard header ----
 
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -25,7 +25,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_pgmath.sh
+++ b/bin/build_pgmath.sh
@@ -5,27 +5,9 @@
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -10,27 +10,9 @@
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_qmcpack.sh
+++ b/bin/build_qmcpack.sh
@@ -15,30 +15,13 @@
 #  make all
 #  make install
 #
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 AOMP=${AOMP:-~/usr/lib/aomp}
 ROCM_VER=${ROCM_VER:-rocm-alt}
 

--- a/bin/build_qmcpack.sh
+++ b/bin/build_qmcpack.sh
@@ -36,7 +36,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 AOMP=${AOMP:-~/usr/lib/aomp}

--- a/bin/build_rocdbgapi.sh
+++ b/bin/build_rocdbgapi.sh
@@ -2,28 +2,10 @@
 #
 #  build_rocdbgapi.sh:  Script to build ROCdbgapi for AOMP standalone build
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocgdb.sh
+++ b/bin/build_rocgdb.sh
@@ -5,28 +5,10 @@
 #                 AOMP_STANDALONE_BUILD=1 && AOMP_BUILD_DEBUG==1
 #                 This depends on rocdbgapi to be built and installed.
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocm-cmake.sh
+++ b/bin/build_rocm-cmake.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocm-cmake.sh
+++ b/bin/build_rocm-cmake.sh
@@ -28,28 +28,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocminfo.sh
+++ b/bin/build_rocminfo.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocminfo.sh
+++ b/bin/build_rocminfo.sh
@@ -28,28 +28,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocprofiler.sh
+++ b/bin/build_rocprofiler.sh
@@ -2,28 +2,10 @@
 #
 #  build_rocprofiler.sh:  Script to build rocprofiler for AOMP standalone build
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_rocr.sh
+++ b/bin/build_rocr.sh
@@ -4,28 +4,10 @@
 #                  aomp compiler installation
 #                  Requires that "build_roct.sh install" be installed first
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_roct.sh
+++ b/bin/build_roct.sh
@@ -2,28 +2,12 @@
 #
 #  build_roct.sh:  Script to build the ROCt thunk libraries.
 #
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
+# --- end standard header ----
 
 INSTALL_ROCT=${INSTALL_ROCT:-$AOMP_INSTALL_DIR}
 

--- a/bin/build_roctracer.sh
+++ b/bin/build_roctracer.sh
@@ -2,28 +2,10 @@
 #
 #  build_roctracer.sh:  Script to build roctracer for AOMP standalone build
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
 
-thisdir=$(getdname $0)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -37,27 +37,8 @@ SUPPLEMENTAL_COMPONENTS="openmpi silo hdf5 fftw"
 PREREQUISITE_COMPONENTS="cmake rocmsmilib hwloc"
 
 # --- Start standard header to set AOMP environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -57,7 +57,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_vdi.sh
+++ b/bin/build_vdi.sh
@@ -49,7 +49,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/build_vdi.sh
+++ b/bin/build_vdi.sh
@@ -28,28 +28,9 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/clone_aomp.sh
+++ b/bin/clone_aomp.sh
@@ -3,28 +3,10 @@
 #  clone_aomp.sh:  Clone the repositories needed to build the aomp compiler.  
 #                  Currently AOMP needs 14 repositories.
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/clone_aomp.sh
+++ b/bin/clone_aomp.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/clone_epsdb_test.sh
+++ b/bin/clone_epsdb_test.sh
@@ -3,28 +3,10 @@
 #  clone_aomp.sh:  Clone the repositories needed to build the aomp compiler.  
 #                  Currently AOMP needs 14 repositories.
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/clone_epsdb_test.sh
+++ b/bin/clone_epsdb_test.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/clone_test.sh
+++ b/bin/clone_test.sh
@@ -3,31 +3,12 @@
 #  list_test_repos.sh: Compare the repos in $AOMP_REPOS_TEST
 #                      with the manifest for the test repos.
 #
-# --- Start standard header ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
-
 
 function list_repo_from_manifest(){
    logcommit=`git log -1 | grep "^commit" | cut -d" " -f2 | xargs`

--- a/bin/clone_test.sh
+++ b/bin/clone_test.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/create_release_tarball.sh
+++ b/bin/create_release_tarball.sh
@@ -26,7 +26,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/create_release_tarball.sh
+++ b/bin/create_release_tarball.sh
@@ -5,28 +5,10 @@
 #  This is how we create the release source tarball.  Only run this after a successful build
 #  so that this captures patched files because the root Makefile turns off patching
 #
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_RSBench.sh
+++ b/bin/run_RSBench.sh
@@ -3,30 +3,12 @@
 # run_RSBench.sh - runs RSBench in the $AOMP_REPOS_TEST dir.
 # User can set RUN_OPTIONS to control what variants(openmp, hip) are selected.
 
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}

--- a/bin/run_RSBench.sh
+++ b/bin/run_RSBench.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_XSBench.sh
+++ b/bin/run_XSBench.sh
@@ -3,30 +3,12 @@
 # run_XSBench.sh - runs XSBench in the $AOMP_REPOS_TEST dir.
 # User can set RUN_OPTIONS to control what variants(openmp, hip) are selected.
 
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}

--- a/bin/run_XSBench.sh
+++ b/bin/run_XSBench.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_babelstream.sh
+++ b/bin/run_babelstream.sh
@@ -6,30 +6,12 @@
 # The babelstream source OMPStream.cpp is patched to override number of teams
 # and threads.
 
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}

--- a/bin/run_babelstream.sh
+++ b/bin/run_babelstream.sh
@@ -27,7 +27,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -23,7 +23,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -2,28 +2,10 @@
 # 
 #  run_nekbone.sh: 
 #
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_gests.sh
+++ b/bin/run_gests.sh
@@ -23,7 +23,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_gests.sh
+++ b/bin/run_gests.sh
@@ -2,31 +2,12 @@
 # 
 #  run_nekbone.sh: 
 #
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
-
 
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -23,7 +23,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -2,28 +2,10 @@
 # 
 #  run_nekbone.sh: 
 #
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_omptests.sh
+++ b/bin/run_omptests.sh
@@ -1,26 +1,8 @@
 #!/bin/bash
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_omptests.sh
+++ b/bin/run_omptests.sh
@@ -20,7 +20,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_openlibm_test.sh
+++ b/bin/run_openlibm_test.sh
@@ -1,26 +1,8 @@
 #!/bin/bash
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_openlibm_test.sh
+++ b/bin/run_openlibm_test.sh
@@ -20,7 +20,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_ovo.sh
+++ b/bin/run_ovo.sh
@@ -20,7 +20,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_ovo.sh
+++ b/bin/run_ovo.sh
@@ -1,28 +1,11 @@
 #!/bin/bash
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 

--- a/bin/run_rajaperf.sh
+++ b/bin/run_rajaperf.sh
@@ -20,7 +20,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 
 function usage(){

--- a/bin/run_rajaperf.sh
+++ b/bin/run_rajaperf.sh
@@ -1,27 +1,10 @@
 #!/bin/bash
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
+# --- end standard header ----
 
 function usage(){
   echo ""

--- a/bin/run_rushlarsen.sh
+++ b/bin/run_rushlarsen.sh
@@ -3,30 +3,12 @@
 # run_rushlarsen.sh - runs rush_larsen microbenchmarks in the $AOMP_REPOS_TEST dir.
 # User can set RUN_OPTIONS to control what variants(openmp, hip) are selected.
 
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}

--- a/bin/run_rushlarsen.sh
+++ b/bin/run_rushlarsen.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -2,33 +2,15 @@
 # 
 #  run_sollve.sh: 
 #
-# --- Start standard header to set build environment variables ----
 
 ulimit -t 120
 
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 single_case=$1
 if [ $single_case ] ;then
   # escape periods for grep command

--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -26,7 +26,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 single_case=$1

--- a/bin/run_su3bench.sh
+++ b/bin/run_su3bench.sh
@@ -24,7 +24,7 @@ function getdname(){
    echo $__DIRN
 }
 thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink "$0"`)
+[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 # Setup AOMP variables

--- a/bin/run_su3bench.sh
+++ b/bin/run_su3bench.sh
@@ -3,30 +3,12 @@
 # run_SU3Bench.sh - runs SU3Bench in the $AOMP_REPOS_TEST dir.
 # User can set RUN_OPTIONS to control what variants(openmp, hip) are selected.
 
-# --- Start standard header to set build environment variables ----
-function getdname(){
-   local __DIRN=`dirname "$1"`
-   if [ "$__DIRN" = "." ] ; then
-      __DIRN=$PWD;
-   else
-      if [ ${__DIRN:0:1} != "/" ] ; then
-         if [ ${__DIRN:0:2} == ".." ] ; then
-               __DIRN=`dirname $PWD`/${__DIRN:3}
-         else
-            if [ ${__DIRN:0:1} = "." ] ; then
-               __DIRN=$PWD/${__DIRN:2}
-            else
-               __DIRN=$PWD/$__DIRN
-            fi
-         fi
-      fi
-   fi
-   echo $__DIRN
-}
-thisdir=$(getdname $0)
-[ ! -L "$0" ] || thisdir=$(getdname `readlink -f "$0"`)
+# --- Start standard header to set AOMP environment variables ----
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
+
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}


### PR DESCRIPTION
This was exposed by executing build_prereq.sh from a directory
other than aomp/bin. Since build_prereq.sh is a symbolic
link, readlink only returned the script name the link
pointed to with no path. getdname would then return empty.
Using the -f option allows readlink to return the full path
and allows getdname to return the proper directory.