### PR TITLE
[AOMP][ASan] Modify build scripts w.r.t to ASan.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -325,7 +325,7 @@ else
 fi
 
 # Sanitizer Build environment flags
-if [ -n "$1" ] && [ "$1" == "asan" ]; then
+if [ -n "$1" ] && [ "$1" == "asan" ] && [ "$AOMP_BUILD_CUDA" != 1 ]; then
   AOMP_BUILD_SANITIZER=ON
   SANITIZER_FLAGS="-fsanitize=address -shared-libasan"
 fi

--- a/bin/build_hipamd.sh
+++ b/bin/build_hipamd.sh
@@ -95,7 +95,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
   # Enable HIPAMD Sanitizer Build
   if [ "$AOMP_BUILD_SANITIZER" == 'ON' ]; then
-    MYCMAKEOPTS="$MYCMAKEOPTS -DCMAKE_CXX_FLAGS=-I$SANITIZER_COMGR_INCLUDE_PATH ${SANITIZER_FLAGS} -DCMAKE_C_FLAGS=${SANITIZER_FLAGS}"
+    ASAN_FLAGS="$SANITIZER_FLAGS -I$SANITIZER_COMGR_INCLUDE_PATH -Wno-error=deprecated-declarations"
   else
     MYCMAKEOPTS="$MYCMAKEOPTS -DCMAKE_CXX_FLAGS=-I$AOMP_include/amd_comgr -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations -DCMAKE_C_FLAGS=-Wno-error=deprecated-declarations"
   fi
@@ -120,8 +120,13 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   cd $BUILD_DIR/build/hipamd
   echo
   echo " -----Running hipamd cmake ---- "
-  echo ${AOMP_CMAKE} $MYCMAKEOPTS $HIPAMD_DIR
-  ${AOMP_CMAKE} $MYCMAKEOPTS $HIPAMD_DIR
+  if [ "$AOMP_BUILD_SANITIZER" == "ON" ]; then
+    echo ${AOMP_CMAKE} $MYCMAKEOPTS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="$ASAN_FLAGS" -DCMAKE_CXX_FLAGS="$ASAN_FLAGS" $HIPAMD_DIR
+    ${AOMP_CMAKE} $MYCMAKEOPTS -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="$ASAN_FLAGS" -DCMAKE_CXX_FLAGS="$ASAN_FLAGS" $HIPAMD_DIR
+  else
+    echo ${AOMP_CMAKE} $MYCMAKEOPTS $HIPAMD_DIR
+    ${AOMP_CMAKE} $MYCMAKEOPTS $HIPAMD_DIR
+	fi
   if [ $? != 0 ] ; then
       echo "ERROR hipamd cmake failed. Cmake flags"
       echo "      $MYCMAKEOPTS"


### PR DESCRIPTION
Change aomp_common_vars,build_openmp.sh,build_hipamd.sh to use **CMAKE_CXX_FLAGS** and **CMAKE_C_FLAGS** to pass sanitizer flags for openmp runtime libraries compilation.