### PR TITLE
[OpenMP][AMDGPU] Add test for dynamic callstack

### DIFF
--- a/test/smoke-fails/dynamic_callstack/Makefile
+++ b/test/smoke-fails/dynamic_callstack/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+TESTNAME     = dynamic_callstack
+TESTSRC_MAIN = dynamic_callstack.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+
+run:
+	OMP_TARGET_OFFLOAD=MANDATORY LIBOMPTARGET_STACK_SIZE=4096 ./$(TESTNAME)

--- a/test/smoke-fails/dynamic_callstack/dynamic_callstack.c
+++ b/test/smoke-fails/dynamic_callstack/dynamic_callstack.c
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <omp.h>
+
+// Cause the compiler to set amdhsa_uses_dynamic_stack to '1' using recursion.
+// That is: stack requirement for main's target region may not be calculated.
+
+// This recursive function will eventually return 0.
+int recursiveFunc(const int Recursions) {
+  if (Recursions < 1)
+    return 0;
+
+  int j[Recursions];
+#pragma omp target private(j)
+  {
+    ;
+  }
+
+  return recursiveFunc(Recursions - 1);
+}
+
+int main()
+{
+  int N = 256;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j] = b[j] + recursiveFunc(j);
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+


### PR DESCRIPTION
This test will check if 'LIBOMPTARGET_STACK_SIZE' is propagated to the kernel launch. If not, this test may loop or crash.

The recursion is necessary to force the compiler to set: amdhsa_uses_dynamic_stack=1

Note: Depends on COV5.