### PR TITLE
Honor FLANG env var as name of flang driver

### DIFF
--- a/bin/run_fBabel.sh
+++ b/bin/run_fBabel.sh
@@ -19,6 +19,7 @@ thisdir=`dirname $realpath`
 
 # Set defaults for environment variables
 AOMP=${AOMP:-/usr/lib/aomp}
+FLANG=${FLANG:-flang}
 
 # note: clone_test.sh puts babelstream in $AOMP_REPOS_TEST/babelstream
 FABELSTREAM_REPO=${FABELSTREAM_REPO:-$AOMP_REPOS_TEST/fortran-babelstream}
@@ -42,10 +43,10 @@ fi
 omp_target_flags="-O3 -fopenmp -fopenmp-targets=$TRIPLE -Xopenmp-target=$TRIPLE -march=$AOMP_GPU -DOMP -DUSE_OPENMPTARGET=1 -DVERSION_STRING=4.0"
 #  So this script runs with old comilers, we only use -fopenmp-target-fast
 #  for LLVM 16 or higher
-LLVM_VERSION=`$AOMP/bin/flang --version | grep version | cut -d" " -f 3 | cut -d"." -f1`
+LLVM_VERSION=`$AOMP/bin/$FLANG --version | grep version | cut -d" " -f 3 | cut -d"." -f1`
 if [ "$LLVM_VERSION" == "version" ]  ; then
   # If 3rd  arg is version, must be vendor cmppiler, so get version from 4th field.
-  LLVM_VERSION=`$AOMP/bin/flang --version | grep version | cut -d" " -f 4 | cut -d"." -f1`
+  LLVM_VERSION=`$AOMP/bin/$FLANG --version | grep version | cut -d" " -f 4 | cut -d"." -f1`
   special_aso_flags="-O3 -fopenmp-target-fast"
   #special_aso_flags="-fopenmp-gpu-threads-per-team=256 -fopenmp-target-fast"
 else
@@ -109,11 +110,11 @@ for option in $RUN_OPTIONS; do
   EXEC=stream-$option
   rm -f $EXEC
   if [ "$option" == "omp-default" ]; then
-    compile_cmd="$AOMP/bin/flang $std $omp_target_flags $omp_src -o $EXEC"
+    compile_cmd="$AOMP/bin/$FLANG $std $omp_target_flags $omp_src -o $EXEC"
   elif [ "$option" == "omp-fast" ]; then
-    compile_cmd="$AOMP/bin/flang $std $omp_fast_flags   $omp_src -o $EXEC"
+    compile_cmd="$AOMP/bin/$FLANG $std $omp_fast_flags   $omp_src -o $EXEC"
   elif [ "$option" == "omp-cpu" ]; then
-    compile_cmd="$AOMP/bin/flang $std $omp_cpu_flags    $omp_src -o $EXEC"
+    compile_cmd="$AOMP/bin/$FLANG $std $omp_cpu_flags    $omp_src -o $EXEC"
   else
     echo "ERROR: Option not recognized: $option."
     exit 1

--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -12,6 +12,7 @@ thisdir=`dirname $realpath`
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 ROCM=${ROCM:-/opt/rocm}
+FLANG=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -67,7 +68,7 @@ else
 fi
 
 export LD_LIBRARY_PATH=$HOME/rocm/aomp/lib:$OPENMPI_DIR/lib:$LD_LIBRARY_PATH
-export FORTRAN_COMPILE="$AOMP/bin/flang -c -I$OPENMPI_DIR/lib"
+export FORTRAN_COMPILE="$AOMP/bin/$FLANG -c -I$OPENMPI_DIR/lib"
 export CC_COMPILE="$AOMP/bin/clang"
 export OTHER_LIBS="-lm -L$AOMP/lib -lflang -lflangmain -lflangrti -lpgmath -lomp -lomptarget "
 export FORTRAN_LINK="$AOMP/bin/clang $OTHER_LIBS"

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -21,7 +21,7 @@ fi
 
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
-F77=${FLANG:-flang}
+FLANG=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -36,7 +36,7 @@ if [ $ret -ne 0 ]; then
   exit 1
 fi
 ulimit -s unlimited
-PATH=$AOMP/bin/:$PATH make F77=$F77 -f makefile.aomp
+PATH=$AOMP/bin/:$PATH make F77=$FLANG -f makefile.aomp
 VERBOSE=${VERBOSE:-"1"}
 if [ $VERBOSE -eq 0 ]; then
   ./nekbone 2>&1 | tee nek.log > /dev/null

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -21,6 +21,7 @@ fi
 
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
+F77=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -35,7 +36,7 @@ if [ $ret -ne 0 ]; then
   exit 1
 fi
 ulimit -s unlimited
-PATH=$AOMP/bin/:$PATH make -f makefile.aomp
+PATH=$AOMP/bin/:$PATH make F77=$F77 -f makefile.aomp
 VERBOSE=${VERBOSE:-"1"}
 if [ $VERBOSE -eq 0 ]; then
   ./nekbone 2>&1 | tee nek.log > /dev/null

--- a/bin/run_ovo.sh
+++ b/bin/run_ovo.sh
@@ -8,6 +8,7 @@ thisdir=`dirname $realpath`
 
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
+FLANG=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -15,7 +16,7 @@ setaompgpu
 AOMP_GPU=${AOMP_GPU:-`$AOMP/bin/mygpu`}
 PATH=$AOMP/bin:$PATH
 CXX=clang++
-FC=flang
+FC=$FLANG
 FFLAGS="-O2  -target x86_64-pc-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU"
 CXXFLAGS="-O2  -target x86_64-pc-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU"
 OMP_TARGET_OFFLOAD=mandatory

