### PR TITLE
Updates to GenASiS and Nekbone test scripts

### DIFF
--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -42,7 +42,7 @@ else
     exit
 fi
 
-export GPU_ID=$($AOMP/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
+export GPU_ID=$($ROCM/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
 currdir=$(pwd)
 if [ -d "$SILO_DIR" ] ; then
     echo "SILO 4.10.2 exists."
@@ -69,7 +69,7 @@ fi
 export LD_LIBRARY_PATH=$HOME/rocm/aomp/lib:$OPENMPI_DIR/lib:$LD_LIBRARY_PATH
 export FORTRAN_COMPILE="$AOMP/bin/flang -c -I$OPENMPI_DIR/lib"
 export CC_COMPILE="$AOMP/bin/clang"
-export OTHER_LIBS="-lm -L$AOMP/lib -L$OPENMPI_DIR/lib -lmpi_usempif08 -lmpi_mpifh -lmpi -lflang -lflangmain -lflangrti -lpgmath -lomp -lomptarget "
+export OTHER_LIBS="-lm -L$AOMP/lib -lflang -lflangmain -lflangrti -lpgmath -lomp -lomptarget "
 export FORTRAN_LINK="$AOMP/bin/clang $OTHER_LIBS"
 export DEVICE_COMPILE="$AOMP/bin/hipcc -D__HIP_PLATFORM_HCC__"
 export HIP_DIR=$ROCM
@@ -77,6 +77,7 @@ cd $currdir
 if [ "$1" != "runonly" ] ; then
   cd $REPO_DIR/Programs/UnitTests/Basics/Runtime/Executables
   echo "=================  STARTING 1st MAKE in $PWD ========"
+  make clean
   make PURPOSE=OPTIMIZE all
   rc=$?
   if [ $rc != 0 ] ; then
@@ -86,6 +87,7 @@ if [ "$1" != "runonly" ] ; then
   echo
   cd $REPO_DIR/Programs/Examples/Basics/FluidDynamics/Executables
   echo "=================  STARTING 2nd  MAKE in $PWD ========"
+  make clean
   make PURPOSE=OPTIMIZE all
   rc=$?
   if [ $rc != 0 ] ; then
@@ -95,6 +97,7 @@ if [ "$1" != "runonly" ] ; then
   echo
   cd $REPO_DIR/Programs/UnitTests/Basics/Devices/Executables
   echo "=================  STARTING 3rd  MAKE in $PWD ========"
+  make clean
   make PURPOSE=OPTIMIZE all
   rc=$?
   if [ $rc != 0 ] ; then

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -9,11 +9,13 @@ thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 
+export LIBOMPTARGET_KERNEL_TRACE=${LIBOMPTARGET_KERNEL_TRACE:-1}
+
 if [ "$1" == "rerun" ]; then
   cd $AOMP_REPOS_TEST/Nekbone
   cd test/nek_gpu1
   ulimit -s unlimited
-  LIBOMPTARGET_KERNEL_TRACE=1 ./nekbone
+  ./nekbone
   exit 0
 fi
 
@@ -36,9 +38,9 @@ ulimit -s unlimited
 PATH=$AOMP/bin/:$PATH make -f makefile.aomp
 VERBOSE=${VERBOSE:-"1"}
 if [ $VERBOSE -eq 0 ]; then
-  LIBOMPTARGET_KERNEL_TRACE=1 ./nekbone 2>&1 | tee nek.log > /dev/null
+  ./nekbone 2>&1 | tee nek.log > /dev/null
 else
-  LIBOMPTARGET_KERNEL_TRACE=1 ./nekbone 2>&1 | tee nek.log
+  ./nekbone 2>&1 | tee nek.log
 fi
 grep -s Exitting nek.log
 ret=$?


### PR DESCRIPTION
- Use ROCM env var instead of AOMP to locate rocm_agent_enumerator
    o Needed when testing ROCm compiler installations in /opt/rocm
    o An AOMP build has rocm_agent_enumerator in $AOMP/bin, but a ROCm compiler installation has it in /opt/rocm/bin
- Don’t add MPI libs to OTHER_LIBS as they are listed in the Makefile
    o Avoids link failure due to duplicate symbols
    o aomp/bin/Makefile_ROCm also specifies these libraries
- Added ‘make clean’ before any make all steps
    o Since we were changing which compiler we were using and rerunning the test
- Allow LIBOMPTARGET_KERNEL_TRACE to be overriden from the user's environment
    o Running with LIBOMPTARGET_KERNEL_TRACE incurs additional overhead in timings