### PR TITLE
Add flag for busy queue tracking to 'hsa-lazy-queues' smoke test

### DIFF
--- a/test/smoke/hsa-lazy-queues/Makefile
+++ b/test/smoke/hsa-lazy-queues/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 RUNCMD      = --hsa-trace ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
-RUNENV      = OMP_NUM_THREADS=2
+RUNENV      = OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)


### PR DESCRIPTION
This is necessary to keep this test passing while changing the default for LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING to 'false'. hsa-lazy-queues requires this to be 'true'.