### PR TITLE
move prereq components to 5.7 sources

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -170,7 +170,7 @@ function buildninja(){
 
 function buildaqlprofile(){
   _cname="aqlprofile"
-  _version=5.6
+  _version=5.7
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname
@@ -187,19 +187,21 @@ function buildaqlprofile(){
   runcmd "cd $_builddir"
   which dpkg 2>/dev/null
   if [ $? == 0 ] ; then
-    runcmd "wget https://repo.radeon.com/rocm/apt/5.6/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.50600-67~20.04_amd64.deb"
-    runcmd "dpkg -x hsa-amd-aqlprofile_1.0.0.50600-67~20.04_amd64.deb $_builddir"
+    # not sure if deb_version is 20 or 22
+    deb_version="22"
+    runcmd "wget https://repo.radeon.com/rocm/apt/5.7/pool/main/h/hsa-amd-aqlprofile5.7.0/hsa-amd-aqlprofile5.7.0_1.0.0.50700.50700-63~${deb_version}.04_amd64.deb"
+    runcmd "dpkg -x hsa-amd-aqlprofile5.7.0_1.0.0.50700.50700-63~${deb_version}.04_amd64.deb $_builddir"
   else
-    runcmd "wget https://repo.radeon.com/rocm/yum/5.6/main/hsa-amd-aqlprofile-1.0.0.50600-67.el7.x86_64.rpm"
-    echo "hsa-amd-aqlprofile-1.0.0.50600-67.el7.x86_64.rpm | cpio -idm"
-    rpm2cpio hsa-amd-aqlprofile-1.0.0.50600-67.el7.x86_64.rpm | cpio -idm
+    runcmd "wget https://repo.radeon.com/rocm/yum/5.7/main/hsa-amd-aqlprofile5.7.0-1.0.0.50700.50700-63.el7.x86_64.rpm"
+    echo "hsa-amd-aqlprofile5.7.0-1.0.0.50700.50700-63.el7.x86_64.rpm | cpio -idm"
+    rpm2cpio hsa-amd-aqlprofile5.7.0-1.0.0.50700.50700-63.el7.x86_64.rpm | cpio -idm
   fi
   if [ -d $_installdir ] ; then
     runcmd "rm -rf $_installdir"
   fi
   runcmd "mkdir -p $_installdir/lib"
   runcmd "cd $_installdir"
-  runcmd "cp -rp $_builddir/opt/rocm-5.6.0/lib  $_installdir"
+  runcmd "cp -rp $_builddir/opt/rocm-5.7.0/lib  $_installdir"
 
   if [ -L $_linkfrom ] ; then
     runcmd "rm $_linkfrom"
@@ -354,7 +356,7 @@ function buildcmake(){
 
 function buildrocmsmilib(){
   _cname="rocmsmilib"
-  _version=5.6.x
+  _version=5.7.x
   _installdir=$AOMP_SUPP_INSTALL/rocmsmilib-$_version
   _linkfrom=$AOMP_SUPP/rocmsmilib
   _builddir=$AOMP_SUPP_BUILD/rocmsmilib

--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -189,6 +189,8 @@ function buildaqlprofile(){
   if [ $? == 0 ] ; then
     # not sure if deb_version is 20 or 22
     deb_version="22"
+    os_version=`grep VERSION_ID /etc/os-release | cut -d"\"" -f2`
+    [ $os_version == "20.04" ] && deb_version="20"
     runcmd "wget https://repo.radeon.com/rocm/apt/5.7/pool/main/h/hsa-amd-aqlprofile5.7.0/hsa-amd-aqlprofile5.7.0_1.0.0.50700.50700-63~${deb_version}.04_amd64.deb"
     runcmd "dpkg -x hsa-amd-aqlprofile5.7.0_1.0.0.50700.50700-63~${deb_version}.04_amd64.deb $_builddir"
   else


### PR DESCRIPTION
Two prereq components aqlprofile and rocsmilib must be moved to 5.7.  Recall prereq and supplemental components are only built if the specified version is not already built.  Once merged, this will trigger the builds in the first aomp COMPONENT build_prereq.sh . 