### PR TITLE
[smoke] - Add ability to export TIMEOUT on a test by test basis.

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -1,5 +1,6 @@
 TESTNAMES_ALL = $(basename $(TESTSRC_ALL))
-SMOKE_TIMEOUT=timeout --foreground 60s
+TIMEOUT ?= 60s
+SMOKE_TIMEOUT ?= timeout --foreground $(TIMEOUT)
 
 all: $(TESTNAME)
 

--- a/test/smoke/d2h_slow_copy/Makefile
+++ b/test/smoke/d2h_slow_copy/Makefile
@@ -10,5 +10,6 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE) -lm -lstdc++
 #-ccc-print-phases
 #"-\#\#\#"
+export TIMEOUT = 120s
 
 include ../Makefile.rules

--- a/test/smoke/many_arrays/Makefile
+++ b/test/smoke/many_arrays/Makefile
@@ -11,6 +11,8 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
+export TIMEOUT = 120s
+
 include ../Makefile.rules
 
 run: $(TESTNAME)


### PR DESCRIPTION
Add 120s timeout to d2h_slow_copy and many_arrays.