### PR TITLE
Added/updated Xteam reduction tests for blocksizes, using threads

### DIFF
--- a/test/smoke-fails/xteam-red-cmdline-option1/Makefile
+++ b/test/smoke-fails/xteam-red-cmdline-option1/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = xteam_red_cmdline_option1
+TESTSRC_MAIN = xteam_red_cmdline_option1.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-target-xteam-reduction-blocksize=512
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/xteam-red-cmdline-option1/xteam_red_cmdline_option1.c
+++ b/test/smoke-fails/xteam-red-cmdline-option1/xteam_red_cmdline_option1.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 1000000;
+
+  double a[N];
+
+  for (int i=0; i<N; i++)
+    a[i]=i;
+
+  double sum1, sum2, sum3, sum4;
+  sum1 = sum2 = sum3 = sum4 = 0;
+  
+#pragma omp target teams distribute parallel for map(tofrom:sum1) reduction(+:sum1)
+  for (int j = 0; j< N; j=j+1)
+    sum1 += a[j];
+
+#pragma omp target teams distribute parallel for map(tofrom:sum2) reduction(+:sum2)
+  for (int j = 0; j< N; j=j+2)
+    sum2 += a[j];
+
+#pragma omp target teams distribute parallel for map(tofrom:sum3,sum4) reduction(+:sum3,sum4)
+  for (int j = 0; j< N; j=j+1) {
+    sum3 += a[j];
+    sum4 += a[j];
+  }
+  
+  printf("%f %f %f %f\n", sum1, sum2, sum3, sum4);
+  
+  int rc =
+    (sum1 != 499999500000) ||
+    (sum2 != 249999500000) ||
+    (sum3 != 499999500000) ||
+    (sum4 != 499999500000);
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 9 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
+

--- a/test/smoke-fails/xteam-red-threads/xteam_red_threads.c
+++ b/test/smoke-fails/xteam-red-threads/xteam_red_threads.c
@@ -110,16 +110,16 @@ int main()
 }
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:256  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:256  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:256  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 4 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:256  args: 6 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:256  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:512  args: 9 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 512)
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2 ConstWGSize:128  args: 5 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 128)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:256  args: 9 teamsXthrds:([[S:[ ]*]][[NUM_TEAMS:[0-9]+]]X 256)


### PR DESCRIPTION
Added/updated Xteam reduction tests for blocksizes, using threads clauses and the command line option -fopenmp-target-xteam-reduction-blocksize.