### PR TITLE
Fixes bug that never checked result of test in check_smoke.sh

### DIFF
--- a/test/smoke-fails/aomp-issue374/Makefile
+++ b/test/smoke-fails/aomp-issue374/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = aomp-issue374.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-fails/aomp-issue374/Makefile
+++ b/test/smoke-fails/aomp-issue374/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = aomp-issue374.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke-fails/collapse1/Makefile
+++ b/test/smoke-fails/collapse1/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -O3
 CLANG        ?= clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke-fails/collapse1/Makefile
+++ b/test/smoke-fails/collapse1/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -O3
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke-fails/workgroup_size/Makefile
+++ b/test/smoke-fails/workgroup_size/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-fails/workgroup_size/Makefile
+++ b/test/smoke-fails/workgroup_size/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 include ../Makefile.rules
 run: $(TESTNAME)
 	$(RUNENV) ./$(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -1,6 +1,7 @@
 TESTNAMES_ALL = $(basename $(TESTSRC_ALL))
 TIMEOUT ?= 60s
 SMOKE_TIMEOUT ?= timeout --foreground $(TIMEOUT)
+CHECK_COMMAND ?= $(or $(TESTCMD), ./$(TESTNAME) $(ARGS))
 
 all: $(TESTNAME)
 
@@ -63,7 +64,7 @@ check: $(TESTNAME)
 	base=`basename $$path`; \
 	( \
 	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
-	  if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) ./$(TESTNAME) $(ARGS) > /dev/null 2>&1); then \
+	  if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(CHECK_COMMAND) > /dev/null 2>&1); then \
 		  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
 		  echo  "" >> ../check-smoke.txt; \
 		  echo $$base $$test_num  >> ../passing-tests.txt; \

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -1,7 +1,7 @@
 TESTNAMES_ALL = $(basename $(TESTSRC_ALL))
 TIMEOUT ?= 60s
 SMOKE_TIMEOUT ?= timeout --foreground $(TIMEOUT)
-CHECK_COMMAND ?= $(or $(TESTCMD), ./$(TESTNAME) $(ARGS))
+CHECK_COMMAND ?= $(or $(RUNCMD), ./$(TESTNAME) $(ARGS))
 
 all: $(TESTNAME)
 

--- a/test/smoke/aomp-issue376/Makefile
+++ b/test/smoke/aomp-issue376/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = aomp-issue376.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/aomp-issue376/Makefile
+++ b/test/smoke/aomp-issue376/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = aomp-issue376.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/no-loop-1/Makefile
+++ b/test/smoke/no-loop-1/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-1/Makefile
+++ b/test/smoke/no-loop-1/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-2/Makefile
+++ b/test/smoke/no-loop-2/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast -fopenmp-gpu-threads-per-team=512
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-2/Makefile
+++ b/test/smoke/no-loop-2/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast -fopenmp-gpu-threads-per-team=512
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-3/Makefile
+++ b/test/smoke/no-loop-3/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -Ofast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-3/Makefile
+++ b/test/smoke/no-loop-3/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -Ofast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-4/Makefile
+++ b/test/smoke/no-loop-4/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast -fno-openmp-target-ignore-env-vars
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-4/Makefile
+++ b/test/smoke/no-loop-4/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast -fno-openmp-target-ignore-env-vars
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-5/Makefile
+++ b/test/smoke/no-loop-5/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-gpu-threads-per-team=512
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-5/Makefile
+++ b/test/smoke/no-loop-5/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-gpu-threads-per-team=512
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-6/Makefile
+++ b/test/smoke/no-loop-6/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -Ofast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-6/Makefile
+++ b/test/smoke/no-loop-6/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -Ofast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-7/Makefile
+++ b/test/smoke/no-loop-7/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -Ofast -fno-openmp-target-ignore-env-vars
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-7/Makefile
+++ b/test/smoke/no-loop-7/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -Ofast -fno-openmp-target-ignore-env-vars
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-8/Makefile
+++ b/test/smoke/no-loop-8/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-8/Makefile
+++ b/test/smoke/no-loop-8/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-sched/Makefile
+++ b/test/smoke/no-loop-sched/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-sched/Makefile
+++ b/test/smoke/no-loop-sched/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/no-loop-split-1/Makefile
+++ b/test/smoke/no-loop-split-1/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -Ofast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/no-loop-split-1/Makefile
+++ b/test/smoke/no-loop-split-1/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -Ofast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-disallow-both/Makefile
+++ b/test/smoke/veccopy-ompt-target-disallow-both/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-disallow-both.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-disallow-both/Makefile
+++ b/test/smoke/veccopy-ompt-target-disallow-both/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-disallow-both.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target-emi-map/Makefile
+++ b/test/smoke/veccopy-ompt-target-emi-map/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-emi-map.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-emi-map/Makefile
+++ b/test/smoke/veccopy-ompt-target-emi-map/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-emi-map.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target-emi/Makefile
+++ b/test/smoke/veccopy-ompt-target-emi/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-emi.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-emi/Makefile
+++ b/test/smoke/veccopy-ompt-target-emi/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-emi.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target-map/Makefile
+++ b/test/smoke/veccopy-ompt-target-map/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-map.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-map/Makefile
+++ b/test/smoke/veccopy-ompt-target-map/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-map.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target-noinit/Makefile
+++ b/test/smoke/veccopy-ompt-target-noinit/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-noinit.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target-noinit/Makefile
+++ b/test/smoke/veccopy-ompt-target-noinit/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-noinit.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	./$(TESTNAME) $(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-wrong-return/Makefile
+++ b/test/smoke/veccopy-ompt-target-wrong-return/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target-wrong-return.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run:
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target-wrong-return/Makefile
+++ b/test/smoke/veccopy-ompt-target-wrong-return/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target-wrong-return.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/veccopy-ompt-target/Makefile
+++ b/test/smoke/veccopy-ompt-target/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = veccopy-ompt-target.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -16,4 +16,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 include ../Makefile.rules
 run:
 	echo $(PATH)
-	./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNCMD)

