### PR TITLE
[build_project] - Reduce build to one make command. 

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -245,6 +245,23 @@ if [ ! -z `which "getconf"` ]; then
 fi
 AOMP_JOB_THREADS=${AOMP_JOB_THREADS:-$COMP_THREADS}
 
+
+if [ "$AOMP_LIMIT_FLANG" == "1" ] ; then
+   # Limit build jobs for llvm flang-new build.
+   FLANG_THREADS=1
+
+   # Third column of free is the amount of available memory
+   memory_regex="[0-9]+\s+[0-9]+\s+([0-9]+)"
+   free_memory=$(free -g)
+
+   if [[ "$free_memory" =~ $memory_regex ]]; then
+     memory_size=${BASH_REMATCH[1]}
+     # 6 GB estimate per thread for MLIR
+     FLANG_THREADS=$((memory_size/6))
+   fi
+
+   AOMP_FLANG_THREADS=${AOMP_FLANG_THREADS:-$FLANG_THREADS}
+fi
 # These are the web sites where the AOMP git repos are pulled from
 GITROC="https://github.com/RadeonOpenCompute"
 GITROCINTERNAL="ssh://$USER@gerrit-git.amd.com:29418/lightning/ec"

--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -245,7 +245,6 @@ if [ ! -z `which "getconf"` ]; then
 fi
 AOMP_JOB_THREADS=${AOMP_JOB_THREADS:-$COMP_THREADS}
 
-
 if [ "$AOMP_LIMIT_FLANG" == "1" ] ; then
    # Limit build jobs for llvm flang-new build.
    FLANG_THREADS=1
@@ -262,6 +261,7 @@ if [ "$AOMP_LIMIT_FLANG" == "1" ] ; then
 
    AOMP_FLANG_THREADS=${AOMP_FLANG_THREADS:-$FLANG_THREADS}
 fi
+
 # These are the web sites where the AOMP git repos are pulled from
 GITROC="https://github.com/RadeonOpenCompute"
 GITROCINTERNAL="ssh://$USER@gerrit-git.amd.com:29418/lightning/ec"

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -141,7 +141,7 @@ if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
 fi
 
 # Make sure we can update the install directory
-if [ "$1" == "install" ] || [ "$1" == "install-fast" ]; then 
+if [ "$1" == "install" ] ; then
    $SUDO mkdir -p $INSTALL_PROJECT
    $SUDO touch $INSTALL_PROJECT/testfile
    if [ $? != 0 ] ; then 
@@ -168,16 +168,16 @@ if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
 fi
 
 # Skip synchronization from git repos if nocmake or install are specified
-if [ "$1" != "nocmake" ] && [ "$1" != "install" ] && [ "$1" != "install-fast" ] ; then
+if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME"
-   echo "Use ""$0 nocmake"" or ""$0 install"" or ""$0 install-fast"" to avoid FRESH START."
+   echo "Use ""$0 nocmake"" or ""$0 install"" to avoid FRESH START."
    rm -rf $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME
    mkdir -p $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME
 else
    if [ ! -d $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME ] ; then 
       echo "ERROR: The build directory $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME does not exist"
-      echo "       run $0 without nocmake, install or install-fast options. " 
+      echo "       run $0 without nocmake or install options. "
       exit 1
    fi
 fi
@@ -202,7 +202,7 @@ fi
 
 cd $BUILD_DIR/build/$AOMP_PROJECT_REPO_NAME
 
-if [ "$1" != "nocmake" ] && [ "$1" != "install" ] && [ "$1" != "install-fast" ] ; then
+if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo
    echo " -----Running cmake ---- " 
    echo ${AOMP_CMAKE} $MYCMAKEOPTS  $AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/llvm
@@ -217,22 +217,16 @@ fi
 echo
 echo " -----Running make ---- " 
 
-if [ "$1" != "install-fast" ] ; then
-   # Workaround for race condition in the build of compiler-rt
-   for prebuild in $(${AOMP_CMAKE} --build . --target help | sed -n '/-version-list/s/^... //p') ; do
-       ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS --target $prebuild
-   done
-
-   # Required for amdllvm support
+if [ "$AOMP_LIMIT_FLANG" == "1" ] ; then
+   # Required for building flang-new on memory limited systems.
    echo ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS clang lld compiler-rt
    ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS clang lld compiler-rt
+
+   echo ${AOMP_CMAKE} --build . -- -j $AOMP_FLANG_THREADS flang-new
+   ${AOMP_CMAKE} --build . -- -j $AOMP_FLANG_THREADS flang-new
 fi
 
-# Required for amdllvm support
-echo ${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
-${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS runtimes cxx
-
-# Finish building
+# Build llvm-project in one step
 echo "Running CMAKE in ${PWD}"
 echo ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS
 ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS
@@ -242,7 +236,7 @@ if [ $? != 0 ] ; then
    exit 1
 fi
 
-if [ "$1" == "install" ] || [ "$1" == "install-fast" ] ; then
+if [ "$1" == "install" ] ; then
    echo " -----Installing to $INSTALL_PROJECT ---- "
    $SUDO ${AOMP_CMAKE} --install .
    if [ $? != 0 ] ; then


### PR DESCRIPTION
We no longer need to specify manual targets
for the build of amdllvm and runtimes. The
install-fast option is no longer needed and
has been removed.

Add AOMP_LIMIT_FLANG and AOMP_FLANG_THREADS
environment variables. Some systems do not have
enough memory to build MLIR with a high number of
threads. Setting AOMP_LIMIT_FLANG will use the old
method of manual make targets to limit the build
of flang-new. The number of threads will be
calculated based on the amount of available memory.
The user can also manually override this by using
AOMP_FLANG_THREADS.