### PR TITLE
Fix smoke tests compiler flags to allow GPU override

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -157,7 +157,7 @@ ifeq ($(CBL),1)
 endif
 
 OMP_FLAGS += $(EXTRA_OMP_FLAGS)
-OMP_FLAGS += -D__OFFLOAD_ARCH_$(INSTALLED_GPU)__
+OMP_FLAGS += -D__OFFLOAD_ARCH_$(AOMP_GPU)__
 
 ifeq ($(VERBOSE),1)
   $(info    Compilation and linking VERBOSE Mode ON)

--- a/test/smoke/gpus/Makefile
+++ b/test/smoke/gpus/Makefile
@@ -14,7 +14,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 LOCAL_OMP_FLAGS1 = $(filter-out -march=$(AOMP_GPU), $(OMP_FLAGS))
-LOCAL_OMP_FLAGS = $(filter-out -D__OFFLOAD_ARCH_$(INSTALLED_GPU)__, $(LOCAL_OMP_FLAGS1))
+LOCAL_OMP_FLAGS = $(filter-out -D__OFFLOAD_ARCH_$(AOMP_GPU)__, $(LOCAL_OMP_FLAGS1))
 
 all: $(GFXLIST)
 


### PR DESCRIPTION
Without this change, executions of the `clang` command in smoke tests ignore the `AOMP_GPU` override while setting the `__OFFLOAD_ARCH_<arch>__` flag. This can produce problems on multi-GPU systems with different GPU architectures if `AOMP_GPU` and `ROCR_VISIBLE_DEVICES` are set to anything other than the default (first) GPU.