### PR TITLE
Use -fopenmp-target-fast on rushlarsen benchmark

### DIFF
--- a/bin/run_rushlarsen.sh
+++ b/bin/run_rushlarsen.sh
@@ -21,7 +21,7 @@ RUN_OPTIONS=${RUN_OPTIONS:-"openmp hip fomp"}
 
 # OMP options
 omp_cxx="$AOMP/bin/clang++"
-omp_flags="-O3 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU -DOMP -DOMP_TARGET_GPU -fopenmp-target-ignore-env-vars"
+omp_flags="-O3 -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$AOMP_GPU -DOMP -DOMP_TARGET_GPU -fopenmp-target-fast"
 omp_dir="tests/rush_larsen/rush_larsen_gpu_omp"
 omp_exec="rush_larsen_gpu_omp"
 


### PR DESCRIPTION
Left out the environment variable for HSA wait states intentionally.