### PR TITLE
[OpenMP][OMPT] Reduce required CMake version from 3.22 to 3.16

### DIFF
--- a/test/smoke-limbo/veccopy-ompt-target-cmake/CMakeLists.txt
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16)
 
 if(NOT DEFINED PROJECT_NAME OR PROJECT_NAME STREQUAL "")
   get_filename_component(PROJECT_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)


### PR DESCRIPTION
We observed failures since testing machines are running lower CMake versions than expected. Hence we reduce the requirement.