### PR TITLE
Update rocprofiler-no-aql-ok.patch for rocm-5.5.x

### DIFF
--- a/bin/patches/rocprofiler-no-aql-ok.patch
+++ b/bin/patches/rocprofiler-no-aql-ok.patch
@@ -1,11 +1,37 @@
 diff --git a/cmake_modules/env.cmake b/cmake_modules/env.cmake
-index 2e9613b..57e6381 100644
+index 6647578..f36498b 100644
 --- a/cmake_modules/env.cmake
 +++ b/cmake_modules/env.cmake
-@@ -122,5 +122,5 @@ endif ()
+@@ -75,5 +75,5 @@ endif ()
  
  find_library ( FIND_AQL_PROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_INSTALL_PREFIX} PATHS ${ROCM_ROOT_DIR})
  if (  NOT FIND_AQL_PROFILE_LIB )
 -  message ( FATAL_ERROR "AQL_PROFILE not installed. Please install AQL_PROFILE" )
 +  message (WARNING "AQL_PROFILE not installed. Please install AQL_PROFILE" )
  endif()
+diff --git a/src/api/CMakeLists.txt b/src/api/CMakeLists.txt
+index 822ee41..c915f2b 100644
+--- a/src/api/CMakeLists.txt
++++ b/src/api/CMakeLists.txt
+@@ -40,7 +40,7 @@ get_filename_component(HSA_RUNTIME_INC_PATH ${HSA_H} DIRECTORY)
+ find_library(AQLPROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_PREFIX_PATH} PATHS ${ROCM_PATH} PATH_SUFFIXES lib)
+ 
+ if(NOT AQLPROFILE_LIB)
+-  message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
++  message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
+ endif()
+ 
+ # ############################################################################################################################################
+diff --git a/src/tools/rocprofv2/CMakeLists.txt b/src/tools/rocprofv2/CMakeLists.txt
+index b2dc968..f18b56f 100644
+--- a/src/tools/rocprofv2/CMakeLists.txt
++++ b/src/tools/rocprofv2/CMakeLists.txt
+@@ -6,7 +6,7 @@ get_property(HSA_RUNTIME_INCLUDE_DIRECTORIES TARGET hsa-runtime64::hsa-runtime64
+ 
+ find_library(AQLPROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_PREFIX_PATH} PATHS ${ROCM_PATH} PATH_SUFFIXES lib)
+ if(NOT AQLPROFILE_LIB)
+-  message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
++  message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
+ endif()
+ 
+ file(GLOB ROCPROFV2_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)


### PR DESCRIPTION
Extended the patch such that it covers all three checks for `AQL_PROFILE_LIB`. That is: change all related `FATAL_ERROR` to `WARNING`.