### PR TITLE
Add a few map related tests

### DIFF
--- a/test/smoke-fort-fails/declare-target-and-explicit-map/Makefile
+++ b/test/smoke-fort-fails/declare-target-and-explicit-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/declare-target-and-explicit-map/main.f95
+++ b/test/smoke-fort-fails/declare-target-and-explicit-map/main.f95
@@ -1,0 +1,16 @@
+module test_0
+    INTEGER :: sp = 1
+!$omp declare target link(sp)
+end module test_0
+
+program main
+use test_0
+integer :: new_len 
+
+!$omp target map(tofrom:new_len) map(tofrom:sp)
+    new_len = sp
+!$omp end target
+
+    PRINT *, new_len
+    PRINT *, sp
+end program

--- a/test/smoke-fort-fails/declare-target-and-implicit-and-explicit-map/Makefile
+++ b/test/smoke-fort-fails/declare-target-and-implicit-and-explicit-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/declare-target-and-implicit-and-explicit-map/main.f95
+++ b/test/smoke-fort-fails/declare-target-and-implicit-and-explicit-map/main.f95
@@ -1,0 +1,37 @@
+module test_0
+        implicit none
+        integer :: decltar_v = 5
+    !$omp declare target link(decltar_v)
+end module test_0
+program main  
+        integer :: hostArray(10), errors = 0  
+        do i = 1, 10    
+                hostArray(i) = 0  
+        end do  
+        call writeIndex(hostArray, 10)
+        do i = 1, 10    
+                if ( hostArray(i) /= i ) then
+                        errors = errors + 1    
+                end if  
+        end do  
+        if ( errors /= 0 ) then
+                stop 1  
+        end if
+        print*, "======= FORTRAN Test passed! ======="
+!       stop 0
+end program main
+subroutine writeIndex(int_array, array_length)
+        use test_0
+        integer :: int_array(*)
+        integer :: array_length  
+        integer :: new_len
+        integer :: v = 5 ! global, when given value like this
+        ! v = 5 ! local, when given value like this 
+!$omp target map(tofrom:new_len) map(tofrom:decltar_v)
+        new_len = decltar_v + v 
+!$omp end target
+        print*, new_len
+        do index_ = 1, new_len 
+                int_array(index_) = index_  
+        end do
+end subroutine writeIndex

--- a/test/smoke-fort-fails/declare-target-link-1/Makefile
+++ b/test/smoke-fort-fails/declare-target-link-1/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/declare-target-link-1/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-1/main.f95
@@ -1,0 +1,27 @@
+module test_0
+    implicit none
+    INTEGER :: sp(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    !$omp declare target link(sp)
+end module test_0
+
+! Work-around for print being weirdly captured by the kernel
+! when placed after the target region
+subroutine print_test(x)
+integer, intent(in), dimension(10) :: x
+integer i
+do i = 1, 10
+     PRINT *, x(i)
+end do
+end subroutine
+
+program main
+    use test_0
+!$omp target map(from:sp)
+    do i = 1, 10
+        sp(i) = i;
+    end do
+!$omp end target
+
+call print_test(sp)
+
+end program

--- a/test/smoke-fort-fails/declare-target-link-2/Makefile
+++ b/test/smoke-fort-fails/declare-target-link-2/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/declare-target-link-2/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-2/main.f95
@@ -1,0 +1,15 @@
+module test_0
+    implicit none
+    INTEGER :: sp = 0
+!$omp declare target link(sp)
+end module test_0
+
+program main
+    use test_0
+!$omp target map(tofrom:sp)
+    sp = 1
+!$omp end target
+
+PRINT *, sp
+
+end program

--- a/test/smoke-fort-fails/declare-target-link-3/Makefile
+++ b/test/smoke-fort-fails/declare-target-link-3/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/declare-target-link-3/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-3/main.f95
@@ -1,0 +1,33 @@
+module test_0
+    implicit none
+    INTEGER :: sp(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    !$omp declare target link(sp)
+end module test_0
+
+! Work-around for print being weirdly captured by the kernel
+! when placed after the target region
+subroutine print_test(x)
+integer, intent(in), dimension(10) :: x
+integer i
+do i = 1, 10
+     PRINT *, x(i)
+end do
+end subroutine
+
+program main
+    use test_0
+!$omp target map(tofrom:sp)
+    do i = 1, 10
+        sp(i) = i;
+    end do
+!$omp end target
+
+!$omp target map(tofrom:sp)
+    do i = 1, 10
+        sp(i) = sp(i) + i;
+    end do
+!$omp end target
+    
+call print_test(sp)
+
+end program


### PR DESCRIPTION
These are some tests that I've managed to get working locally via https://github.com/ROCm-Developer-Tools/llvm-project/pull/217 which is a patch that builds on top of milestone-1 primarily to add declare target link support for some simple int and array of int data (although it can likely work with other types, but unsure how far it extends into fortran allocatables and more complex types), but it also has a little look into implicit and explicit map, although they both have a long ways to go before these components are ready for an ATD merge or upstream debut, just some preliminary looks into what's needed to support it in their case. 

I am unsure if this is how these tests are supposed to be implemented so please do mention if I am missing something in the Makefile or if a specific return type or message is required on success.  