### PR TITLE
[Smoke] Fixes RUNCMD in test invocation

### DIFF
--- a/test/smoke/hsa-lazy-queues/Makefile
+++ b/test/smoke/hsa-lazy-queues/Makefile
@@ -12,8 +12,8 @@ else
 	RUNPROF   = $(AOMPROCM)/../bin/rocprof
 endif
 
-RUNCMD      = --hsa-trace ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
 RUNENV      = OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
+RUNCMD      = --hsa-trace ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -22,6 +22,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-
-run:
-	$(RUNENV) $(RUNPROF) $(RUNCMD)


### PR DESCRIPTION
Make use of Makefile mechanism to auto-generate `run` rule.