### PR TITLE
[Openmp] OMPTest version of veccopy test

### DIFF
--- a/test/smoke-fails/veccopy-ompTest/Makefile
+++ b/test/smoke-fails/veccopy-ompTest/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy
+TESTSRC_MAIN = veccopy.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) -I$(AOMP_REPOS)/llvm-project/openmp/libomptarget/test/ompTest/include -L$(AOMP_REPOS)/build/openmp/libomptarget -lomptest
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fails/veccopy-ompTest/veccopy.cpp
+++ b/test/smoke-fails/veccopy-ompTest/veccopy.cpp
@@ -1,0 +1,53 @@
+#include <stdio.h>
+
+#include "OmptTester.h"
+
+OMPTTESTCASE(InitialSuite, veccopy) {
+  int N = 10;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+  
+  SequenceAsserter.insert(omptest::OmptAssertEvent::Target("User Target"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetSubmit("User Target Submit"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong varlue: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+}
+
+int main(int argc, char **argv) {
+  Runner R;
+  R.run();
+
+  return 0;
+}


### PR DESCRIPTION
This is a initial smoke-fails test to include the omptest library for the actual unit testint. It is crude in that it uses hard-coded paths to find the library's includes.