### PR TITLE
Fix install-fast

### DIFF
--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -226,16 +226,17 @@ if [ "$1" != "install-fast" ] ; then
    # Required for amdllvm support
    echo ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS clang lld compiler-rt
    ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS clang lld compiler-rt
-
-   # Required for amdllvm support
-   echo ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
-   ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
 fi
+
+# Required for amdllvm support
+echo ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
+${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
 
 # Finish building
 echo "Running CMAKE in ${PWD}"
 echo ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS
 ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS
+
 if [ $? != 0 ] ; then
    echo "ERROR make -j $AOMP_JOB_THREADS failed"
    exit 1


### PR DESCRIPTION
Fix install-fast for now.

This slows down install-fast slightly but ensures that cmake config is not invoked concurrently. 