### PR TITLE
Small tweaks to fortran stream_no_teams

### DIFF
--- a/trunk/stream_no_teams/src/OpenMPTargetStream.F90
+++ b/trunk/stream_no_teams/src/OpenMPTargetStream.F90
@@ -83,10 +83,10 @@ module OpenMPTargetStream
 
         subroutine read_arrays(h_A, h_B, h_C)
             implicit none
-            real(kind=REAL64), intent(inout) :: h_A(:), h_B(:), h_C(:)
+            real(kind=REAL64), allocatable, intent(inout) :: h_A(:), h_B(:), h_C(:)
             integer(kind=StreamIntKind) :: i
             ! this might need to use a copy API instead...
-            !$omp target parallel do
+            !$omp target parallel do map(tofrom: h_A, h_B, h_C)
             do i=1,N
                h_A(i) = A(i)
                h_B(i) = B(i)
@@ -156,9 +156,11 @@ module OpenMPTargetStream
             s = real(0,kind=REAL64)
             ! temporarily avoid offload of reduction till we have that working
             !!$omp target parallel do reduction(+:s)
-            do i=1,N
-               s = s + A(i) * B(i)
-            end do
+            !$omp target map(tofrom: s)
+              do i=1,N
+                s = s + A(i) * B(i)
+              end do
+            !$omp end target
         end function dot
 
 end module OpenMPTargetStream

--- a/trunk/stream_no_teams/src/main.F90
+++ b/trunk/stream_no_teams/src/main.F90
@@ -4,7 +4,7 @@ module BabelStreamUtil
 
     implicit none
 
-    integer(kind=StreamIntKind) :: array_size = 33554432
+    integer(kind=StreamIntKind) :: array_size = 3355443
     integer(kind=StreamIntKind) :: num_times  = 100
     logical                     :: mibibytes  = .false.
     logical                     :: use_gigs   = .false.


### PR DESCRIPTION
I think these tweaks (except perhaps the main size change) might be necessary required to have the correct semantics for the test, but I'm no OpenMP expert so I could be incorrect! However, this does currently get the test working with some minor additions to ATD by applying the following open PRs:

- (https://github.com/ROCm-Developer-Tools/llvm-project/pull/225
- (https://github.com/ROCm-Developer-Tools/llvm-project/pull/247 

I changed the "dot" function to use a target region, there's no synch back of the data to array A, B and C from device so the function will be doing calculation with incorrect data at the moment (original arrays). So it needs a write back from device via update or exit  with tofrom (it'd be the latter for now as we don't actually have update support yet) or we do the calculation on device using target rather than a parallel target as we have no reduction just now.

Add the allocatable keyword to the input parameters h_A, h_B, h_C of the "read_arrays" function and explicitly map them as tofrom (could be from instead to be a little more restrictive):
- The former I'm not sure if it's a bug by the frontend to not indicate that you can't pass an allocatable into an argument that doesn't have the allocatable keyword on it or if it's legal, if it's legal then it's something the allocatable PR currently doesn't handle and I'll likely need to consider how to handle it. Which seems like it could be tricky.
- the latter as an explicit mapping seems necessary for the read behaviour, it could likely be a from mapping as well, instead of tofrom. Currently implicit mapping of allocatables doesn't map the data, just the descriptor, not sure if the semantics are correct in this case, so I need to look a little more closely into it. But in any case if the intent is to read back I think it should likely be an explicit from or tofrom map for each allocatable array argument.