### PR TITLE
[SMOKE-fort] Check loop tripcount for LLVM-flang

### DIFF
--- a/test/smoke-fort/milestone-2/Makefile
+++ b/test/smoke-fort/milestone-2/Makefile
@@ -4,6 +4,8 @@ TESTNAME     = main
 TESTSRC_MAIN = main.f95
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV       += LIBOMPTARGET_INFO=-1
+RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
 FLANG        ?= flang-new
 OMP_BIN      = $(AOMP)/bin/$(FLANG)

--- a/test/smoke-fort/milestone-2/main.f95
+++ b/test/smoke-fort/milestone-2/main.f95
@@ -25,3 +25,5 @@ subroutine writeIndex(int_array, array_length)
 !$omp end target teams distribute parallel do
 
 end subroutine writeIndex
+
+/// CHECK: Tripcount: 10


### PR DESCRIPTION
We need to check if loop trip count is set correctly in the OpenMP runtime.