### PR TITLE
[Smoke] Add tests for TargetID Support

### DIFF
--- a/test/smoke-fails/targetid/Makefile
+++ b/test/smoke-fails/targetid/Makefile
@@ -1,11 +1,11 @@
 include ../../Makefile.defs
 
-TESTNAME     = multi-image
-TESTSRC_MAIN = multi-image.c
+TESTNAME     = targetid
+TESTSRC_MAIN = targetid.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-OMP_FLAGS    = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$(AOMP_GPU) -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx803
+OMP_FLAGS    = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:sramecc-:xnack+
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
@@ -14,5 +14,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	./$(TESTNAME)
+	HSA_XNACK=1 ./$(TESTNAME)
+# 	will pass only on machines where xnack+ is configured
+
 	strings $(TESTNAME) |grep -i gfx

--- a/test/smoke-fails/targetid/targetid.c
+++ b/test/smoke-fails/targetid/targetid.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(void) {
+  int isHost = 1;
+
+#pragma omp target map(tofrom: isHost)
+  {
+    isHost = omp_is_initial_device();
+    printf("Hello world. %d\n", 100);
+    for (int i =0; i<5; i++) {
+      printf("Hello world. iteration %d\n", i);
+    }
+  }
+
+  printf("Target region executed on the %s\n", isHost ? "host" : "device");
+
+  return isHost;
+}
+

--- a/test/smoke-fails/targetid_multi_image/Makefile
+++ b/test/smoke-fails/targetid_multi_image/Makefile
@@ -1,0 +1,21 @@
+include ../../Makefile.defs
+
+TESTNAME     = targetid-multi-image
+TESTSRC_MAIN = targetid-multi-image.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+OMP_FLAGS    = -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack- -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a:xnack+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	HSA_XNACK=1 ./$(TESTNAME)
+# 	will pass only on machines where xnack+ is configured
+
+	HSA_XNACK=0 ./$(TESTNAME)
+	strings $(TESTNAME) |grep -i gfx

--- a/test/smoke-fails/targetid_multi_image/targetid-multi-image.c
+++ b/test/smoke-fails/targetid_multi_image/targetid-multi-image.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(void) {
+  int isHost = 1;
+
+#pragma omp target map(tofrom: isHost)
+  {
+    isHost = omp_is_initial_device();
+    printf("Hello world. %d\n", 100);
+    for (int i =0; i<5; i++) {
+      printf("Hello world. iteration %d\n", i);
+    }
+  }
+
+  printf("Target region executed on the %s\n", isHost ? "host" : "device");
+
+  return isHost;
+}
+


### PR DESCRIPTION
Tests for single arch as well as multi-arch compilation. They will work only on system which have been configured for xnack+.