### PR TITLE
Babelstream: add CCC_OVERRIDE_OPTIONS check for -DOMP_TARGET_FAST_DOT

### DIFF
--- a/bin/run_babelstream.sh
+++ b/bin/run_babelstream.sh
@@ -95,7 +95,14 @@ for option in $RUN_OPTIONS; do
   elif [ "$option" == "no_loop" ]; then
     # FAST_DOT requires merge of http://gerrit-git.amd.com/c/lightning/ec/llvm-project/+/705744
     $AOMP/bin/llvm-nm $AOMP/lib/libomptarget-new-amdgpu-gfx906.bc | grep kmpc_xteam_sum_d >/dev/null
-    [ $? == 0 ] && omp_flags+=" -DOMP_TARGET_FAST_DOT"
+    FAST_DOT_STATUS=$?
+    # Check if new runtime is disabled via CCC_OVERRIDE_OPTIONS
+    # Set new runtime status = 0 if new runtime has not been disabled
+    echo "Checking CCC_OVERRIDE_OPTIONS"
+    echo $CCC_OVERRIDE_OPTIONS | grep -ve '+-fno-openmp-target-new-runtime'
+    NEW_RT_STATUS=$?
+    FAST_DOT_STATUS=$((FAST_DOT_STATUS+NEW_RT_STATUS))
+    [ $FAST_DOT_STATUS == 0 ] && omp_flags+=" -DOMP_TARGET_FAST_DOT"
     omp_flags+=" -fopenmp-target-ignore-env-vars"
     omp_flags+=" -fopenmp-assume-no-thread-state"
     omp_flags+=" -fopenmp-target-new-runtime"


### PR DESCRIPTION
Check if new runtime is disabled via:
    CCC_OVERRIDE_OPTIONS='+-fno-openmp-target-new-runtime'

Don't set -DOMP_TARGET_FAST_DOT if new runtime is disabled.