### PR TITLE
[Smoke] Add tests for code object version 5

### DIFF
--- a/test/smoke/helloworld_cov5/Makefile
+++ b/test/smoke/helloworld_cov5/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = helloworld_cov5
+TESTSRC_MAIN = helloworld_cov5.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) -mcode-object-version=5
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke/helloworld_cov5/helloworld_cov5.c
+++ b/test/smoke/helloworld_cov5/helloworld_cov5.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main(void) {
+  int isHost = 1;
+
+#pragma omp target map(tofrom: isHost)
+  {
+    isHost = omp_is_initial_device();
+    printf("Hello world. %d\n", 100);
+    for (int i =0; i<5; i++) {
+      printf("Hello world. iteration %d\n", i);
+    }
+  }
+
+  printf("Target region executed on the %s\n", isHost ? "host" : "device");
+
+  return isHost;
+}
+

--- a/test/smoke/kmpc_alloc_cov5/Makefile
+++ b/test/smoke/kmpc_alloc_cov5/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = kmpc_alloc_cov5
+TESTSRC_MAIN = kmpc_alloc_cov5.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) -mcode-object-version=5
+
+include ../Makefile.rules

--- a/test/smoke/kmpc_alloc_cov5/kmpc_alloc_cov5.cpp
+++ b/test/smoke/kmpc_alloc_cov5/kmpc_alloc_cov5.cpp
@@ -1,0 +1,35 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C" {
+void *__kmpc_impl_malloc(size_t) {
+  printf("Called malloc on host, error\n");
+  exit(1);
+}
+void __kmpc_impl_free(void *) {
+  printf("Called free on host, error\n");
+  exit(1);
+}
+}
+
+// Call the kmpc_impl malloc/free hooks from devicertl
+
+#pragma omp declare target
+extern "C" {
+void *__kmpc_impl_malloc(size_t);
+void __kmpc_impl_free(void *);
+}
+#pragma omp end declare target
+
+int main() {
+#pragma omp target device(0)
+  {
+    void *p = __kmpc_impl_malloc(128);
+    for (unsigned i = 0; i < 128; i++) {
+      *(char *)p = i;
+    }
+    __kmpc_impl_free(p);
+  }
+  return 0;
+}


### PR DESCRIPTION
Testing helloworld and kmpc_alloc with -mcode-object-version=5 flag.