### PR TITLE
Fix OMPT smoke-limbo tests.

### DIFF
--- a/test/smoke-limbo/veccopy-ompt-target-default-device/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/callbacks.h
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <memory>
 #include <unordered_set>
 
 // Tool related code below
@@ -8,7 +9,8 @@
 
 // Map of devices traced
 typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
-extern DeviceMap_t DeviceMap;
+typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
+extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
@@ -135,9 +137,9 @@ static int start_trace(int device_num, ompt_device_t *Device) {
     return 0;
 
   // This device will be traced.
-  assert(DeviceMap.find(Device) == DeviceMap.end() &&
+  assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
 	 "Device already present in the map");
-  DeviceMap.insert(Device);
+  DeviceMapPtr->insert(Device);
   
   return ompt_start_trace(Device, &on_ompt_callback_buffer_request_default_device,
 			  &on_ompt_callback_buffer_complete_default_device);
@@ -181,6 +183,7 @@ static void on_ompt_callback_device_initialize
     printf("WARNING: No function ompt_get_record_type found in device callbacks\n");
   }
 
+  DeviceMapPtr = std::make_unique<DeviceMap_t>();
   set_trace_ompt(device);
   
   start_trace(device_num, device);

--- a/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
@@ -12,7 +12,7 @@
 #include "callbacks.h"
 
 // Map of devices traced
-DeviceMap_t DeviceMap;
+DeviceMapPtr_t DeviceMapPtr;
 
 int main()
 {
@@ -34,7 +34,7 @@ int main()
   {
   }
 
-  for (auto Dev : DeviceMap)
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
   
   for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
@@ -45,7 +45,7 @@ int main()
     }
   }
 
-  for (auto Dev : DeviceMap) {
+  for (auto Dev : *DeviceMapPtr) {
     flush_trace(Dev);
     stop_trace(Dev);
   }

--- a/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
@@ -9,7 +9,7 @@
 #include "callbacks.h"
 
 // Map of devices traced
-DeviceMap_t DeviceMap;
+DeviceMapPtr_t DeviceMapPtr;
 
 int main()
 {
@@ -31,7 +31,7 @@ int main()
   {
   }
 
-  for (auto Dev : DeviceMap)
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
   
   for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
@@ -42,7 +42,7 @@ int main()
     }
   }
 
-  for (auto Dev : DeviceMap) {
+  for (auto Dev : *DeviceMapPtr) {
     flush_trace(Dev);
     stop_trace(Dev);
   }


### PR DESCRIPTION
Since device-init callback is now called early, allocation of device-tracking metadata must be done early as well.