### PR TITLE
Fix OFFLOAD_ARCH_gfxABC in Makefile.defs.

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -43,27 +43,36 @@ ifeq (opt,$(findstring opt,$(AOMP)))
   INSTALLED_GPU  = $(shell $(AOMP)/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
   GFXLIST = $(shell ls $(AOMP)/lib | grep -oP 'amdgcn-\K\S+(?=.bc)')
 else
-   # Set GFXLIST from aomp_common_vars
-   GFXLIST = $(shell grep GFXLIST= ../../../bin/aomp_common_vars | grep -o "gfx.*" | sed -E "s|\"}||" | sed -E "s|gfx1010||")
+  # Set GFXLIST from aomp_common_vars
+  GFXLIST = $(shell grep GFXLIST= ../../../bin/aomp_common_vars | grep -o "gfx.*" | sed -E "s|\"}||" | sed -E "s|gfx1010||")
 
-   # If AOMP not pointing to rocm, then assume neither offload-arch nor mygpu utilities exist.
-   # So use lspci to search for volta and if not then use standalone rocm_agent_enumerator
-   # to autodetect which GPU is active.
-   ifneq ("$(wildcard /usr/sbin/lspci)","")
-     lspci_loc = /usr/sbin/lspci
-   else
-     lspci_loc = /usr/bin/lspci
-   endif
-   ISVOLTA = $(shell $(lspci_loc) -n | grep 10de:1db4)
-   ISGTX750= $(shell $(lspci_loc) -n | grep 10de:1380)
-   ifeq (10de,$(findstring 10de,$(ISVOLTA)))
-      INSTALLED_GPU = sm_70
-   else ifeq (10de,$(findstring 10de,$(ISGTX750)))
-      INSTALLED_GPU = sm_50
-   else
-      ifneq ($(CBL),1)
+  # If AOMP not pointing to rocm, then assume neither offload-arch nor mygpu utilities exist.
+  # So use lspci to search for volta and if not then use standalone rocm_agent_enumerator
+  # to autodetect which GPU is active.
+  ifneq ("$(wildcard /usr/sbin/lspci)","")
+    lspci_loc = /usr/sbin/lspci
+  else
+    lspci_loc = /usr/bin/lspci
+  endif
+  ISVOLTA = $(shell $(lspci_loc) -n | grep 10de:1db4)
+  ISGTX750= $(shell $(lspci_loc) -n | grep 10de:1380)
+  ifeq (10de,$(findstring 10de,$(ISVOLTA)))
+    INSTALLED_GPU = sm_70
+  else ifeq (10de,$(findstring 10de,$(ISGTX750)))
+    INSTALLED_GPU = sm_50
+  else
+    ifneq ($(CBL),1)
+      # Honor AOMP_GPU.
+      ifneq ("$(AOMP_GPU)","")
+        INSTALLED_GPU = $(shell echo $(AOMP_GPU))
+      # Honor ROCR_VISIBLE_DEVICES. Returns first GPU in list.
+      else ifneq ("$(ROCR_VISIBLE_DEVICES)","")
+        INSTALLED_GPU = $(shell $(AOMP)/bin/offload-arch -c | grep -oP gfx.+?\(?=:\))
+      # Default to rocm_agent_enumerator. Returns first GPU in list.
+      else
         INSTALLED_GPU = $(shell $(AOMP)/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
       endif
+    endif
   endif
 endif
 


### PR DESCRIPTION
This ensures the macro matches --offload-arch by honoring AOMP_GPU and ROCR_VISIBLE_DEVICES. The first visible GPU found when setting ROCR_VISIBLE_DEVICES will be used.

Spacing adjustments.