### PR TITLE
Update supported list of GPUs for targetid_multi_image test

### DIFF
--- a/test/smoke/targetid_multi_image/Makefile
+++ b/test/smoke/targetid_multi_image/Makefile
@@ -10,7 +10,7 @@ CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-UNSUPPORTED  = gfx1030,gfx1031,gfx1032,gfx1033,gfx1034,gfx1035,gfx1036,gfx1100,gfx1101,gfx1102,gfx1103,gfx1150,gfx1151
+SUPPORTED  = gfx90a,gfx90c,gfx940,gfx941,gfx942,gfx1010,gfx1011,gfx1012,gfx1013
 
 HSA_XNACK ?= 1
 RUNCMD       = HSA_XNACK=$(HSA_XNACK) ./$(TESTNAME) && HSA_XNACK=0 ./$(TESTNAME) && strings $(TESTNAME) |grep -i gfx


### PR DESCRIPTION
Run this test only on GPUs which support toggling XNACK feature on per process basis using HSA_XNACK environment variable.