### PR TITLE
[OpenMP][OMPT] Refactor OMPT tests for use with libomptest

### DIFF
--- a/test/smoke-limbo/aomp-issue376/Makefile
+++ b/test/smoke-limbo/aomp-issue376/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = aomp-issue376
+TESTSRC_MAIN = aomp-issue376.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNENV       += OMPTEST_USE_OMPT_TRACING=1
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/aomp-issue376/aomp-issue376.c
+++ b/test/smoke-limbo/aomp-issue376/aomp-issue376.c
@@ -1,0 +1,48 @@
+/* Based on https://github.com/ROCm-Developer-Tools/aomp/issues/376 */
+
+#include <stdio.h>
+#include <assert.h>
+#include <omp.h>
+
+int start_trace();
+int stop_trace();
+
+int main()
+{
+  int initial_device=1;
+
+  start_trace();
+  
+ #pragma omp target data map(tofrom: initial_device) 
+  {
+      int a;
+      #pragma omp target
+      {
+          for(int i=0; i<100; i++){
+          a+=i;
+        }
+      }
+  }
+#pragma omp target data map(tofrom: initial_device) device(0)
+  {
+      int a;
+      #pragma omp target
+      {
+          for(int i=0; i<100; i++){
+          a+=i;
+        }
+      }
+  }
+
+  stop_trace();
+
+  return 0;
+}
+
+/// CHECK: Callback Target
+/// CHECK-SAME: device_num=0
+
+
+
+
+

--- a/test/smoke-limbo/veccopy-ompt-target-emi-map/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-map/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy-ompt-target-emi-map
+TESTSRC_MAIN = veccopy-ompt-target-emi-map.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNENV       += OMPTEST_USE_OMPT_EMI=1
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-emi-map/veccopy-ompt-target-emi-map.c
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-map/veccopy-ompt-target-emi-map.c
@@ -1,0 +1,88 @@
+#include <stdio.h>
+#include <assert.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+  /// CHECK: 0: Could not register callback 'ompt_callback_target_map_emi'
+  /// CHECK: Callback Init:
+  /// CHECK: Callback Load:
+  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback Submit EMI: endpoint=1 req_num_teams=1
+  /// CHECK: Callback Submit EMI: endpoint=2 req_num_teams=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback Target EMI: kind=1 endpoint=2
+  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback Submit EMI: endpoint=1 req_num_teams=0
+  /// CHECK: Callback Submit EMI: endpoint=2 req_num_teams=0
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback Target EMI: kind=1 endpoint=2
+  /// DISABLED-CHECK: Callback Fini:

--- a/test/smoke-limbo/veccopy-ompt-target-emi-tracing/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-tracing/Makefile
@@ -1,0 +1,21 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy-ompt-target-emi-tracing
+TESTSRC_MAIN = veccopy-ompt-target-emi-tracing.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNENV       += OMPTEST_USE_OMPT_EMI=1
+RUNENV       += OMPTEST_USE_OMPT_TRACING=1
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	echo $(PATH)
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.c
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <assert.h>
+#include <omp.h>
+
+int start_trace();
+int flush_trace();
+int stop_trace();
+
+int main()
+{
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+  start_trace();
+  
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  flush_trace();
+  stop_trace();
+
+  start_trace();
+  
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  stop_trace();
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: Record Submit:
+

--- a/test/smoke-limbo/veccopy-ompt-target-emi/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-emi/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy-ompt-target-emi
+TESTSRC_MAIN = veccopy-ompt-target-emi.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNENV       += OMPTEST_USE_OMPT_EMI=1
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-emi/veccopy-ompt-target-emi.c
+++ b/test/smoke-limbo/veccopy-ompt-target-emi/veccopy-ompt-target-emi.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <assert.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+  /// CHECK: Callback Init:
+  /// CHECK: Callback Load:
+  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback Submit EMI: endpoint=1 req_num_teams=1
+  /// CHECK: Callback Submit EMI: endpoint=2 req_num_teams=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback Target EMI: kind=1 endpoint=2
+  /// CHECK: Callback Target EMI: kind=1 endpoint=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=1
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=2
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=2
+  /// CHECK: Callback Submit EMI: endpoint=1 req_num_teams=0
+  /// CHECK: Callback Submit EMI: endpoint=2 req_num_teams=0
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=3
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=1 optype=4
+  /// CHECK: Callback DataOp EMI: endpoint=2 optype=4
+  /// CHECK: Callback Target EMI: kind=1 endpoint=2
+  /// DISABLED-CHECK: Callback Fini:

--- a/test/smoke-limbo/veccopy-ompt-target-map/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-map/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy-ompt-target-map
+TESTSRC_MAIN = veccopy-ompt-target-map.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-map/veccopy-ompt-target-map.c
+++ b/test/smoke-limbo/veccopy-ompt-target-map/veccopy-ompt-target-map.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+  /// CHECK: 0: Could not register callback 'ompt_callback_target_map'
+  /// CHECK: Callback Init:
+  /// CHECK: Callback Load:
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback Submit: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] req_num_teams=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
+
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback Submit: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] req_num_teams=0
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
+  /// DISABLED-CHECK: Callback Fini:

--- a/test/smoke-limbo/veccopy-ompt-target/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = veccopy-ompt-target
+TESTSRC_MAIN = veccopy-ompt-target.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNCMD      = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+run:
+	echo $(PATH)
+	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target/veccopy-ompt-target.c
+++ b/test/smoke-limbo/veccopy-ompt-target/veccopy-ompt-target.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 100000;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+  /// CHECK: Callback Init:
+  /// CHECK: Callback Load:
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback Submit: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] req_num_teams=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
+
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=1
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=2
+  /// CHECK: Callback Submit: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] req_num_teams=0
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=3
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback DataOp: target_id=[[TARGET_ID:[0-9]+]] host_op_id=[[HOST_OP_ID:[0-9]+]] optype=4
+  /// CHECK: Callback Target: target_id=[[TARGET_ID:[0-9]+]] kind=1 endpoint=2
+  /// DISABLED-CHECK: Callback Fini:


### PR DESCRIPTION
A new variable is declared within Makefile.defs: 'OMPTEST' This will cover an include directory and linker flag.

To enable the use of EMI or OMPT tracing, we use the environmental vars:
 * OMPTEST_USE_OMPT_EMI
 * OMPTEST_USE_OMPT_TRACING

The first batch will only cover "standard" OMPT use cases within smoke:
 * aomp-issue376
 * veccopy-ompt-target-emi-map
 * veccopy-ompt-target-emi-tracing
 * veccopy-ompt-target-emi
 * veccopy-ompt-target-map
 * veccopy-ompt-target

Note: For now we want to duplicate(!) these tests within smoke-limbo.

In smoke there are currently three other tests which are not altered:
 * veccopy-ompt-target-disallow-both
 * veccopy-ompt-target-noinit
 * veccopy-ompt-target-wrong-return