### PR TITLE
Fix script that runs sollve tests.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -425,6 +425,7 @@ function setaompgpu (){
       detected_gpu=$($AOMP/bin/mygpu)
     elif [ -a $AOMP/bin/amdgpu-arch ]; then
       detected_gpu=$($AOMP/bin/amdgpu-arch)
+      detected_gpu=$(echo $detected_gpu | awk '{print $1,$5}')
     else
       detected_gpu=$($AOMP/../bin/mygpu)
     fi

--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -123,7 +123,7 @@ else
      export MY_SOLLVE_FLAGS="$MY_SOLLVE_FLAGS -fopenmp-version=45"
   fi
   echo "       The full make command:"
-  echo " make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all"
+  echo " make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS=\"-lm $MY_SOLLVE_FLAGS\" CXXFLAGS=\"$MY_SOLLVE_FLAGS\" FFLAGS=\"$MY_SOLLVE_FLAGS\" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all"
 make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all
   rc=$?
   echo
@@ -135,7 +135,7 @@ make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY
      echo "       If compile worked, you may rerun the binary with this command:"
      echo " $AOMP_REPOS_TEST/$AOMP_SOLVV_REPO_NAME/bin/${single_case}.o"
   else
-     echo "       Expected binary $AOMP_REPOS_TEST/$AOMP_SOLVV_REPO_NAME/bin/${single_case}.o does NOT exists!"
+     echo "       Expected binary $AOMP_REPOS_TEST/$AOMP_SOLVV_REPO_NAME/bin/${single_case}.o does NOT exist!"
   fi
   echo
   popd


### PR DESCRIPTION
The script relies on another function to return a single value for the `-march` option. In the latest trunk this isn't true because the amdgpu-arch script now return a list of values one for each GPU:

```
$ ~/rocm/trunk_1.0/bin/amdgpu-arch
gfx90a
gfx90a
gfx90a
```

Whereas mygpu returns:

```
$ ~/rocm/aomp_16.0-OPTR4/bin/mygpu
gfx90a
```