### PR TITLE
[smoke] - parallel check_smoke.sh with other test enhancements.

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -45,6 +45,8 @@ verify-log: run
 	$(CC) verify_output.c -o verify_output
 	path=`pwd`; \
 	base=`basename $$path`; \
+	( \
+	flock -e 9 && echo  "" >> ../check-smoke.txt; \
 	if   (./verify_output); then \
 		echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		echo  "" >> ../check-smoke.txt; \
@@ -52,19 +54,23 @@ verify-log: run
 	else  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		echo  "" >> ../check-smoke.txt; \
 		echo $$base $$test_num  >> ../failing-tests.txt; \
-	fi
+	fi; \
+	)9>../lockfile;
 
 check: $(TESTNAME)
 	path=`pwd`; \
 	base=`basename $$path`; \
-	if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) ./$(TESTNAME) $(ARGS) > /dev/null 2>&1); then \
-		echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
-		echo  "" >> ../check-smoke.txt; \
-		echo $$base $$test_num  >> ../passing-tests.txt; \
-	else	echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
-		echo  "" >> ../check-smoke.txt; \
-		echo $$base $$test_num  >> ../failing-tests.txt; \
-	fi
+	( \
+	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
+	  if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) ./$(TESTNAME) $(ARGS) > /dev/null 2>&1); then \
+		  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
+		  echo  "" >> ../check-smoke.txt; \
+		  echo $$base $$test_num  >> ../passing-tests.txt; \
+	  else	echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
+		  echo  "" >> ../check-smoke.txt; \
+		  echo $$base $$test_num  >> ../failing-tests.txt; \
+	  fi; \
+	)9>../lockfile;
 
 
 # ----- Demo compile and link to object file

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -12,11 +12,11 @@ BLU="\033[0;34m"
 ORG="\033[0;33m"
 BLK="\033[0m"
 
