### PR TITLE
[Smoke] Test case for SWDEV-373823 : [OpenMP] Possibly incorrect glob…

### DIFF
--- a/test/smoke-fails/clang-373823/Makefile
+++ b/test/smoke-fails/clang-373823/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = clang-373823
+TESTSRC_MAIN = clang-373823.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CFLAGS       += -fopenmp-target-ignore-env-vars
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run: $(TESTNAME)
+	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)

--- a/test/smoke-fails/clang-373823/clang-373823.c
+++ b/test/smoke-fails/clang-373823/clang-373823.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+
+// Check that function called from target region is set to "rpc:0"
+
+#define N 100
+void computeFoo(double *Ptr)
+{
+  int stack[N];
+  for(int i = 0; i < N;  i++) {
+    stack[i] = i;
+    // required to force rpc:1
+    Ptr[i] += 1;
+  }
+  // required to force rpc:1
+  Ptr[0] = stack[N-1] + 1.0;
+}
+
+int computeFindNeighbors()
+{
+  double a[N] = {0.0};
+  int j;
+
+  #pragma omp target teams distribute parallel for
+  for (j = 0; j< N; j++) {
+    computeFoo(a);
+  }
+
+  int fail = 0;
+  if (a[0] != 100.0) {
+    fail++;
+    printf ("Wrong value: a[%d]=%lf\n", 0, a[0]);
+  }
+
+  if (!fail)
+    printf("Success\n");
+  return fail;
+}
+
+int main() {
+  return computeFindNeighbors();
+}
+
+/// CHECK: rpc:0


### PR DESCRIPTION
…alization of local variable in device function

Check that rpc value is zero, not one, for function called from target region.