### PR TITLE
[Smoke] Added test for 'target teams loop' conditional code generation.

### DIFF
--- a/test/smoke-fails/loop-dir-10/Makefile
+++ b/test/smoke-fails/loop-dir-10/Makefile
@@ -1,0 +1,32 @@
+include ../../Makefile.defs
+
+TESTNAME     = loop_dir_10
+TESTSRC_MAIN = loop_dir_10.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(AOMP)/bin/FileCheck $(TESTSRC_MAIN)
+
+COMP_OUT  = $(TESTNAME).compile.out
+COMP_EXPECTED  = $(TESTNAME).compile.expected
+
+CLANG        ?= clang
+CFLAGS  += -mllvm -debug-only=target-teams-loop-codegen
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+$(TESTNAME): $(TESTNAME).c
+	$(SETENV) $(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OMP_FLAGS) $(TESTSRC_MAIN) -o $(TESTNAME) 2>&1 | tee $(COMP_OUT)
+
+compile: $(TESTNAME)
+	diff $(COMP_EXPECTED) $(COMP_OUT)
+
+run: compile
+	$(RUNENV) $(RUNCMD)
+
+# clean up local files
+clean::
+	rm -f $(COMP_OUT)

--- a/test/smoke-fails/loop-dir-10/loop_dir_10.c
+++ b/test/smoke-fails/loop-dir-10/loop_dir_10.c
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <omp.h>
+
+int N = 10000;
+
+void foo(int i) {}
+
+int main()
+{
+  int fail = 0;
+  int a[N];
+  int ea[N];
+  int b[N];
+
+  int i;
+  for (i=0; i<N; i++) {
+    b[i]=i;
+    a[i]=0;
+    ea[i]=0;
+  }
+
+  // Expected results.
+  #pragma omp target teams distribute parallel for
+  for (i=0; i < N; i++) {
+    for (int j=0; j < N; j++)
+      ea[i] = b[j] * N + j;
+  }
+
+  // Usual case, emit as 'target teams distribute parallel for'
+  #pragma omp target teams loop
+  for (i=0; i < N; i++) {
+    for (int j=0; j < N; j++)
+      a[i] = b[j] * N + j;
+  }
+
+  for (i=0; i<N; i++)
+    if (a[i] != ea[i] ) {
+      fail++;
+      printf("'target teams loop' as 'distribute parallel for'\n");
+      printf("  a[%d]=%d, expected ea[%d]=%d\n", i, a[i], i, ea[i]);
+      break;
+    }
+
+  for (i=0; i<N; i++) {
+    a[i]=0;
+  }
+
+  // Emit 'target teams distribute' due to 'loop bind(parallel)'
+  #pragma omp target teams loop
+  for (i=0; i < N; i++) {
+    #pragma omp loop bind(parallel)
+    for (int j=0; j < N; j++)
+      a[i] = b[j] * N + j;
+  }
+
+  for (i=0; i<N; i++)
+    if (a[i] != ea[i] ) {
+      fail++;
+      printf("'target teams loop' as 'distribute': loop bind(parallel)\n");
+      printf("  a[%d]=%d, expected ea[%d]=%d\n", i, a[i], i, ea[i]);
+      break;
+    }
+
+  for (i=0; i<N; i++) {
+    a[i]=0;
+  }
+
+  // Emit 'target teams distribute' due to function call.
+  #pragma omp target teams loop
+  for (i=0; i < N; i++) {
+    for (int j=0; j < N; j++) {
+      foo(i);
+      a[i] = b[j] * N + j;
+    }
+  }
+
+  for (i=0; i<N; i++)
+    if (a[i] != ea[i] ) {
+      fail++;
+      printf("'target teams loop' as 'distribute': function call\n");
+      printf("  a[%d]=%d, expected ea[%d]=%d\n", i, a[i], i, ea[i]);
+      break;
+    }
+
+  for (i=0; i<N; i++) {
+    a[i]=0;
+  }
+
+  int nt = 0;
+  // Compute expected results with equivalent combined directive.
+  #pragma omp target teams distribute num_teams(32)
+  for (i=0; i < N; i++) {
+    if (!nt) nt = omp_get_num_teams();
+    for (int j=0; j < N; j++)
+      ea[j] = b[j] * N + nt;
+  }
+
+  nt = 0;
+  // Emit 'target teams distribute' due to OpenMP API call.
+  #pragma omp target teams loop num_teams(32)
+  for (i=0; i < N; i++) {
+    if (!nt) nt = omp_get_num_teams();
+    for (int j=0; j < N; j++)
+      a[j] = b[j] * N + nt;
+  }
+
+  for (i=0; i<N; i++)
+    if (a[i] != ea[i] ) {
+      fail++;
+      printf("'target teams loop' as 'distribute': OpenMP API function call\n");
+      printf("  a[%d]=%d, expected ea[%d]=%d\n", i, a[i], i, ea[i]);
+      break;
+    }
+
+  if (!fail)
+    printf("Success\n");
+  return fail;
+}
+/// CHECK: DEVID:  0 SGN:5 ConstWGSize:256  args: 5 teamsXthrds:(  40X 256)
+/// CHECK: DEVID:  0 SGN:5 ConstWGSize:256  args: 5 teamsXthrds:(  40X 256)
+/// CHECK: DEVID:  0 SGN:5 ConstWGSize:256  args: 5 teamsXthrds:(  40X 256)
+/// CHECK: DEVID:  0 SGN:3 ConstWGSize:257  args: 5 teamsXthrds:( 624X 256)
+/// CHECK: DEVID:  0 SGN:3 ConstWGSize:257  args: 6 teamsXthrds:(  32X 256)
+/// CHECK: DEVID:  0 SGN:3 ConstWGSize:257  args: 6 teamsXthrds:(  32X 256)
+/// CHECK: Success

--- a/test/smoke-fails/loop-dir-10/loop_dir_10.compile.expected
+++ b/test/smoke-fails/loop-dir-10/loop_dir_10.compile.expected
@@ -1,0 +1,6 @@
+target-teams-loop-codegen as parallel for: HOST: loop_dir_10.c: 30
+target-teams-loop-codegen as distribute: HOST: loop_dir_10.c: 49
+target-teams-loop-codegen as distribute: HOST: loop_dir_10.c: 69
+target-teams-loop-codegen as distribute: HOST: loop_dir_10.c: 100
+target-teams-loop-codegen as distribute: DEVICE: loop_dir_10.c: 69
+target-teams-loop-codegen as distribute: DEVICE: loop_dir_10.c: 100


### PR DESCRIPTION
Verify that 'target teams loop' is emitted as
    'target teams distribute parallel for'
or
    'target teams distribute'

depending on the contents of the associated loop-nest. By default, it is emitted as 'target teams distribute parallel for' unless the loop-nest contains:
  1) a #loop bind(parallel)
  2) generic function call
  3) call to OpenMP API function
Otherwise, it's emitted as 'target teams distributef'