-# limit any step to 6 minutes
+# Limit any step to 6 minutes
 ulimit -t 150
 
 function gatherdata(){
-  #Replace false positive return codes with 'Check the run.log' so that user knows to visually inspect those.
+  # Replace false positive return codes with 'Check the run.log' so that user knows to visually inspect those.
   echo ""
   if [ -e check-smoke.txt ]; then
     sed -i '/devices/ {s/0/Check the run.log above/}; /stream/ {s/0/Check the run.log above/}' check-smoke.txt
@@ -27,7 +27,7 @@ function gatherdata(){
   fi
   echo ""
 
-  #Gather Test Data
+  # Gather Test Data
   passing_tests=0
   if [ -e passing-tests.txt ]; then
     ((passing_tests=$(wc -l <  passing-tests.txt)))
@@ -40,14 +40,14 @@ function gatherdata(){
     ((total_tests+=$(wc -l <  failing-tests.txt)))
   fi
 
-  #Print Results
+  # Print Results
   echo -e "$BLU"-------------------- Results --------------------"$BLK"
   echo -e "$BLU"Number of tests: $total_tests"$BLK"
   echo ""
   echo -e "$GRN"Passing tests: $passing_tests/$total_tests"$BLK"
   echo ""
 
-  #Print failed tests
+  # Print failed tests
   echo -e "$RED"
   if [ "$SKIP_FAILS" != 1 ] && [ "$known_fails" != "" ] ; then
     echo "Known failures: $known_fails"
@@ -67,7 +67,7 @@ function gatherdata(){
   fi
   echo -e "$BLK"
 
-  #Tests that need visual inspection
+  # Tests that need visual inspection
   echo ""
   echo -e "$ORG"
   echo "---------- Please inspect the output above to verify the following tests ----------"
@@ -91,7 +91,7 @@ script_dir=$(dirname "$0")
 pushd $script_dir
 path=$(pwd)
 
-#Clean all testing directories, except in parallel build
+# Clean all testing directories, except in parallel build
 if [ "$AOMP_PARALLEL_SMOKE" != 1 ]; then
   make clean
 fi
@@ -140,6 +140,7 @@ if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
   AOMP_JOB_THREADS=${AOMP_JOB_THREADS:-$COMP_THREADS}
   if [ $AOMP_JOB_THREADS -gt 16 ]; then
     AOMP_JOB_THREADS=16
+    echo "Limiting job threads to $AOMP_JOB_THREADS."
   fi
   echo THREADS: $AOMP_JOB_THREADS
 
@@ -202,12 +203,12 @@ exit
 fi
 # ---------- End parallel logic ----------
 
-#Loop over all directories and make run / make check depending on directory name
+# Loop over all directories and make run / make check depending on directory name
 for directory in ./*/; do
   pushd $directory > /dev/null
   path=$(pwd)
   base=$(basename $path)
-  #Skip tests that are known failures
+  # Skip tests that are known failures
   skip=0
   for test in $skip_tests ; do
     if [ $test == $base ] ; then
@@ -247,7 +248,7 @@ for directory in ./*/; do
     make verify-log
   else
     make check > /dev/null 2>&1
-    #liba_bundled has an additional Makefile, that may fail on the make check
+    # liba_bundled has an additional Makefile, that may fail on the make check
     if [ $? -ne 0 ] && ( [ $base == 'liba_bundled' ] || [ $base == 'liba_bundled_cmdline' ] ) ; then
       echo "$base: Make Failed" >> ../make-fail.txt
     fi
@@ -256,7 +257,7 @@ for directory in ./*/; do
   popd > /dev/null
 done
 
-#Print run.log for all tests that need visual inspection
+# Print run.log for all tests that need visual inspection
 for directory in ./*/; do
   pushd $directory > /dev/null
   path=$(pwd)
@@ -311,7 +312,7 @@ if [ "$EPSDB" == 1 ] ; then
   fi
 fi
 
-#Clean up, hide output
+# Clean up, hide output
 if [ "$EPSDB" != 1 ] && [ "$CLEANUP" != 0 ]; then
   cleanup
 fi

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Checks all tests in smoke directory using make check. Programs return 0 for success or a number > 0 for failure.
-# Tests that need to be visually inspected: devices, pfspecify, pfspecify_str, stream
+# Tests that need to be visually inspected: devices, stream
 #
 #
 
@@ -16,6 +16,17 @@ BLK="\033[0m"
 ulimit -t 150
 
 function gatherdata(){
+  #Replace false positive return codes with 'Check the run.log' so that user knows to visually inspect those.
+  echo ""
+  if [ -e check-smoke.txt ]; then
+    sed -i '/devices/ {s/0/Check the run.log above/}; /stream/ {s/0/Check the run.log above/}' check-smoke.txt
+    cat check-smoke.txt
+  fi
+  if [ -e make-fail.txt ]; then
+    cat make-fail.txt
+  fi
+  echo ""
+
   #Gather Test Data
   passing_tests=0
   if [ -e passing-tests.txt ]; then
@@ -60,10 +71,7 @@ function gatherdata(){
   echo ""
   echo -e "$ORG"
   echo "---------- Please inspect the output above to verify the following tests ----------"
-  echo "devices"
-  echo "pfspecifier"
-  echo "pfspecifier_str"
-  echo "stream"
+  echo "devices, stream"
   echo -e "$BLK"
 }
 
@@ -83,9 +91,11 @@ script_dir=$(dirname "$0")
 pushd $script_dir
 path=$(pwd)
 
-#Clean all testing directories
+#Clean all testing directories, except in parallel build
+if [ "$AOMP_PARALLEL_SMOKE" != 1 ]; then
   make clean
-  cleanup
+fi
+cleanup
 
 export OMP_TARGET_OFFLOAD=${OMP_TARGET_OFFLOAD:-MANDATORY}
 echo OMP_TARGET_OFFLOAD=$OMP_TARGET_OFFLOAD
@@ -96,11 +106,13 @@ echo ""
 
 echo "************************************************************************************" > check-smoke.txt
 echo "                   A non-zero exit code means a failure occured." >> check-smoke.txt
-echo "Tests that need to be visually inspected: devices, pfspecify, pfspecify_str, stream" >> check-smoke.txt
+echo "Tests that need to be visually inspected: devices, stream" >> check-smoke.txt
 echo "***********************************************************************************" >> check-smoke.txt
 
 known_fails=""
 skip_tests=""
+newest_rocm=$(ls /opt | grep -e "rocm-[0-9].[0-9].[0-9]" | tail -1)
+AOMPROCM=${AOMPROCM:-/opt/"$newest_rocm"}
 
 if [ "$SKIP_FAILURES" == 1 ] ; then
   skip_tests=$known_fails
@@ -111,6 +123,84 @@ if [ "$SKIP_FORTRAN" == 1 ] ; then
   skip_tests+="`find .  -iname '*.f9[50]' | sed s^./^^ | awk -F/ '{print $1}'` "
   echo $skip_tests
 fi
+
+# ---------- Begin parallel logic ----------
+if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
+  COMP_THREADS=1
+  MAX_THREADS=16
+  if [ ! -z `which "getconf"` ]; then
+     COMP_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
+     if [ "$AOMP_PROC" == "ppc64le" ] ; then
+        COMP_THREADS=$(( COMP_THREADS / 6))
+     fi
+     if [ "$AOMP_PROC" == "aarch64" ] ; then
+        COMP_THREADS=$(( COMP_THREADS / 4))
+     fi
+  fi
+  AOMP_JOB_THREADS=${AOMP_JOB_THREADS:-$COMP_THREADS}
+  if [ $AOMP_JOB_THREADS -gt 16 ]; then
+    AOMP_JOB_THREADS=16
+  fi
+  echo THREADS: $AOMP_JOB_THREADS
+
+  # Parallel Make
+  for directory in ./*/; do
+    pushd $directory > /dev/null
+    base=$(basename `pwd`)
+    echo Make: $base
+    if [ $base == "gpus" ]; then # Compile and link only test
+      make clean > /dev/null
+      make &> make-log.txt
+      if [ $? -ne 0 ]; then
+        flock -e lockfile -c "echo $base: Make Failed >> ../make-fail.txt"
+      else
+        flock -e lockfile -c "echo $base  >> ../passing-tests.txt"
+      fi
+    else
+      sem --jobs $AOMP_JOB_THREADS  --id def_sem -u 'base=$(basename $(pwd)); make clean > /dev/null; make &> make-log.txt; if [ $? -ne 0 ]; then flock -e lockfile -c "echo $base: Make Failed >> ../make-fail.txt"; fi;'
+    fi
+    popd > /dev/null
+  done
+
+  # Wait for jobs to finish before execution
+  sem --wait --id def_sem
+
+  # Parallel execution, currently limited to 4 jobs
+  for directory in ./*/; do
+    pushd $directory > /dev/null
+    base=$(basename `pwd`)
+    echo RUN $base
+    if [ $base == 'hip_rocblas' ] ; then
+      ls $AOMPROCM/rocblas > /dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        echo -e "$RED"$base - needs rocblas installed at $AOMPROCM/rocblas:"$BLK"
+        echo -e "$RED"$base - ROCBLAS NOT FOUND!!! SKIPPING TEST!"$BLK"
+        popd > /dev/nul -cl
+        continue
+      fi
+    elif [ $base == 'devices' ] || [ $base == 'stream' ] ; then
+      sem --jobs 4 --id def_sem -u 'make run > /dev/null 2>&1'
+      sem --jobs 4 --id def_sem -u 'make check > /dev/null 2>&1'
+    elif [ $base == 'printf_parallel_for_target' ] || [ $base == 'omp_places' ] || [ $base == 'pfspecifier' ] || [ $base == 'pfspecifier_str' ] ; then
+      sem --jobs 4 --id def_sem -u 'make verify-log > /dev/null'
+    elif [ $base == 'flags' ] ; then
+      make run
+    elif [ $base == 'liba_bundled' ] || [ $base == 'liba_bundled_cmdline' ]; then
+      sem --jobs 4 --id def_sem -u 'base=$(basename $(pwd)); make check > /dev/null; if [ $? -ne 0 ]; then flock -e lockfile -c "echo $base: Make Failed >> ../make-fail.txt"; fi;'
+    elif [ $base == "gpus" ]; then # Compile and link only test
+      echo gpus is compile only!
+    else
+      sem --jobs 4 --id def_sem -u 'make check > /dev/null 2>&1'
+    fi
+    popd > /dev/null
+done
+
+# Wait for jobs to finish executing
+sem --wait --id def_sem
+gatherdata
+exit
+fi
+# ---------- End parallel logic ----------
 
 #Loop over all directories and make run / make check depending on directory name
 for directory in ./*/; do
@@ -131,8 +221,6 @@ for directory in ./*/; do
     popd > /dev/null
     continue
   fi
-  newest_rocm=$(ls /opt | grep -e "rocm-[0-9].[0-9].[0-9]" | tail -1)
-  AOMPROCM=${AOMPROCM:-/opt/"$newest_rocm"}
   if [ $base == 'hip_rocblas' ] ; then
     ls $AOMPROCM/rocblas > /dev/null 2>&1
     if [ $? -ne 0 ]; then
@@ -142,32 +230,23 @@ for directory in ./*/; do
       continue
     fi
   fi
-  if [ $base == 'devices' ] || [ $base == 'pfspecifier' ] || [ $base == 'pfspecifier_str' ] || [ $base == 'stream' ] ; then
-    make
-    if [ $? -ne 0 ]; then
-      echo "$base: Make Failed" >> ../make-fail.txt
-    fi
+  make
+  if [ $? -ne 0 ]; then
+    echo "$base: Make Failed" >> ../make-fail.txt
+    popd > /dev/null
+    continue
+  fi
+  if [ $base == 'devices' ] || [ $base == 'stream' ] ; then
     make run > /dev/null 2>&1
     make check > /dev/null 2>&1
-
-  #flags has multiple runs
-  elif [ $base == 'flags' ] ; then
-    make
+  elif [ $base == 'flags' ] ; then # Flags has multiple runs
     make run > /dev/null 2>&1
-  elif [ $base == 'printf_parallel_for_target' ] || [ $base == 'omp_places' ] ; then
+  elif [ $base == "gpus" ]; then # Compile and link only test
+    echo "$base" >> ../passing-tests.txt
+  elif [ $base == 'printf_parallel_for_target' ] || [ $base == 'omp_places' ] || [ $base == 'pfspecifier' ] || [ $base == 'pfspecifier_str' ] ; then
     make verify-log
   else
-    make
-    if [ $? -ne 0 ]; then
-      echo "$base: Make Failed" >> ../make-fail.txt
-      popd > /dev/null
-      continue
-    fi
-    if [ $base == "gpus" ]; then # Compile and link only test
-      echo "$base" >> ../passing-tests.txt
-    else
-      make check > /dev/null 2>&1
-    fi
+    make check > /dev/null 2>&1
     #liba_bundled has an additional Makefile, that may fail on the make check
     if [ $? -ne 0 ] && ( [ $base == 'liba_bundled' ] || [ $base == 'liba_bundled_cmdline' ] ) ; then
       echo "$base: Make Failed" >> ../make-fail.txt
@@ -182,7 +261,7 @@ for directory in ./*/; do
   pushd $directory > /dev/null
   path=$(pwd)
   base=$(basename $path)
-  if [ $base == 'devices' ] || [ $base == 'pfspecifier' ] || [ $base == 'pfspecifier_str' ] || [ $base == 'stream' ] ; then
+  if [ $base == 'devices' ] || [ $base == 'stream' ] ; then
     echo ""
     echo -e "$ORG"$base - Run Log:"$BLK"
     echo "--------------------------"
@@ -195,16 +274,6 @@ for directory in ./*/; do
   popd > /dev/null
 done
 
-#Replace false positive return codes with 'Check the run.log' so that user knows to visually inspect those.
-sed -i '/pfspecifier/ {s/0/Check the run.log above/}; /devices/ {s/0/Check the run.log above/}; /stream/ {s/0/Check the run.log above/}' check-smoke.txt
-echo ""
-if [ -e check-smoke.txt ]; then
-  cat check-smoke.txt
-fi
-if [ -e make-fail.txt ]; then
-  cat make-fail.txt
-fi
-echo ""
 
 gatherdata
 

--- a/test/smoke/flags/Makefile
+++ b/test/smoke/flags/Makefile
@@ -33,6 +33,8 @@ run:
 check: compile
 	@path=`pwd`; \
 	base=`basename $$path`; \
+	( \
+	flock -e 9 && echo  "" >> ../check-smoke.txt; \
 	if   (./$(TESTNAME)); then \
 		echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		echo "" >> ../check-smoke.txt; \
@@ -40,7 +42,8 @@ check: compile
 	else  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		echo "" >> ../check-smoke.txt; \
 		echo $$base $$test_num  >> ../failing-tests.txt; \
-	fi
+	fi; \
+	)9>../lockfile;
 
 clean::
 	rm -f $(TESTNAME) $(TESTNAME).a llbin sbin obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log

--- a/test/smoke/liba_bundled/MyDeviceLib/Makefile
+++ b/test/smoke/liba_bundled/MyDeviceLib/Makefile
@@ -25,7 +25,7 @@ else
   ARCH    = amdgcn
 endif
 
-TMPDIR   ?= ./build
+TMPDIR    = ./build
 CFLAGS  = -c $(AOMP_CPUTARGET) -fopenmp -fopenmp-targets=$(TRIPLE) \
             -Xopenmp-target=$(TRIPLE) \
             -march=$(AOMP_GPU) -O2

--- a/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
+++ b/test/smoke/liba_bundled_cmdline/MyDeviceLib/Makefile
@@ -26,7 +26,7 @@ else
   ARCH    = amdgcn
 endif
 
-TMPDIR   ?= ./build
+TMPDIR    = ./build
 UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 CFLAGS  = -c -target $(HOST_TARGET) -fopenmp -fopenmp-targets=$(TRIPLE) \

--- a/test/smoke/liba_bundled_cmdline/MyHostLib/Makefile
+++ b/test/smoke/liba_bundled_cmdline/MyHostLib/Makefile
@@ -18,7 +18,7 @@ LIBSRC1   = hfunc1
 LIBSRC2   = hfunc2
 LIBSRC3   = hfunc3
 
-TMPDIR   ?= ./build
+TMPDIR    = ./build
 UNAMEP    = $(shell uname -m)
 HOST_TARGET = $(UNAMEP)-pc-linux-gnu
 CFLAGS  = -c -target $(HOST_TARGET) -O2

--- a/test/smoke/pfspecifier/expected.txt
+++ b/test/smoke/pfspecifier/expected.txt
@@ -1,0 +1,18 @@
+Signed: 392
+Unsigned: 7235
+Unsigned: 610
+Unsigned: 7fa
+Unsigned: 7FA
+floating point: 392.650000
+floating point: 392.650000
+S notation point: 3.926500e+02
+S notation point: 3.926500E+02
+floating point: 392.65
+floating point: 392.65
+Hexadecimal: 0x1.88a6666666666p+8
+Hexadecimal: 0X1.88A6666666666P+8
+Characters: A
+Pointer: 0x1000000000040
+Signed: 392
+Only percent sign %
+No specifier!

--- a/test/smoke/pfspecifier/verify_output.c
+++ b/test/smoke/pfspecifier/verify_output.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(){
+  int errors = system("diff expected.txt run.log");
+  if (errors){
+    printf("\nFail! Run.log does not match expected output.\n");
+    return 1;
+  }
+  printf("Passed!\n");
+  return 0;
+}

--- a/test/smoke/pfspecifier_str/expected.txt
+++ b/test/smoke/pfspecifier_str/expected.txt
@@ -1,0 +1,9 @@
+String on   host: 12345_ABCDEFGabcdegf?!
+String on device: 12345_ABCDEFGabcdegf?!
+String on device: 12345_ABCDEFGabcdegf?!
+String on device: 12345_ABCDEFGabcdegf?!
+String on device: 12345_ABCDEFGabcdegf?!
+String on device: 67890_XYZxyz?!
+String on device:         67890_XYZxyz?!
+Data   on device: 22 <<<        67890_XYZxyz?!>>> 22   22
+Data   on   host: 22 <<<        67890_XYZxyz?!>>> 22   22

--- a/test/smoke/pfspecifier_str/verify_output.c
+++ b/test/smoke/pfspecifier_str/verify_output.c
@@ -1,0 +1,12 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(){
+  int errors = system("diff expected.txt run.log");
+  if (errors){
+    printf("\nFail! Run.log does not match expected output.\n");
+    return 1;
+  }
+  printf("Passed!\n");
+  return 0;
+}


### PR DESCRIPTION
- AOMP_PARALLEL_SMOKE=1 will instead use sem/flock to compile
  and execute smoke tests in parallel. Currently, limited
  to 16 jobs when compiling and 4 when executing.
- Condensed if/else logic in check_smoke.sh sequential loop.
- Added verify step for pfspecifier and pfspecifier_str.
- Flags is a complex smoke test, which has it's own
  run script and Makefile. Makefile was updated to
  use flock to avoid race conditions.
- Fix TMPDIR in libbundled/liba_bundled_cmdline where
  'make clean' was trying to delete files in /tmp.