### PR TITLE
[Test] Unifies command executed in run and test

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -59,11 +59,7 @@ endif
 run: $(TESTNAME)
 ifneq (,$(findstring $(AOMP_GPU)$(AOMP_TARGET_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(AOMP_GPU)$(AOMP_TARGET_FEATURES),$(UNSUPPORTED)))
-ifeq ($(RUNCMD),)
-	$(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
-else
-	$(RUNENV) $(RUNCMD)
-endif
+	$(RUNENV) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND) 2>&1 | tee $@.log
 else
 	@echo "  $(SKIP_RUN_UNSUPPORTED)"
 endif
@@ -105,7 +101,7 @@ ifeq (,$(findstring $(AOMP_GPU)$(AOMP_TARGET_FEATURES),$(UNSUPPORTED)))
 	base=`basename $$path`; \
 	( \
 	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
-	  $(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(CHECK_COMMAND) > /dev/null 2>&1; \
+	  $(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND) > /dev/null 2>&1; \
 	  test_status=$$?; \
 	  echo "$$test_status" > TEST_STATUS; \
 	  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \

--- a/test/smoke/hsa-lazy-queues/Makefile
+++ b/test/smoke/hsa-lazy-queues/Makefile
@@ -12,8 +12,10 @@ else
 	RUNPROF   = $(AOMPROCM)/../bin/rocprof
 endif
 
+RUNPROF_FLAGS = --hsa-trace
+
 RUNENV      = OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
-RUNCMD      = $(RUNPROF) --hsa-trace ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
+RUNCMD      = ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)


### PR DESCRIPTION
The issue this patch addresses is that the system constructs the actual command line for `make run` and `make check` differently.

I have changed this behavior by relying on the `CHECK_COMMAND` in both rules. This allows us to then also use the exact same variables in both places. One addition that I need to make was create a new variable that is used to provide flags for a potentially specified profiler.