### PR TITLE
[Smoke] Fix testing for target region printing

### DIFF
--- a/test/smoke/flang-f90print/Makefile
+++ b/test/smoke/flang-f90print/Makefile
@@ -12,3 +12,5 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
+run: $(TESTNAME)
+	./$(TESTNAME) 2>&1 | grep -q 'f90print inside target region' && echo 'Success' || (echo 'Failure' && false)

--- a/test/smoke/flang-f90print/flang-f90print.f90
+++ b/test/smoke/flang-f90print/flang-f90print.f90
@@ -3,7 +3,8 @@ program test
     use f90deviceio
     write(0, *) "Before target "
     !$omp target
-       call f90print("In tagret ")
+       call f90print("f90print inside target region")
+       !if the above line is not printed then the test has failed
     !$omp end target
     write(0,*) "After target "
 end program test


### PR DESCRIPTION
`make run` now checks if the desired message `f90print inside target region` has been printed or not.