### PR TITLE
[Build] Fix stats issue in build_aomp script

### DIFF
--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -52,7 +52,7 @@ function build_aomp_component() {
        file_count=`wc -l $_stats_dir/$COMPONENT.files | cut -d" " -f1`
        file_count=$(( file_count -1 ))
        echo "COMPONENT $COMPONENT FILES : $file_count " >> $_stats_dir/$COMPONENT.stats
-       new_bytes=`grep " total" $_stats_dir/$COMPONENT.files | cut -d" " -f1`
+       new_bytes=`grep " total" $_stats_dir/$COMPONENT.files | cut -d" " -f1 | awk '{sum += $1} END {print sum}'`
        k_bytes=$(( new_bytes / 1024 ))
        m_bytes=$(( k_bytes / 1024 ))
        echo "COMPONENT $COMPONENT SIZE  : $k_bytes KB  $m_bytes MB " >> $_stats_dir/$COMPONENT.stats


### PR DESCRIPTION
The call to xargs may lead to multiple of the later-on 'grep'ed values. To account for that the script now sums up all potential matches of the grep command to produce a single number.