### PR TITLE
Setting $HIP_CLANG_PATH to $AOMP/bin before running GenASiS and GESTS applications.

### DIFF
--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -79,6 +79,7 @@ export OTHER_LIBS="-lm -L$AOMP/lib -lflang -lflangmain -lflangrti -lpgmath -lomp
 export FORTRAN_LINK="$AOMP/bin/clang $OTHER_LIBS"
 export DEVICE_COMPILE="$AOMP/bin/hipcc -D__HIP_PLATFORM_HCC__"
 export HIP_DIR=$ROCM
+export HIP_CLANG_PATH=$AOMP/bin
 cd $currdir
 if [ "$1" != "runonly" ] ; then
   cd $REPO_DIR/Programs/UnitTests/Basics/Runtime/Executables

--- a/bin/run_gests.sh
+++ b/bin/run_gests.sh
@@ -61,6 +61,7 @@ fi
 
 export LD_LIBRARY_PATH=$HOME/rocm/aomp/lib:$OPENMPI_DIR/lib:$FFTW_DIR/lib:$LD_LIBRARY_PATH
 export ROCM_DIR=$AOMP
+export HIP_CLANG_PATH=$AOMP/bin
 cd $REPO_DIR
 if [ "$1" != "runonly" ] ; then
   echo "=================  STARTING MAKE in $PWD ========"


### PR DESCRIPTION
Adding export HIP_CLANG_PATH=$AOMP/bin line to run_genasis.sh and run_gests.sh