### PR TITLE
[silo] Update with new wget location/compression

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -262,8 +262,10 @@ function buildsilo(){
   fi
   runcmd "mkdir -p $_builddir"
   runcmd "cd $_builddir"
-  runcmd "wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-$_version.tgz"
-  runcmd "tar -xzf silo-$_version.tgz"
+  # runcmd "wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-$_version.tgz"
+  # runcmd "tar -xzf silo-$_version.tgz"
+  runcmd "wget https://software.llnl.gov/Silo/ghpages/releases/silo-$_version.tar.xz"
+  runcmd "tar -x --xz -f silo-$_version.tar.xz"
   runcmd "cd silo-$_version"
   if [ -d $_installdir ] ; then 
     runcmd "rm -rf $_installdir"


### PR DESCRIPTION
New CI test systems were unable to build silo as it moved.  Updated with new location, same version.  There are newer 4.11 & 4.11.1 available if we want to move forward.