### PR TITLE
[ASan][OpenMP] Patch for OpenMP NPSDB scripts for ASan.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -68,9 +68,15 @@ AOMP_STANDALONE_BUILD=${AOMP_STANDALONE_BUILD:-1}
 if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
    # Default is to build nvptx for STANDALONE build
    AOMP_BUILD_CUDA=${AOMP_BUILD_CUDA:-1}
+   AOMP_BUILD_SANITIZER=${AOMP_BUILD_SANITIZER:-0}
 else
    # Default is to NOT build nvptx for ROCm integrated build
    AOMP_BUILD_CUDA=${AOMP_BUILD_CUDA:-0}
+   if [ "$SANITIZER" == 1 ]; then
+      AOMP_BUILD_SANITIZER=${AOMP_BUILD_SANITIZER:-1}
+   else
+      AOMP_BUILD_SANITIZER=${AOMP_BUILD_SANITIZER:-0}
+   fi
 fi
 
 # AOMP uses RPATH (not) RUNPATH because LD_LIBRARY_PATH is a user feature for

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -134,7 +134,8 @@ echo " =================  START build_aomp.sh ==================="
 echo 
 if [ -n "$AOMP_JENKINS_BUILD_LIST" ] ; then
    components=$AOMP_JENKINS_BUILD_LIST
-   components="extras openmp flang-legacy pgmath flang flang_runtime"
+   # disable below as it seems to be breaking afar, wait for ethan
+   #components="extras openmp flang-legacy pgmath flang flang_runtime"
 else
    if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
       # There is no good external repo for the opencl runtime but we only need the headers for build_vdi.sh


### PR DESCRIPTION
Requirement to ship ASan instrumented OpenMP runtime library Build & Install support. The patch achieves the following objectives:-

1. Build & Install support OpenMP{Release-ASan(llvm/lib/asan)}.
2. Build & Install support OpenMP{Debug-ASan(llvm/lib-debug/asan)}.