### PR TITLE
Modify run_genasis.sh script to reflect recent changes in hipcc and change openmpi_set_cu_mask call to gpurun call.

### DIFF
--- a/bin/Makefile_ROCm
+++ b/bin/Makefile_ROCm
@@ -59,7 +59,7 @@ ifeq ($(ENABLE_OMP_OFFLOAD), 1)
   DEFINES += -fopenmp-targets=$(OFFLOAD_TRIPLE) -Xopenmp-target=$(OFFLOAD_TRIPLE) -march=$(OFFLOAD_ARCH)
 endif
 ifeq ($(ENABLE_HIP), 1)
-  DEVICE_COMPILE ?= $(HIP_DIR)/bin/hipcc -c -D__HIP_PLATFORM_HCC__
+  DEVICE_COMPILE ?= $(HIP_DIR)/bin/hipcc -c -D__HIP_PLATFORM_AMD__
   LIBRARY_DEVICE = -L$(HIP_DIR)/lib -lamdhip64
   Device_Interface = Device_HIP
 endif
@@ -71,7 +71,7 @@ ifeq ($(ENABLE_MPI), 1)
   #CC_COMPILE = $(OPENMPI_DIR)/bin/mpicc -v
   #CC_COMPILE = $(ROCM_DIR)/bin/clang -v
   FCFLAGS =  $(DEFINES) 
-  CC_COMPILE =  $(HIP_DIR)/bin/hipcc -c -D__HIP_PLATFORM_HCC__
+  CC_COMPILE =  $(HIP_DIR)/bin/hipcc -c -D__HIP_PLATFORM_AMD__
   FCFLAGS += $(LIBRARY_OPENMPI)
   #LINK = $(OPENMPI_DIR)/bin/mpifort
   LINK = $(FORTRAN_LINK)

--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -130,7 +130,7 @@ if [ "$1" != "buildonly" ] ; then
   #echo ldd ./SineWaveAdvection_$GENASIS_MACHINE
   #ldd ./SineWaveAdvection_$GENASIS_MACHINE
   echo
-  _cmd="$OPENMPI_DIR/bin/mpirun -np 1 $AOMP/bin/openmpi_set_cu_mask $REPO_DIR/Programs/Examples/Basics/FluidDynamics/Executables/SineWaveAdvection_$GENASIS_MACHINE nCells=128,128,128"
+  _cmd="$OPENMPI_DIR/bin/mpirun -np 1 $AOMP/bin/gpurun $REPO_DIR/Programs/Examples/Basics/FluidDynamics/Executables/SineWaveAdvection_$GENASIS_MACHINE nCells=128,128,128"
   echo $_cmd
   time $_cmd
   echo "=================  end mpirun  ========"

--- a/bin/run_gests.sh
+++ b/bin/run_gests.sh
@@ -79,7 +79,7 @@ if [ "$1" != "buildonly" ] ; then
   cd $REPO_DIR
   echo
   echo "=================  attempting mpirun  ========"
-  _cmd="$OPENMPI_DIR/bin/mpirun -np 1 $AOMP/bin/openmpi_set_cu_mask ./PSDNS_fft.x"
+  _cmd="$OPENMPI_DIR/bin/mpirun -np 1 $AOMP/bin/gpurun ./PSDNS_fft.x"
   echo $_cmd
   time $_cmd
   echo


### PR DESCRIPTION
HIP runtime has stopped using/checking-for __HIP_PLATFORM_HCC__.  There was a change that landed around late October in the HIP runtime. Instead we were told to use __HIP_PLATFORM_AMD__

Also, changed openmpi_set_cu_mask call to gpurun call in both run_genasis.sh and run_gests.sh scripts.