### PR TITLE
Update script for run_sollve to work for upstream OpenMP

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -487,6 +487,8 @@ function setaompgpu (){
     echo Set AOMP_GPU with mygpu.
     if [ -a $AOMP/bin/mygpu ]; then
       detected_gpu=$($AOMP/bin/mygpu)
+    elif [ -a $AOMP/bin/amdgpu-arch ]; then
+      detected_gpu=$($AOMP/bin/amdgpu-arch)
     else
       detected_gpu=$($AOMP/../bin/mygpu)
     fi


### PR DESCRIPTION
In case of upstream OpenMP, use `amdgpu-arch` if `mygpu` is not found to
detect the AOMP GPU.