### PR TITLE
[smoke] - make clean once inside individual test directory.

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -197,7 +197,7 @@ run_sbin: sbin
 
 # Cleanup anything this makefile can create
 clean::
-	rm -f $(TESTNAME) $(TESTNAME).a llbin sbin obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log *.mod verify_output *.stb *.ilm *.cmod *.cmdx $(TESTNAME)_og11
+	rm -f $(TESTNAME) $(TESTNAME).a llbin sbin obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log *.mod verify_output *.stb *.ilm *.cmod *.cmdx $(TESTNAME)_og11 make-log.txt
 
 clean_log:
 	rm -f *.log

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -206,12 +206,10 @@ if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
 fi
 # ---------- End parallel logic ----------
 
-# Clean all testing directories
-make clean
-
 # Loop over all directories and make run / make check depending on directory name
 for directory in ./*/; do
   pushd $directory > /dev/null
+  make clean
   path=$(pwd)
   base=$(basename $path)
   # Skip tests that are known failures


### PR DESCRIPTION
- This is to avoid not cleaning tests in smoke if they are not present in smoke/Makefile. This is already done in the smoke-fails directory.
- Add make-log.txt to clean rule.