### PR TITLE
[Smoke] Fix test for using two SDMA engines

### DIFF
--- a/test/smoke-limbo/multi-sdma/multi-sdma.cpp
+++ b/test/smoke-limbo/multi-sdma/multi-sdma.cpp
@@ -28,11 +28,11 @@ int main(int argc, char **argv) {
 
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 1
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 2
-// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 4
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 1
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 2
-// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 4
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 1
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 2
-// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 4
 // CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 1
+// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 2
+// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 1
+// CHECK: TARGET AMDGPU RTL --> Running Async Copy on SDMA Engine: 2


### PR DESCRIPTION
This updates the test to work with the changes in https://github.com/llvm/llvm-project/pull/73633