### PR TITLE
Update manifests/build for ROCm 5.7 sources.

### DIFF
--- a/bin/build_rocprofiler.sh
+++ b/bin/build_rocprofiler.sh
@@ -91,6 +91,7 @@ echo
 echo " -----Running make for rocprofiler ---- " 
 echo make -j $AOMP_JOB_THREADS
 make -j $AOMP_JOB_THREADS
+make -j $AOMP_JOB_THREADS mytest
 if [ $? != 0 ] ; then 
       echo " "
       echo "ERROR: make -j $AOMP_JOB_THREADS  FAILED"

--- a/bin/patches/rocprofiler-no-aql-ok.patch
+++ b/bin/patches/rocprofiler-no-aql-ok.patch
@@ -1,44 +1,39 @@
 diff --git a/cmake_modules/env.cmake b/cmake_modules/env.cmake
-index 6647578..f36498b 100644
+index 5841277..70220e9 100644
 --- a/cmake_modules/env.cmake
 +++ b/cmake_modules/env.cmake
-@@ -75,5 +75,5 @@ endif ()
- 
- find_library ( FIND_AQL_PROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_INSTALL_PREFIX} PATHS ${ROCM_ROOT_DIR})
- if (  NOT FIND_AQL_PROFILE_LIB )
--  message ( FATAL_ERROR "AQL_PROFILE not installed. Please install AQL_PROFILE" )
-+  message (WARNING "AQL_PROFILE not installed. Please install AQL_PROFILE" )
+@@ -88,7 +88,7 @@ find_library(
+     FIND_AQL_PROFILE_LIB "libhsa-amd-aqlprofile64.so"
+     HINTS ${CMAKE_PREFIX_PATH}
+     PATHS ${ROCM_ROOT_DIR}
+-    PATH_SUFFIXES lib REQUIRED)
++    PATH_SUFFIXES lib)
+ if(NOT FIND_AQL_PROFILE_LIB)
+     message("AQL_PROFILE not installed. Please install AQL_PROFILE")
  endif()
 diff --git a/src/api/CMakeLists.txt b/src/api/CMakeLists.txt
-index 822ee41..0794266 100644
+index 574b77f..a152c71 100644
 --- a/src/api/CMakeLists.txt
 +++ b/src/api/CMakeLists.txt
-@@ -40,7 +40,7 @@ get_filename_component(HSA_RUNTIME_INC_PATH ${HSA_H} DIRECTORY)
- find_library(AQLPROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_PREFIX_PATH} PATHS ${ROCM_PATH} PATH_SUFFIXES lib)
+@@ -56,7 +56,7 @@ find_library(
+     PATH_SUFFIXES lib)
  
  if(NOT AQLPROFILE_LIB)
--  message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
-+	message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
+-    message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
++    message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
  endif()
  
- # ############################################################################################################################################
+ # ########################################################################################
 diff --git a/src/tools/rocprofv2/CMakeLists.txt b/src/tools/rocprofv2/CMakeLists.txt
-index b2dc968..fe64dcb 100644
+index 8693bf3..f05e519 100644
 --- a/src/tools/rocprofv2/CMakeLists.txt
 +++ b/src/tools/rocprofv2/CMakeLists.txt
