### PR TITLE
[examples] Restore default optimization level for Fortran examples

### DIFF
--- a/examples/fortran/declare_target/Makefile
+++ b/examples/fortran/declare_target/Makefile
@@ -66,7 +66,7 @@ endif
 
 FORT   =$(AOMP)/bin/flang
 LFLAGS = 
-FFLAGS = -O2 -fopenmp -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET)
+FFLAGS = -fopenmp -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET)
 
 # ----- Demo compile and link in one step, no object code saved
 $(TESTNAME): $(TESTNAME).$(FILETYPE)

--- a/examples/fortran/simple_offload/Makefile
+++ b/examples/fortran/simple_offload/Makefile
@@ -66,7 +66,7 @@ endif
 
 FORT   =$(AOMP)/bin/flang
 LFLAGS = 
-FFLAGS = -O2 -fopenmp -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET)
+FFLAGS = -fopenmp -fopenmp-targets=$(AOMP_GPUTARGET) -Xopenmp-target=$(AOMP_GPUTARGET)
 
 # ----- Demo compile and link in one step, no object code saved
 $(TESTNAME): $(TESTNAME).$(FILETYPE)


### PR DESCRIPTION
Flang compiler was fixed and it is possible to compile and run Fortran examples with -O0 optimization level.

Signed-off-by: Dominik Adamski <dominik.adamski@amd.com>