--- a/bin/run_rushlarsen.sh
+++ b/bin/run_rushlarsen.sh
@@ -12,6 +12,7 @@ thisdir=`dirname $realpath`
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
 AOMPHIP=${AOMPHIP:-$AOMP}
+FLANG=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -24,7 +25,7 @@ omp_flags="-O3 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgc
 omp_dir="tests/rush_larsen/rush_larsen_gpu_omp"
 omp_exec="rush_larsen_gpu_omp"
 
-fomp_f90="$AOMP/bin/flang"
+fomp_f90="$AOMP/bin/$FLANG"
 fomp_flags="-O3 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU -DOMP -DOMP_TARGET_GPU -g"
 fomp_dir="tests/rush_larsen/rush_larsen_gpu_omp_fort"
 fomp_exec="rush_larsen_gpu_omp_fort"

--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -72,6 +72,7 @@ fi
 
 # Setup AOMP variables
 AOMP=${AOMP:-/usr/lib/aomp}
+FLANG=${FLANG:-flang}
 
 # Use function to set and test AOMP_GPU
 setaompgpu
@@ -99,7 +100,7 @@ fi
 if [ "$make_target" == "all" ] ; then
   if [ "$SKIP_SOLLVE45" != 1 ]; then
     echo "--------------------------- START OMP 4.5 TESTING ---------------------"
-    make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=4.5 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 all
+    make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=4.5 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 all
     echo
   fi
 else
@@ -123,8 +124,8 @@ else
      export MY_SOLLVE_FLAGS="$MY_SOLLVE_FLAGS -fopenmp-version=45"
   fi
   echo "       The full make command:"
-  echo " make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS=\"-lm $MY_SOLLVE_FLAGS\" CXXFLAGS=\"$MY_SOLLVE_FLAGS\" FFLAGS=\"$MY_SOLLVE_FLAGS\" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all"
-make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all
+  echo " make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS=\"-lm $MY_SOLLVE_FLAGS\" CXXFLAGS=\"$MY_SOLLVE_FLAGS\" FFLAGS=\"$MY_SOLLVE_FLAGS\" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all"
+make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS" LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 OMP_VERSION=$this_omp_version SOURCES=$single_case all
   rc=$?
   echo
   echo "DONE:  Single SOLLVE_VV test case: $single_case"
@@ -159,7 +160,7 @@ if [ "$SKIP_SOLLVE50" != 1 ]; then
   echo "--------------------------- START OMP 5.0 TESTING ---------------------"
   export MY_SOLLVE_FLAGS="$MY_SOLLVE_FLAGS -fopenmp-version=50"
   make tidy
-  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.0 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
+  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.0 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
   echo
   echo "--------------------------- OMP 5.0 Detailed Results ---------------------------" >> combined-results.txt
   echo "--------------------------- OMP 5.0 Results ---------------------------" >> abrev.combined-results.txt
@@ -178,7 +179,7 @@ if [ "$SKIP_SOLLVE51" != 1 ]; then
   custom_source="\" -type f ! \( -name *test_target_has_device_addr.c* \)\""
 
   make tidy
-  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.1 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
+  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.1 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
   echo
   echo "--------------------------- OMP 5.1 Detailed Results ---------------------------" >> combined-results.txt
   echo "--------------------------- OMP 5.1 Results ---------------------------" >> abrev.combined-results.txt
@@ -191,7 +192,7 @@ if [ "$SKIP_SOLLVE52" != 1 ]; then
   # Run OpenMP 5.2 Tests
   export MY_SOLLVE_FLAGS="$MY_SOLLVE_FLAGS -fopenmp-version=52"
   make tidy
-  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.2 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
+  make CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG CFLAGS="-lm $MY_SOLLVE_FLAGS" CXXFLAGS="$MY_SOLLVE_FLAGS" FFLAGS="$MY_SOLLVE_FLAGS"  OMP_VERSION=5.2 LOG=1 LOG_ALL=1 VERBOSE_TESTS=1 VERBOSE=1 SOURCES="$custom_source" all
   echo
   echo "--------------------------- OMP 5.2 Detailed Results ---------------------------" >> combined-results.txt
   echo "--------------------------- OMP 5.2 Results ---------------------------" >> abrev.combined-results.txt

--- a/bin/run_umt_2013.sh
+++ b/bin/run_umt_2013.sh
@@ -3,6 +3,7 @@ export ROCM_PATH=/opt/rocm
 
 export AOMP=$HOME/rocm/aomp
 export UMT_PATCH=$HOME/git/aomp16.0/aomp/bin/patches
+FLANG=${FLANG:-flang}
 
 export UMT_PATH=$HOME/git/aomp-test/UMT2013-20140204
 
@@ -33,7 +34,7 @@ if [ "$1" == "build_mpi" ]; then
 
     pushd $OMPI_PATH
     ./autogen.pl
-    ./configure --prefix=$MPI_INSTALL_DIR CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/flang OMPI_CC=$AOMP/bin/clang OMPI_CXX=$AOMP/bin/clang++ OMPI_FC=$AOMP/bin/flang
+    ./configure --prefix=$MPI_INSTALL_DIR CC=$AOMP/bin/clang CXX=$AOMP/bin/clang++ FC=$AOMP/bin/$FLANG OMPI_CC=$AOMP/bin/clang OMPI_CXX=$AOMP/bin/clang++ OMPI_FC=$AOMP/bin/$FLANG
     make && make install
     popd
     exit 1


### PR DESCRIPTION
  - No change in default behavior of using "flang" as driver
  - Needed for testing with llvm-flang "flang-new" driver