### PR TITLE
[OpenMP][OMPT] Adapt include dir to new header installation path

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -287,5 +287,5 @@ else
 endif
 
 # Header include path + linker flag for libomptest based OMPT tests
-OMPTEST = -I$(AOMP_REPOS)/llvm-project/openmp/libomptarget/test/ompTest/include -lomptest
+OMPTEST = -I$(AOMP)/lib/omptest/include -lomptest
 


### PR DESCRIPTION
Once libomptest installs headers into the new location we will need to adapt.