### PR TITLE
Add new tests and tweak old to emit error/success messages at runtime

### DIFF
--- a/test/smoke-fort-fails/1D-full-bounds-exp-map/Makefile
+++ b/test/smoke-fort-fails/1D-full-bounds-exp-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/1D-full-bounds-exp-map/main.f95
+++ b/test/smoke-fort-fails/1D-full-bounds-exp-map/main.f95
@@ -1,0 +1,19 @@
+program main
+  INTEGER :: sp_write(10) = (/0,0,0,0,0,0,0,0,0,0/)
+
+  !$omp target map(tofrom:sp_write(1:10))
+      do index = 1, 10
+          sp_write(index) = index
+      end do
+  !$omp end target
+
+  do i = 1, 10
+      if (sp_write(i) /= i) then
+          print*, "======= FORTRAN Test Failed! ======="
+          stop 1    
+      end if  
+  end do 
+
+  print*, "======= FORTRAN Test passed! ======="
+  
+end program

--- a/test/smoke-fort-fails/1D-partial-bounds-exp-map/Makefile
+++ b/test/smoke-fort-fails/1D-partial-bounds-exp-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/1D-partial-bounds-exp-map/main.f95
+++ b/test/smoke-fort-fails/1D-partial-bounds-exp-map/main.f95
@@ -1,0 +1,32 @@
+program main
+  INTEGER :: sp_read(10) = (/1,2,3,4,5,6,7,8,9,10/)
+  INTEGER :: sp_write(10) = (/0,0,0,0,0,0,0,0,0,0/)
+
+  !$omp target map(tofrom:sp_read(2:5)) map(tofrom:sp_write(2:5))
+      do i = 2, 5
+          sp_write(i) = sp_read(i)
+      end do
+  !$omp end target
+
+  if (sp_write(1) /= 0) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1    
+  end if  
+
+  do i = 2, 5
+      if (sp_write(i) /= i) then
+          print*, "======= FORTRAN Test Failed! ======="
+          stop 1    
+      end if  
+  end do 
+      
+  do i = 6, 10
+      if (sp_write(i) /= 0) then
+          print*, "======= FORTRAN Test Failed! ======="
+          stop 1    
+      end if  
+  end do 
+
+  print*, "======= FORTRAN Test passed! ======="
+  
+end program

--- a/test/smoke-fort-fails/bycopy-implicit-map/Makefile
+++ b/test/smoke-fort-fails/bycopy-implicit-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/bycopy-implicit-map/main.f95
+++ b/test/smoke-fort-fails/bycopy-implicit-map/main.f95
@@ -1,0 +1,20 @@
+program main
+  REAL :: inc_r = 0.5
+  REAL :: inc_w = 0.5
+  !$omp target map(tofrom:inc_w)
+      inc_w = inc_r + inc_w
+      inc_r = 15
+  !$omp end target    
+  
+PRINT *, inc_r ! should return 0.5/.5 the fortran equivelant, it's a bycopy with no map
+PRINT *, inc_w ! should return 1.0/1. the fortran equivelant, it's a byref with a map
+
+
+if (inc_r /= 0.5 .OR. inc_w /= 1.0) then     
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1    
+end if  
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/smoke-fort-fails/declare-target-and-explicit-map/main.f95
+++ b/test/smoke-fort-fails/declare-target-and-explicit-map/main.f95
@@ -13,4 +13,12 @@ integer :: new_len
 
     PRINT *, new_len
     PRINT *, sp
+
+if (sp /= new_len) then     
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1    
+end if  
+
+print*, "======= FORTRAN Test passed! ======="
+
 end program

--- a/test/smoke-fort-fails/declare-target-link-1/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-1/main.f95
@@ -24,4 +24,13 @@ program main
 
 call print_test(sp)
 
+do i = 1, 10
+    if (sp(i) /= i) then
+        print*, "======= FORTRAN Test Failed! ======="     
+        stop 1    
+    end if  
+end do 
+
+print*, "======= FORTRAN Test passed! ======="
+
 end program

--- a/test/smoke-fort-fails/declare-target-link-2/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-2/main.f95
@@ -12,4 +12,11 @@ program main
 
 PRINT *, sp
 
+if (sp /= 1) then     
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1    
+end if  
+
+print*, "======= FORTRAN Test passed! ======="
+
 end program

--- a/test/smoke-fort-fails/declare-target-link-3/main.f95
+++ b/test/smoke-fort-fails/declare-target-link-3/main.f95
@@ -30,4 +30,13 @@ program main
     
 call print_test(sp)
 
+do i = 1, 10
+    if (sp(i) /= i * 2) then
+        print*, "======= FORTRAN Test Failed! ======="     
+        stop 1    
+    end if  
+end do 
+
+print*, "======= FORTRAN Test passed! ======="
+
 end program

--- a/test/smoke-fort-fails/exp-real-map/Makefile
+++ b/test/smoke-fort-fails/exp-real-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/exp-real-map/main.f95
+++ b/test/smoke-fort-fails/exp-real-map/main.f95
@@ -1,0 +1,29 @@
+subroutine print_test(x)
+  real, intent(in), dimension(10) :: x
+  integer i
+  do i = 1, 10
+    PRINT *, x(i)
+  end do
+end subroutine
+        
+program main
+  REAL :: sp(10) = (/0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5/)
+
+!$omp target map(tofrom:sp)
+  do i = 1, 10
+    sp(i) = sp(i) + i
+  end do
+!$omp end target
+
+call print_test(sp)
+
+do i = 1, 10
+  if (sp(i) /= i + 0.5) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1    
+  end if  
+end do 
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program 

--- a/test/smoke-fort-fails/single-value-map/Makefile
+++ b/test/smoke-fort-fails/single-value-map/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/single-value-map/main.f95
+++ b/test/smoke-fort-fails/single-value-map/main.f95
@@ -1,0 +1,34 @@
+program main  
+  integer :: hostArray(10), errors = 0  
+  do i = 1, 10    
+          hostArray(i) = 0  
+  end do  
+  call writeIndex(hostArray, 10)
+  do i = 1, 10    
+          if ( hostArray(i) /= i ) then
+                  errors = errors + 1    
+          end if  
+  end do  
+  if ( errors /= 0 ) then
+          stop 1  
+  end if
+  print*, "======= FORTRAN Test passed! ======="
+!       stop 0
+end program main
+subroutine writeIndex(int_array, array_length)
+  integer :: int_array(*)
+  integer :: array_length  
+  integer :: new_len
+  integer :: v
+! Setting the value when defining the interface, apparently makes the integer
+! a global, so to mimic the cpp example, this has to be set here... but it 
+! currently also works if asigned above, just not the same semantics as in C++
+ v = 10
+!$omp target map(from:new_len)
+  new_len = v
+!$omp end target
+  print*, new_len
+  do index_ = 1, new_len 
+          int_array(index_) = index_  
+  end do
+end subroutine writeIndex


### PR DESCRIPTION
Adding a few new map related flang-new tests to the fails, which pass on amd-trunk-dev with the addition of PR: https://github.com/ROCm-Developer-Tools/llvm-project/pull/217 currently. The PR will be upstreamed over time and these tests will eventually be able to be moved to pass.  