### PR TITLE
[Smoke] This fixes `make check`

### DIFF
--- a/test/smoke/targetid_multi_image/Makefile
+++ b/test/smoke/targetid_multi_image/Makefile
@@ -12,8 +12,9 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 SUPPORTED  = gfx90a,gfx90c,gfx940,gfx941,gfx942,gfx1010,gfx1011,gfx1012,gfx1013
 
-HSA_XNACK ?= 1
-RUNCMD       = HSA_XNACK=$(HSA_XNACK) ./$(TESTNAME) && HSA_XNACK=0 ./$(TESTNAME) && strings $(TESTNAME) |grep -i gfx
+HSA_XNACK   ?= 1
+RUNENV       = HSA_XNACK=$(HSA_XNACK)
+RUNCMD       = ./$(TESTNAME) && HSA_XNACK=0 ./$(TESTNAME) && strings $(TESTNAME) |grep -i gfx
 
 #-ccc-print-phases
 #"-\#\#\#"


### PR DESCRIPTION
In `make check` the `RUNCMD` is used within a timeout run. The issue is that if we have `HSA_XNACK=1` in the beginning of the `RUNCMD` than timeout will complain that this is not executable. I moved it to `RUNENV`, which precedes the timeout. Manually validated that the test still prints out the expected xnack settings (which it does not test).