### PR TITLE
Add llvm-legacy build to flang-legacy.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -73,8 +73,8 @@ AOMP_SUPP_INSTALL=${AOMP_SUPP_INSTALL:-$AOMP_SUPP/install}
 
 # last version of rocm that supports the legacy driver (command generation)
 # The archives and includes are installed as an AOMP supplemental component 
-AOMP_FLANG_LEGACY_REL=${AOMP_FLANG_LEGACY_REL:-$AOMP_SUPP/flang-legacy-LFL}
-if [ -d $AOMP_FLANG_LEGACY_REL/llvm ] ; then
+AOMP_FLANG_LEGACY_REL=${AOMP_FLANG_LEGACY_REL:-$AOMP_FLANG_LEGACY_REL/flang-legacy}
+if [ -d $AOMP_FLANG_LEGACY_REL/llvm-legacy ] ; then
    AOMP_BUILD_FLANG_LEGACY=1
 else
    AOMP_BUILD_FLANG_LEGACY=0

--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -71,15 +71,6 @@ AOMP_SUPP_BUILD=${AOMP_SUPP_BUILD:-$AOMP_SUPP/build}
 # AOMP_SUPP_INSTALL must be permanent directory.
 AOMP_SUPP_INSTALL=${AOMP_SUPP_INSTALL:-$AOMP_SUPP/install}
 
-# last version of rocm that supports the legacy driver (command generation)
-# The archives and includes are installed as an AOMP supplemental component 
-AOMP_FLANG_LEGACY_REL=${AOMP_FLANG_LEGACY_REL:-$AOMP_FLANG_LEGACY_REL/flang-legacy}
-if [ -d $AOMP_FLANG_LEGACY_REL/llvm-legacy ] ; then
-   AOMP_BUILD_FLANG_LEGACY=1
-else
-   AOMP_BUILD_FLANG_LEGACY=0
-fi
-
 # Set the directory location where all local AOMP git repos are stored.
 
 # To build aomp from the release source taball, set these values to 0
@@ -225,6 +216,16 @@ GITPROJECT=$GITROCDEV
 AOMP_PROJECT_REPO_NAME=${AOMP_PROJECT_REPO_NAME:-llvm-project}
 AOMP_EXTRAS_REPO_NAME=${AOMP_EXTRAS_REPO_NAME:-aomp-extras}
 AOMP_FLANG_REPO_NAME=${AOMP_FLANG_REPO_NAME:-flang}
+
+# Last version of rocm (5.5) that supports the legacy driver (command generation)
+# The archives are built during flang-legacy.
+AOMP_FLANG_LEGACY_REL=${AOMP_FLANG_LEGACY_REL:-${AOMP_REPOS}/${AOMP_FLANG_REPO_NAME}/flang-legacy}
+echo $AOMP_FLANG_LEGACY_REL
+if [ -d $AOMP_FLANG_LEGACY_REL/llvm-legacy ] ; then
+   AOMP_BUILD_FLANG_LEGACY=1
+else
+   AOMP_BUILD_FLANG_LEGACY=0
+fi
 
 # The AOMP_XXX_REPO_NAME is the directory name following $AOMP_REPOS.
 

--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -52,7 +52,7 @@ EOF
 }
 
 SUPPLEMENTAL_COMPONENTS=${SUPPLEMENTAL_COMPONENTS:-openmpi silo hdf5 fftw ninja}
-PREREQUISITE_COMPONENTS=${PREREQUISITE_COMPONENTS:-cmake rocmsmilib hwloc flang-legacy-LFL aqlprofile}
+PREREQUISITE_COMPONENTS=${PREREQUISITE_COMPONENTS:-cmake rocmsmilib hwloc aqlprofile}
 
 # --- Start standard header to set AOMP environment variables ----
 realpath=`realpath $0`
@@ -165,50 +165,6 @@ function buildninja(){
     runcmd "rm $_linkfrom"
   fi
   runcmd "ln -sf $_installdir $_linkfrom"
-  echo "# $_linkfrom is now symbolic link to $_installdir " >>$CMDLOGFILE
-}
-
-function buildflang-legacy-LFL(){
-  _cname="flang-legacy-LFL"
-  _version=5.5
-  _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
-  _linkfrom=$AOMP_SUPP/$_cname
-  _builddir=$AOMP_SUPP_BUILD/$_cname
-
-  SKIPBUILD="FALSE"
-  checkversion
-  if [ "$SKIPBUILD" == "TRUE"  ] ; then
-    return
-  fi
-  if [ -d $_builddir ] ; then
-    runcmd "rm -rf $_builddir"
-  fi
-  runcmd "mkdir -p $_builddir"
-  runcmd "cd $_builddir"
-  which dpkg 2>/dev/null
-  if [ $? == 0 ] ; then
-    runcmd "wget https://repo.radeon.com/rocm/apt/5.5/pool/main/r/rocm-llvm5.5.0/rocm-llvm5.5.0_16.0.0.23144.50500-63~20.04_amd64.deb"
-    runcmd "dpkg -x rocm-llvm5.5.0_16.0.0.23144.50500-63~20.04_amd64.deb $_builddir"
-  else
-    runcmd "wget https://repo.radeon.com/rocm/yum/5.5/main/rocm-llvm5.5.0-16.0.0.23144.50500-63.el7.x86_64.rpm"
-    echo "rpm2cpio rocm-llvm5.5.0-16.0.0.23144.50500-63.el7.x86_64.rpm | cpio -idm"
-    rpm2cpio rocm-llvm5.5.0-16.0.0.23144.50500-63.el7.x86_64.rpm | cpio -idm
-  fi
-  if [ -d $_installdir ] ; then
-    runcmd "rm -rf $_installdir"
-  fi
-  runcmd "mkdir -p $_installdir/llvm/lib"
-  runcmd "cd $_installdir/llvm"
-  # we only need archive libs for libclang and libLLVM and include files to build flang-legacy.
-  runcmd "cp -rp $_builddir/opt/rocm-5.5.0/llvm/lib/libLLVM*.a  $_installdir/llvm/lib"
-  runcmd "cp -rp $_builddir/opt/rocm-5.5.0/llvm/lib/libclang*.a  $_installdir/llvm/lib"
-  runcmd "cp -rp $_builddir/opt/rocm-5.5.0/llvm/include $_installdir/llvm"
-
-  if [ -L $_linkfrom ] ; then
-    runcmd "rm $_linkfrom"
-  fi
-  runcmd "ln -sf $_installdir $_linkfrom"
-  runcmd "rm -rf $_builddir"
   echo "# $_linkfrom is now symbolic link to $_installdir " >>$CMDLOGFILE
 }
 
@@ -518,8 +474,6 @@ for _component in $_components ; do
     buildrocmsmilib
   elif [ $_component == "ninja" ] ; then
     buildninja
-  elif [ $_component == "flang-legacy-LFL" ] ; then
-    buildflang-legacy-LFL
   elif [ $_component == "aqlprofile" ] ; then
     buildaqlprofile
   else


### PR DESCRIPTION
This gets rid of the wget of ROCm 5.5 llvm package in favor of building the needed llvm/clang libraries from source to support various operating systems and spack.