### PR TITLE
ROCm 5.3 package reorg. (#378)

### DIFF
--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -124,8 +124,8 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   -DDEVICELIBS_ROOT=$DEVICELIBS_ROOT \
   -DNEW_BC_PATH=1 \
   -DCMAKE_INSTALL_PREFIX=$INSTALL_EXTRAS \
-  -DCMAKE_PREFIX_PATH=$DEVICELIBS_BUILD_PATH;$OUT_DIR/build/devicelibs"
-
+  -DCMAKE_PREFIX_PATH=$DEVICELIBS_BUILD_PATH;$OUT_DIR/build/devicelibs \
+  -DENABLE_DEVEL_PACKAGE=ON"
   fi
 
   mkdir -p $BUILD_DIR/build/extras

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -62,6 +62,11 @@ MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
 -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON"
 
 
+if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
+  MYCMAKEOPTS="$MYCMAKEOPTS
+  -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
+fi
+
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
   help_build_aomp
 fi

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -155,7 +155,12 @@ if [ "$1" == "install" ] ; then
    fi
    echo "SUCCESSFUL INSTALL to $INSTALL_FLANG "
    echo
-   if [ -d $OUT_DIR/openmp-extras ]; then
+   if [ -d $OUT_DIR/openmp-extras/devel ]; then
+     echo "Add flang symbolic link."
+     echo "Copy flang, flang1, flang2 into $OUT_DIR/llvm/bin"
+     cp $OUT_DIR/openmp-extras/devel/bin/flang1 $OUT_DIR/llvm/bin
+     cp $OUT_DIR/openmp-extras/devel/bin/flang2 $OUT_DIR/llvm/bin
+   elif [-d $OUT_DIR/openmp-extras ]; then
      echo "Add flang symbolic link."
      echo "Copy flang, flang1, flang2 into $OUT_DIR/llvm/bin"
      cp $OUT_DIR/openmp-extras/bin/flang1 $OUT_DIR/llvm/bin

--- a/bin/build_flang_runtime.sh
+++ b/bin/build_flang_runtime.sh
@@ -71,6 +71,11 @@ MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
 -DOPENMP_BUILD_DIR=$OPENMP_BUILD_DIR \
 -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH"
 
+if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
+  MYCMAKEOPTS="$MYCMAKEOPTS
+  -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
+fi
+
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
   help_build_aomp
 fi

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -100,6 +100,10 @@ COMMON_CMAKE_OPTS="-DDEVICELIBS_ROOT=$DEVICELIBS_ROOT
 -DOPENMP_TEST_C_COMPILER=$OUT_DIR/llvm/bin/clang
 -DOPENMP_TEST_CXX_COMPILER=$OUT_DIR/llvm/bin/clang++"
 
+if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
+  COMMON_CMAKE_OPTS="$COMMON_CMAKE_OPTS -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
+fi
+
 if [ "$AOMP_BUILD_CUDA" == 1 ] ; then
    COMMON_CMAKE_OPTS="$COMMON_CMAKE_OPTS
 -DLIBOMPTARGET_NVPTX_ENABLE_BCLIB=ON
@@ -234,6 +238,11 @@ if [ "$1" == "install" ] ; then
          echo "ERROR make install failed "
          exit 1
       fi
+      if [[ "$DEVEL_PACKAGE" =~ "devel" ]]; then
+        AOMP_INSTALL_DIR="$AOMP_INSTALL_DIR/""$DEVEL_PACKAGE"
+        echo "Request for devel package found."
+      fi
+
       # Copy selected debugable runtime sources into the installation lib-debug/src directory
       # to satisfy the above -fdebug-prefix-map.
       $SUDO mkdir -p $AOMP_INSTALL_DIR/lib-debug/src/openmp/runtime/src

--- a/bin/build_pgmath.sh
+++ b/bin/build_pgmath.sh
@@ -59,6 +59,10 @@ else
     -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG"
 fi
 
+if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
+  MYCMAKEOPTS="$MYCMAKEOPTS
+  -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
+fi
 
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
   help_build_aomp


### PR DESCRIPTION
* ROCm 5.3 package reorg.

Split openmp package to runtime and devel

Change-Id: If6f263f38304866eabdfb7a5cd54059eac09008d

* Define runtime and development package for non-stand alone build

Changes based on review comments

Co-authored-by: Ethan Stewart <ethan.stewart@amd.com>