### PR TITLE
[smoke-fails] Update loop-dir-2. Use bind clause when 'loop' not nested.

### DIFF
--- a/test/smoke-fails/loop-dir-2/loop_dir_2.c
+++ b/test/smoke-fails/loop-dir-2/loop_dir_2.c
@@ -6,7 +6,10 @@ int main() {
   int sum = 0;
   int fail = 0;
 
-  #pragma omp loop reduction(+:sum)
+  // If a loop construct is not nested inside another OpenMP construct then
+  // the bind clause must be present. The following 'loop' directive is
+  // equivalent to a 'for' (a worksharing-loop).
+  #pragma omp loop reduction(+:sum) bind(parallel)
   for(k=0; k<10; k++) {
     sum += k;
   }


### PR DESCRIPTION
Recent patch (correctly) requres a 'loop' directive that isn't nested inside a teams or parallel region to have a bind clause.