--- a/test/smoke/veccopy-ompt-target/Makefile
+++ b/test/smoke/veccopy-ompt-target/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = veccopy-ompt-target.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+TESTCMD      = ./$(TESTNAME) | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/workgroup_size_option1/Makefile
+++ b/test/smoke/workgroup_size_option1/Makefile
@@ -7,6 +7,8 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=1024
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/workgroup_size_option1/Makefile
+++ b/test/smoke/workgroup_size_option1/Makefile
@@ -7,7 +7,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=1024
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/workgroup_size_option2/Makefile
+++ b/test/smoke/workgroup_size_option2/Makefile
@@ -7,7 +7,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=128
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/workgroup_size_option2/Makefile
+++ b/test/smoke/workgroup_size_option2/Makefile
@@ -7,6 +7,8 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 EXTRA_CFLAGS += -fopenmp-gpu-threads-per-team=128
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/xteam-red-1-g/Makefile
+++ b/test/smoke/xteam-red-1-g/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast -g
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-1-g/Makefile
+++ b/test/smoke/xteam-red-1-g/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast -g
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-1/Makefile
+++ b/test/smoke/xteam-red-1/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-1/Makefile
+++ b/test/smoke/xteam-red-1/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-2/Makefile
+++ b/test/smoke/xteam-red-2/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-2/Makefile
+++ b/test/smoke/xteam-red-2/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-3/Makefile
+++ b/test/smoke/xteam-red-3/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -Ofast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-3/Makefile
+++ b/test/smoke/xteam-red-3/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -Ofast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-4/Makefile
+++ b/test/smoke/xteam-red-4/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-4/Makefile
+++ b/test/smoke/xteam-red-4/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-collapse/Makefile
+++ b/test/smoke/xteam-red-collapse/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-collapse/Makefile
+++ b/test/smoke/xteam-red-collapse/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/xteam-red-unsupported/Makefile
+++ b/test/smoke/xteam-red-unsupported/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
-TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
 
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
@@ -17,4 +17,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
 run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke/xteam-red-unsupported/Makefile
+++ b/test/smoke/xteam-red-unsupported/Makefile
@@ -6,6 +6,8 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
+TESTCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
 CFLAGS       += -fopenmp-target-fast
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)


### PR DESCRIPTION
Some tests were using the 'make run' command to encode a more complex command for testing. This would never trigger a test failure in check_smoke.sh as it relies on the 'make check' rule.

This patch fixes this for some tests.

I don't know if more tests in smoke show this behavior.