### PR TITLE
Add openmpi path detection to Makefile.defs, defines OMPIDIR and MPILIBS

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -78,25 +78,18 @@ endif
 
 OMPIDIR ?= ~/local/openmpi
 ifeq "$(wildcard $(OMPIDIR))" ""
-  #$(warning openmpi not found at $(OMPIDIR))
   OMPIDIR = /opt/openmpi-4.1.5
   ifeq "$(wildcard $(OMPIDIR))" ""
-    #$(warning openmpi not found at $(OMPIDIR))
     OMPIDIR = /opt/openmpi-4.1.4
     ifeq "$(wildcard $(OMPIDIR))" ""
-      #$(warning openmpi not found at $(OMPIDIR))
       OMPIDIR = /usr/local/openmpi
       ifeq "$(wildcard $(OMPIDIR))" ""
-        #$(warning openmpi not found at $(OMPIDIR))
         OMPIDIR = /usr/lib/x86_64-linux-gnu/openmpi
         ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
-          #$(warning openmpi not found at $(OMPIDIR))
           OMPIDIR = /usr/lib/openmpi
           ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
-            #$(warning openmpi not found at $(OMPIDIR))
             OMPIDIR = /usr/local
             ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
-              #$(warning openmpi not found at $(OMPIDIR))
               $(error Openmpi not found on the system and is required. Set OMPIDIR to openmpi installation)
             endif
           endif

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -75,6 +75,42 @@ ifeq ($(FILECHECK_RT),error)
   endif
 endif
 
+
+OMPIDIR ?= ~/local/openmpi
+ifeq "$(wildcard $(OMPIDIR))" ""
+  #$(warning openmpi not found at $(OMPIDIR))
+  OMPIDIR = /opt/openmpi-4.1.5
+  ifeq "$(wildcard $(OMPIDIR))" ""
+    #$(warning openmpi not found at $(OMPIDIR))
+    OMPIDIR = /opt/openmpi-4.1.4
+    ifeq "$(wildcard $(OMPIDIR))" ""
+      #$(warning openmpi not found at $(OMPIDIR))
+      OMPIDIR = /usr/local/openmpi
+      ifeq "$(wildcard $(OMPIDIR))" ""
+        #$(warning openmpi not found at $(OMPIDIR))
+        OMPIDIR = /usr/lib/x86_64-linux-gnu/openmpi
+        ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
+          #$(warning openmpi not found at $(OMPIDIR))
+          OMPIDIR = /usr/lib/openmpi
+          ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
+            #$(warning openmpi not found at $(OMPIDIR))
+            OMPIDIR = /usr/local
+            ifeq "$(wildcard $(OMPIDIR)/lib/libmpi*)" ""
+              #$(warning openmpi not found at $(OMPIDIR))
+              $(error Openmpi not found on the system and is required. Set OMPIDIR to openmpi installation)
+            endif
+          endif
+        endif
+      endif
+    endif
+  endif
+endif
+
+$(info -- openmpi found at $(OMPIDIR))
+MPILIBS ?= -L${OMPIDIR}/lib -lmpi
+
+
+
 # If AOMP env variable contains opt use rocm_agent_enumerator for device id.
 # Set GFXLIST to available gfx numbers pulled from installed bc files.
 ifeq (opt,$(findstring opt,$(AOMP)))


### PR DESCRIPTION
next patch will clean up smoke-fails/mpi-openmp-targ