### PR TITLE
[smoke] Report exit status as last non-zero command in pipeline

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -1,3 +1,5 @@
+SHELL=/bin/bash -o pipefail
+
 ifeq ($(AOMP),)
 # --- Standard Makefile check for AOMP installation ---
 ifeq ("$(wildcard $(AOMP))","")


### PR DESCRIPTION
   * Needed for self checking tests that pipe output to FILECHECK
   * Example from: smoke/xteam-red-unsupported

     RUNCMD = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)

   * By default, a non-zero exit status in TESTNAME is masked by the pipe to FILECHECK.  Adding pipefail allows the test exit status to be reported and detected as a failure.