### PR TITLE
Add test for OMP_ALLOCATOR env variable.

### DIFF
--- a/test/smoke-fails/omp_allocator_env/Makefile
+++ b/test/smoke-fails/omp_allocator_env/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = omp_allocator_env
+TESTSRC_MAIN = omp_allocator_env.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+ALIGN_VAL    = 4096
+CLANG        = clang++ -DALIGN_VAL=$(ALIGN_VAL)
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+
+run:
+	OMP_ALLOCATOR=omp_default_mem_alloc:alignment=$(ALIGN_VAL) ./omp_allocator_env

--- a/test/smoke-fails/omp_allocator_env/omp_allocator_env.cpp
+++ b/test/smoke-fails/omp_allocator_env/omp_allocator_env.cpp
@@ -1,0 +1,22 @@
+#include<cstdio>
+#include<omp.h>
+
+#ifndef ALIGN_VAL
+#error must set ALIGN_VAL as compile time constant and default alignment value
+#endif
+
+int main() {
+  omp_allocator_handle_t default_alloc = omp_get_default_allocator();
+  if (default_alloc != omp_default_mem_alloc)
+    return 1;
+
+  int *p = (int *)omp_alloc(123456*sizeof(int));
+  // check if it is aligned to ALIGN_VAL
+  if (((uintptr_t)p) % ALIGN_VAL != 0) {
+    printf("Pointer not aligned to %d\n", ALIGN_VAL);
+    return 1;
+  }
+
+  printf("All good %p\n", p);
+  return 0;
+}


### PR DESCRIPTION
Any value of the env variable is discarded and the default memory allocator selected, with a warning at app launch time.
Selecting the default allocator with alignment trait gives same warning and does not respect requested alignment.