### PR TITLE
Add tests for VLAs in offloaded OpenMP regions.

### DIFF
--- a/test/smoke-fails/vla-in-parallel-for-1/Makefile
+++ b/test/smoke-fails/vla-in-parallel-for-1/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN       = $(AOMP)/bin/$(CLANG)
+CC            = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS    += -O0
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/vla-in-parallel-for-1/test.c
+++ b/test/smoke-fails/vla-in-parallel-for-1/test.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 1;
+  int M = 10;
+
+  double a[M*N];
+  double a_ref[M*N];
+  double b[M*N];
+
+  for (int i=0; i<M*N; i++) {
+    a[i] = 0;
+    b[i] = 10 + i;
+  }
+
+  // HOST calculation of a_ref:
+  for(int i=0; i<M*N; i++) {
+    int NN = 2;
+    double A[NN];
+    double red_A = 0.0;
+    // double value = b[i];
+    a_ref[i] = 0;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = b[i] + k;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a_ref[i] += red_A;
+  }
+
+  // DEVICE calculation of a:
+  #pragma omp target teams distribute parallel for map(to:b[:M*N]) map(from:a[:M*N])
+  for(int i=0; i<M*N; i++) {
+    int NN = 2;
+    double A[NN];
+    double red_A = 0.0;
+    // double value = b[i];
+    a[i] = 0;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = b[i] + k;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a[i] += red_A;
+  }
+
+  // Compare host and device results:
+  for (int i=0; i<M*N; i++) {
+    if (a_ref[i] != a[i] ) {
+      printf("Wrong value: a[%d] = %f a_ref[%d] = %f\n", i, a[i], i, a_ref[i]);
+      return 1;
+    }
+  }
+
+  printf("Success\n");
+  return 0;
+}

--- a/test/smoke-fails/vla-in-parallel-for/Makefile
+++ b/test/smoke-fails/vla-in-parallel-for/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN       = $(AOMP)/bin/$(CLANG)
+CC            = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS    += -O3 
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/vla-in-parallel-for/test.c
+++ b/test/smoke-fails/vla-in-parallel-for/test.c
@@ -1,0 +1,67 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+  int M = 10;
+
+  double a[M*N];
+  double a_ref[M*N];
+  double b[M*N];
+
+  for (int i=0; i<M*N; i++) {
+    a[i] = 0;
+    b[i] = i;
+  }
+
+  // HOST calculation of a_ref:
+  int NN = 10;
+  double A[NN];
+  for(int i=0; i<M*N; i++) {
+    double red_A = 0.0;
+    double value = b[i];
+    a_ref[i] = value;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = k;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a_ref[i] += red_A;
+  }
+
+  // DEVICE calculation of a:
+  #pragma omp target teams distribute parallel for map(to:b[:M*N]) map(from:a[:M*N])
+  for(int i=0; i<M*N; i++) {
+    int NN = 10;
+    double A[NN];
+    double red_A = 0.0;
+    double value = b[i];
+    a[i] = value;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = k;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a[i] += red_A;
+  }
+
+  // Compare host and device results:
+  for (int i=0; i<M*N; i++) {
+    if (a_ref[i] != a[i] ) {
+      printf("Wrong value: a[%d] = %f\n", i, a[i]);
+      return 1;
+    }
+  }
+
+  printf("Success\n");
+  return 0;
+}

--- a/test/smoke-fails/vla-in-teams-distribute-1/Makefile
+++ b/test/smoke-fails/vla-in-teams-distribute-1/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN       = $(AOMP)/bin/$(CLANG)
+CC            = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS    += -O0 
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/vla-in-teams-distribute-1/test.c
+++ b/test/smoke-fails/vla-in-teams-distribute-1/test.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+  int M = 10;
+
+  double a[M*N];
+  double a_ref[M*N];
+  double b[M*N];
+
+  for (int i=0; i<M*N; i++) {
+    a[i] = 0;
+    b[i] = i;
+  }
+
+  // HOST calculation of a_ref:
+  int NN = 10;
+  double A[NN];
+  for(int i=0; i<M*N; i++) {
+    double red_A = 0.0;
+    double value = b[i];
+    a_ref[i] = value;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = k;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a_ref[i] += red_A;
+  }
+
+  #pragma omp target map(to:b[:M*N]) map(from:a[:M*N])
+  {
+    int NN = 10;
+    double A[NN];
+    for(int i=0; i<M*N; i++) {
+      double red_A = 0.0;
+      double value = b[i];
+      a[i] = value;
+
+      for (int k=0; k<NN; k++) {
+        A[k] = k;
+      }
+
+      for(int k=0; k<NN; k++) {
+        red_A += A[k];
+      }
+
+      a[i] += red_A;
+    }
+  }
+
+  // Compare host and device results:
+  for (int i=0; i<M*N; i++) {
+    if (a_ref[i] != a[i] ) {
+      printf("Wrong value: a[%d] = %f\n", i, a[i]);
+      return 1;
+    }
+  }
+
+  printf("Success\n");
+
+  return 0;
+}

