### PR TITLE
[smoke] If AOMP_PARALLEL_SMOKE requested, skip prerequisites

### DIFF
--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -135,6 +135,9 @@ fi
 
 # ---------- Begin parallel logic ----------
 if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
+  if [ -z ${AOMP_NO_PREREQ+x} ]; then
+    export AOMP_NO_PREREQ=1     # disable prereq target so builds can be reused
+  fi
   sem --help > /dev/null
   if [ $? -eq 0 ]; then
     COMP_THREADS=1


### PR DESCRIPTION
    - Allows parallel builds to be reused, skips recompiling
    - Only set AOMP_NO_PREREQ=1 if it isn't already set (even if set
      to an empty string, reason for using conditioanl +x vs. :- init)