### PR TITLE
[OpenMP][OMPT] Fix oversight in #700

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -291,3 +291,6 @@ else
    RUNENV = env $(SET_DEVICE_DEBUG) $(TKILL) $(CBL_ENV)
 endif
 
+# Header include path + linker flag for libomptest based OMPT tests
+OMPTEST = -I$(AOMP_REPOS)/llvm-project/openmp/libomptarget/test/ompTest/include -lomptest
+


### PR DESCRIPTION
(Re-)Added Makefile definition for OMPTEST.
Hence, libomptest was not linked and the tests would fail.