--- a/test/smoke-fails/vla-in-teams-distribute-2/Makefile
+++ b/test/smoke-fails/vla-in-teams-distribute-2/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN       = $(AOMP)/bin/$(CLANG)
+CC            = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS    += -O3
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/vla-in-teams-distribute-2/test.c
+++ b/test/smoke-fails/vla-in-teams-distribute-2/test.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+  int M = 10;
+
+  double a[M*N];
+  double a_ref[M*N];
+  double b[M*N];
+
+  for (int i=0; i<M*N; i++) {
+    a[i] = 0;
+    a_ref[i] = 0;
+    b[i] = i;
+  }
+
+  // HOST calculation of a_ref:
+  for(int i=0; i<M*N; i++) {
+    int NN = 10;
+    double A[NN];
+    double red_A = 0.0;
+    double value = b[i];
+    a_ref[i] = i;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = value;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a_ref[i] += red_A;
+  }
+
+  // DEVICE calculation of a:
+  #pragma omp target teams distribute map(to:b[:M*N]) map(from:a[:M*N])
+  for(int i=0; i<M*N; i++) {
+    int NN = 10;
+    double A[NN];
+    double red_A = 0.0;
+    double value = b[i];
+    a[i] = i;
+
+    #pragma omp parallel for
+    for (int k=0; k<NN; k++) {
+      A[k] = value;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a[i] += red_A;
+  }
+
+  // Compare host and device results:
+  for (int i=0; i<M*N; i++) {
+    if (a_ref[i] != a[i] ) {
+      printf ("Wrong value: a[%d] = %f\n", i, a[i]);
+      return 1;
+    }
+  }
+
+  printf("Success\n");
+
+  return 0;
+}

--- a/test/smoke-fails/vla-in-teams-distribute/Makefile
+++ b/test/smoke-fails/vla-in-teams-distribute/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN       = $(AOMP)/bin/$(CLANG)
+CC            = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS    += -O0
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/vla-in-teams-distribute/test.c
+++ b/test/smoke-fails/vla-in-teams-distribute/test.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+  int M = 10;
+
+  double a[M*N];
+  double a_ref[M*N];
+  double b[M*N];
+
+  for (int i=0; i<M*N; i++) {
+    a[i] = 0;
+    a_ref[i] = 0;
+    b[i] = i;
+  }
+
+  // HOST calculation of a_ref:
+  for(int i=0; i<M*N; i++) {
+    int NN = 10;
+    double A[NN];
+    double red_A = 0.0;
+    double value = b[i];
+    a_ref[i] = i;
+
+    for (int k=0; k<NN; k++) {
+      A[k] = value;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a_ref[i] += red_A;
+  }
+
+  // DEVICE calculation of a:
+  #pragma omp target teams distribute map(to:b[:M*N]) map(from:a[:M*N])
+  for(int i=0; i<M*N; i++) {
+    int NN = 10;
+    double A[NN];
+    double red_A = 0.0;
+    double value = b[i];
+    a[i] = i;
+
+    #pragma omp parallel for
+    for (int k=0; k<NN; k++) {
+      A[k] = value;
+    }
+
+    for(int k=0; k<NN; k++) {
+      red_A += A[k];
+    }
+
+    a[i] += red_A;
+  }
+
+  // Compare host and device results:
+  for (int i=0; i<M*N; i++) {
+    if (a_ref[i] != a[i] ) {
+      printf ("Wrong value: a[%d] = %f\n", i, a[i]);
+      return 1;
+    }
+  }
+
+  printf("Success\n");
+
+  return 0;
+}


### PR DESCRIPTION
Add tests for VLAs in offloaded OpenMP regions.

Adding tests for VLA in target regions.

I am adding 5 tests:
- 3 (all vla-in-teams-distribute tests) will pass when this patch lands: https://reviews.llvm.org/D153883
- vla-in-parallel-for will pass due to the use of -O3
- vla-in-parallel-for-1 will fail in the backend because it uses -O0 and the calls to stacksave are not optimized out. This test exposes a backend bug which needs to be handled separately.