-@@ -6,7 +6,7 @@ get_property(HSA_RUNTIME_INCLUDE_DIRECTORIES TARGET hsa-runtime64::hsa-runtime64
- 
- find_library(AQLPROFILE_LIB "libhsa-amd-aqlprofile64.so" HINTS ${CMAKE_PREFIX_PATH} PATHS ${ROCM_PATH} PATH_SUFFIXES lib)
+@@ -13,7 +13,7 @@ find_library(
+     PATHS ${ROCM_PATH}
+     PATH_SUFFIXES lib)
  if(NOT AQLPROFILE_LIB)
--  message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
-+	message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
+-    message(FATAL_ERROR "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
++    message(WARNING "AQL_PROFILE not installed. Please install hsa-amd-aqlprofile!")
  endif()
  
  file(GLOB ROCPROFV2_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-@@ -26,4 +26,4 @@ target_include_directories(rocprofv2
- target_link_libraries(rocprofv2 PRIVATE ${AQLPROFILE_LIB} hsa-runtime64::hsa-runtime64 stdc++fs Threads::Threads atomic -ldl)
- # install(TARGETS rocprofv2 RUNTIME
- #   DESTINATION ${CMAKE_INSTALL_BINDIR}
--#   COMPONENT runtime)
-\ No newline at end of file
-+#   COMPONENT runtime)

--- a/manifests/aomp_18.0.xml
+++ b/manifests/aomp_18.0.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.6 release branches of external repositories -->
+	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.7 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-5.6" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-5.7" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roctools"  fetch="https://github.com/ROCm-Developer-Tools/" />
     <remote name="roc"  fetch="https://github.com/RadeonOpenCompute/" />
     <remote name="rocsw"  fetch="https://github.com/ROCmSoftwarePlatform/" />
 
-<!-- These first 6 repos are NOT rocm 5.6 -->
+<!-- These first 6 repos are NOT rocm 5.7 -->
 <project remote="roc" path="llvm-project" name="llvm-project"    revision="amd-stg-open" groups="unlocked" />
 
 <project remote="roctools" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.6" groups="unlocked" />
-<project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="roct-thunk-interface" name="ROCT-Thunk-Interface" revision="rocm-5.6.x" groups="unlocked" />
-<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.6" groups="unlocked" />
+<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.7" groups="unlocked" />
+<project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="roct-thunk-interface" name="ROCT-Thunk-Interface" revision="rocm-5.7.x" groups="unlocked" />
+<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.7" groups="unlocked" />
 </manifest>

--- a/manifests/aomp_new_18.0.xml
+++ b/manifests/aomp_new_18.0.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.6 release branches of external repositories -->
+	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.7 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-5.6" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-5.7" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roctools"  fetch="https://github.com/ROCm-Developer-Tools/" />
     <remote name="roc"  fetch="https://github.com/RadeonOpenCompute/" />
     <remote name="rocsw"  fetch="https://github.com/ROCmSoftwarePlatform/" />
 
-<!-- These first 6 repos are NOT rocm 5.6 -->
+<!-- These first 6 repos are NOT rocm 5.7 -->
 <project remote="roc" path="llvm-project" name="llvm-project"    revision="amd-stg-open" groups="unlocked" />
 
 <project remote="roctools" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.6" groups="unlocked" />
-<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.6" groups="unlocked" />
+<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.7" groups="unlocked" />
+<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.7" groups="unlocked" />
 <project remote="gerritgit" name="hsa/ec/hsa-runtime" path="hsa-runtime" revision="bdecf27cfd17a5829ce823eefd52b0574f48fa4e" upstream="amd-master" groups="unlocked" />
 <project remote="gerritgit" name="compute/ec/libhsakmt" path="roct-thunk-interface" revision="c0212c95e89d25a28f44608d3ae961ba1c78fe40" upstream="amd-mainline" groups="unlocked" />
 </manifest>

--- a/manifests/aompi_18.0.xml
+++ b/manifests/aompi_18.0.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- Manifest for AOMP 18.0-x which uses ROCM 5.6 release branches of external repositories -->
+  <!-- Manifest for AOMP 18.0-x which uses ROCM 5.7 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-5.6" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-5.7" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roctools"  fetch="https://github.com/ROCm-Developer-Tools/" />
     <remote name="roc"  fetch="https://github.com/RadeonOpenCompute/" />
     <remote name="rocsw"  fetch="https://github.com/ROCmSoftwarePlatform/" />
 
-<!-- These first 6 repos are NOT rocm 5.6 -->
+<!-- These first 6 repos are NOT rocm 5.7 -->
     <project remote="gerritgit" path="llvm-project" name="lightning/ec/llvm-project" revision="amd-stg-open" groups="unlocked" />
 
     <project remote="roctools" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roctools" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
     <project remote="roctools" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-    <project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roctools" path="clr" name="clr"                        revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.6" groups="unlocked" />
-    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="roc" path="roct-thunk-interface" name="ROCT-Thunk-Interface" revision="rocm-5.6.x" groups="unlocked" />
-    <project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.6" groups="unlocked" />
+    <project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roctools" path="clr" name="clr"                        revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.7" groups="unlocked" />
+    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="roc" path="roct-thunk-interface" name="ROCT-Thunk-Interface" revision="rocm-5.7.x" groups="unlocked" />
+    <project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.7" groups="unlocked" />
 </manifest>

--- a/manifests/aompi_new_18.0.xml
+++ b/manifests/aompi_new_18.0.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.6 release branches of external repositories -->
+	<!-- Manifest for AOMP 18.0-x which uses ROCM 5.7 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-5.6" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-5.7" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roctools"  fetch="https://github.com/ROCm-Developer-Tools/" />
     <remote name="roc"  fetch="https://github.com/RadeonOpenCompute/" />
     <remote name="rocsw"  fetch="https://github.com/ROCmSoftwarePlatform/" />
 
-<!-- These first 6 repos are NOT rocm 5.6 -->
+<!-- These first 6 repos are NOT rocm 5.7 -->
 <project remote="gerritgit" path="llvm-project" name="lightning/ec/llvm-project" revision="amd-stg-open" groups="unlocked" />
 
 <project remote="roctools" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
 <project remote="roctools" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.6.x" groups="unlocked" />
-<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.6" groups="unlocked" />
-<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.6" groups="unlocked" />
+<project remote="roctools" path="rocprofiler" name="rocprofiler"              revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="roctracer" name="roctracer"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCdbgapi" name="ROCdbgapi"                  revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="ROCgdb" name="ROCgdb"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="hip"    name="hip"                           revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roctools" path="clr" name="clr"                        revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocminfo" name="rocminfo"                         revision="rocm-5.7.x" groups="unlocked" />
+<project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-5.7" groups="unlocked" />
+<project remote="rocsw" path="hipfort" name="hipfort"                 revision="release/rocm-rel-5.7" groups="unlocked" />
 <project remote="gerritgit" name="hsa/ec/hsa-runtime" path="hsa-runtime" revision="bdecf27cfd17a5829ce823eefd52b0574f48fa4e" upstream="amd-master" groups="unlocked" />
 <project remote="gerritgit" name="compute/ec/libhsakmt" path="roct-thunk-interface" revision="c0212c95e89d25a28f44608d3ae961ba1c78fe40" upstream="amd-mainline" groups="unlocked" />
 </manifest>


### PR DESCRIPTION
Updated build_rocprofiler.sh to build the tests
to avoid missing file error on install step.

Updated rocprofiler-no-aql-patch.

Updated manifests with 5.7 branches.