### PR TITLE
[Smoke] Remove LD_PRELOAD from test

### DIFF
--- a/test/smoke/map_to_from_prob/Makefile
+++ b/test/smoke/map_to_from_prob/Makefile
@@ -9,7 +9,7 @@ CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-RUNENV = LD_LIBRARY_PATH=$(AOMP)/lib-debug #LIBOMPTARGET_DEBUG=1 
+# RUNENV = LD_LIBRARY_PATH=$(AOMP)/lib-debug #LIBOMPTARGET_DEBUG=1
 #-ccc-print-phases
 #"-\#\#\#"
 


### PR DESCRIPTION
The LD_PRELOAD seems to cause a hang as of now. This test does not use any of the lib-debug functionality, so remove the preloading.