### PR TITLE
[smoke] Don't rerun tests that hit timeout

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -107,19 +107,13 @@ ifeq (,$(findstring $(AOMP_GPU),$(UNSUPPORTED)))
 	base=`basename $$path`; \
 	( \
 	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
-	  test_status=0; \
-	  if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(CHECK_COMMAND) > /dev/null 2>&1); then \
-		  test_status=$$?; \
-		  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
-		  echo  "" >> ../check-smoke.txt; \
-		  echo $$base $$test_num  >> ../passing-tests.txt; \
-	  else	test_status=$$?; \
-		  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
-		  echo  "" >> ../check-smoke.txt; \
-		  echo $$base $$test_num  >> ../failing-tests.txt; \
-	  fi; \
+	  $(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(CHECK_COMMAND) > /dev/null 2>&1; \
+	  test_status=$$?; \
 	  echo "$$test_status" > TEST_STATUS; \
-	  exit $$test_status; \
+	  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
+	  echo  "" >> ../check-smoke.txt; \
+	  if [ $$test_status -eq 0 ]; then echo $$base $$test_num >> ../passing-tests.txt; \
+	                              else echo $$base $$test_num >> ../failing-tests.txt; fi; \
 	)9>../lockfile;
 else
 	@echo "  $(SKIP_RUN_UNSUPPORTED)"

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -89,15 +89,13 @@ verify-log: run
 	path=`pwd`; \
 	base=`basename $$path`; \
 	( \
-	flock -e 9 && echo  "" >> ../check-smoke.txt; \
-	if   (./verify_output); then \
-		echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
-		echo  "" >> ../check-smoke.txt; \
-		echo $$base $$test_num  >> ../passing-tests.txt; \
-	else  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
-		echo  "" >> ../check-smoke.txt; \
-		echo $$base $$test_num  >> ../failing-tests.txt; \
-	fi; \
+	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
+	  ./verify_output; \
+	  vrfy_status=$$?; \
+	  echo $$base $$test_num return code: $$vrfy_status >> ../check-smoke.txt; \
+	  echo  "" >> ../check-smoke.txt; \
+	  if [ $$vrfy_status -eq 0 ]; then echo $$base $$test_num >> ../passing-tests.txt; \
+	                              else echo $$base $$test_num >> ../failing-tests.txt; fi; \
 	)9>../lockfile;
 
 check: $(TESTNAME)

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -107,14 +107,19 @@ ifeq (,$(findstring $(AOMP_GPU),$(UNSUPPORTED)))
 	base=`basename $$path`; \
 	( \
 	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
+	  test_status=0; \
 	  if   ($(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(CHECK_COMMAND) > /dev/null 2>&1); then \
-		  echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
+		  test_status=$$?; \
+		  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
 		  echo  "" >> ../check-smoke.txt; \
 		  echo $$base $$test_num  >> ../passing-tests.txt; \
-	  else	echo $$base $$test_num return code: $$? >> ../check-smoke.txt; \
+	  else	test_status=$$?; \
+		  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
 		  echo  "" >> ../check-smoke.txt; \
 		  echo $$base $$test_num  >> ../failing-tests.txt; \
 	  fi; \
+	  echo "$$test_status" > TEST_STATUS; \
+	  exit $$test_status; \
 	)9>../lockfile;
 else
 	@echo "  $(SKIP_RUN_UNSUPPORTED)"
@@ -247,7 +252,7 @@ run_sbin: sbin
 
 # Cleanup anything this makefile can create
 clean::
-	rm -f $(TESTNAME) $(TESTNAME).a llbin sbin obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log *.mod verify_output *.stb *.ilm *.cmod *.cmdx $(TESTNAME)_og11 make-log.txt
+	rm -f $(TESTNAME) $(TESTNAME).a llbin sbin obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log *.mod verify_output *.stb *.ilm *.cmod *.cmdx $(TESTNAME)_og11 make-log.txt TEST_STATUS
 
 clean_log:
 	rm -f *.log

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -246,6 +246,8 @@ if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
         sem --jobs 4 --id def_sem -u 'make check > /dev/null 2>&1'
       fi
       #---
+      test_status=`cat TEST_STATUS`
+      if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
       run=$(($run+1))
       done
       #--- End test iteration
@@ -312,6 +314,8 @@ for directory in $SMOKE_DIRS; do
   make
   if [ $? -ne 0 ]; then
     echo "$base: Make Failed" >> ../make-fail.txt
+    test_status=`cat TEST_STATUS`
+    if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
     run=$(($run+1))
     continue
   fi
@@ -329,10 +333,15 @@ for directory in $SMOKE_DIRS; do
     # liba_bundled has an additional Makefile, that may fail on the make check
     if [ $? -ne 0 ] && ( [ $base == 'liba_bundled' ] || [ $base == 'liba_bundled_cmdline' ] ) ; then
       echo "$base: Make Failed" >> ../make-fail.txt
+      test_status=`cat TEST_STATUS`
+      if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
+      break     # don't rerun timeouts
     fi
   fi
   echo ""
   #---
+  test_status=`cat TEST_STATUS`
+  if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
   run=$(($run+1))
   done
   #--- End test iteration

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -246,8 +246,10 @@ if [ "$AOMP_PARALLEL_SMOKE" == 1 ]; then
         sem --jobs 4 --id def_sem -u 'make check > /dev/null 2>&1'
       fi
       #---
-      test_status=`cat TEST_STATUS`
-      if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
+      if [ -r "TEST_STATUS" ]; then
+        test_status=`cat TEST_STATUS`
+        if [ "$test_status" == "124" ]; then break; fi  # don't rerun timeouts
+      fi
       run=$(($run+1))
       done
       #--- End test iteration
@@ -314,8 +316,10 @@ for directory in $SMOKE_DIRS; do
   make
   if [ $? -ne 0 ]; then
     echo "$base: Make Failed" >> ../make-fail.txt
-    test_status=`cat TEST_STATUS`
-    if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
+    if [ -r "TEST_STATUS" ]; then
+      test_status=`cat TEST_STATUS`
+      if [ "$test_status" == "124" ]; then break; fi    # don't rerun timeouts
+    fi
     run=$(($run+1))
     continue
   fi
@@ -333,15 +337,18 @@ for directory in $SMOKE_DIRS; do
     # liba_bundled has an additional Makefile, that may fail on the make check
     if [ $? -ne 0 ] && ( [ $base == 'liba_bundled' ] || [ $base == 'liba_bundled_cmdline' ] ) ; then
       echo "$base: Make Failed" >> ../make-fail.txt
-      test_status=`cat TEST_STATUS`
-      if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
-      break     # don't rerun timeouts
+      if [ -r "TEST_STATUS" ]; then
+        test_status=`cat TEST_STATUS`
+        if [ "$test_status" == "124" ]; then break; fi  # don't rerun timeouts
+      fi
     fi
   fi
   echo ""
   #---
-  test_status=`cat TEST_STATUS`
-  if [ "$test_status" == "124" ]; then break; fi       # don't rerun timeouts
+  if [ -r "TEST_STATUS" ]; then
+    test_status=`cat TEST_STATUS`
+    if [ "$test_status" == "124" ]; then break; fi      # don't rerun timeouts
+  fi
   run=$(($run+1))
   done
   #--- End test iteration


### PR DESCRIPTION
    - Capture/examine run status in a TEST_STATUS file in test directory
    - Makefile exit status is otherwise 2 on error so it is not possible
      to detect timeout by looking at the exit status of the make command