### PR TITLE
Remove use of legacy --fopenmp-targets specification from Makefile fo…

### DIFF
--- a/test/smoke-fails/clang-383246/Makefile
+++ b/test/smoke-fails/clang-383246/Makefile
@@ -8,7 +8,6 @@ RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 
 $(info $(AOMP))
 
-CFLAGS       += -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)


### PR DESCRIPTION
…r clang-383246

With move  to --offload-arch as default in Makefile defs caused error  without given specification of -march. Removes legacy options as not required  explicitly for the test