### PR TITLE
Pass ASAN enable/disable information to flang runtime

### DIFF
--- a/bin/build_flang_runtime.sh
+++ b/bin/build_flang_runtime.sh
@@ -40,6 +40,9 @@ if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
   -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
 fi
 
+if [ "$SANITIZER" == 1 ]; then
+  MYCMAKEOPTS="$MYCMAKEOPTS -DSANITIZER=$SANITIZER "
+fi
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
   help_build_aomp
 fi


### PR DESCRIPTION
SWDEV-398694 -Flang is initializing cmake_shared_linker_flags, that need update for ASAN builds.