### PR TITLE
Changes driver example

### DIFF
--- a/examples/openmp/driver_tests/emit_llvm_S.sh
+++ b/examples/openmp/driver_tests/emit_llvm_S.sh
@@ -38,7 +38,7 @@ if [  -z $gpu ]; then
   echo "$gpu"
 fi
 
-targetoptions="-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$gpu"
+targetoptions="-fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$gpu --no-offload-new-driver"
 RC=0
 
 cmd="$AOMP/bin/clang $tmpcfile -fopenmp -emit-llvm -S"


### PR DESCRIPTION
Adds flag to driver example so that it doesn't get checked for new driver. The new driver doesn't produce a bundled output for host and device as the old driver did using the offload-bundler.