### PR TITLE
Add test which tries to enable USM in flang but fails

### DIFF
--- a/test/smoke-fails/flang-usm2/Makefile
+++ b/test/smoke-fails/flang-usm2/Makefile
@@ -1,0 +1,17 @@
+USE_OFFLOAD_ARCH = 1
+AOMP_TARGET_FEATURES=:xnack+
+
+include ../../Makefile.defs
+
+TESTNAME     = flang-usm
+TESTSRC_MAIN = flang-usm.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang 
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/flang-usm2/flang-usm.f90
+++ b/test/smoke-fails/flang-usm2/flang-usm.f90
@@ -1,0 +1,32 @@
+program test
+    use omp_lib
+    implicit none
+    integer,parameter                   :: nsize = 1024*256,ninc = 1024,niter = 10
+    real,pointer                        :: a(:),b(:)
+    integer                             :: i,j,k
+    double precision                    :: wstart, wend, wstarttotal, wendtotal
+
+
+    call omp_set_default_device(3)
+    !$omp requires unified_shared_memory
+    allocate(a(nsize*ninc),b(nsize*ninc))
+    b = 1000
+    wstarttotal = omp_get_wtime()
+    do k=1,niter
+    wstart = omp_get_wtime()
+        !$omp target teams distribute parallel do collapse(2) !num_teams(880) thread_limit(256)
+        do i=1,nsize
+            do j=1,ninc
+                a((i-1)*ninc+j) = j + 100*i + b((i-1)*ninc+j)
+                !b((i-1)*ninc+j) = j + 1000*i + a((i-1)*ninc+j)
+            end do
+        enddo
+    wend = omp_get_wtime()
+    
+    write(*,*) "Work took", 1e-9*(nsize*ninc*4)/(wEND - wSTART), "GB/s"
+    enddo
+    wendtotal = omp_get_wtime()
+    write(*,*) "a(2),b(2) =", a(2),b(2)
+    write(*,*) "Work took", 1e-9*niter*(nsize*ninc*8)/(wENDtotal - wSTARTtotal), "GB/s"
+    
+end program test


### PR DESCRIPTION
Add test which tries to enable USM in flang but fails.

When running the test with:

```
HSA_XNACK=1 LIBOMPTARGET_KERNEL_TRACE=2 ./flang-usm
```

The output shows that unified memory is not enabled in the runtime:
```
Call             __tgt_rtl_init_requires:        1us              0 (             0)
```

The output value should be:
```
Call             __tgt_rtl_init_requires:        1us              8 (             0)
```