### PR TITLE
[OpenMP][OMPT] Remove tracing control functions when libomptest based

### DIFF
--- a/test/smoke-limbo/aomp-issue376/aomp-issue376.c
+++ b/test/smoke-limbo/aomp-issue376/aomp-issue376.c
@@ -4,16 +4,11 @@
 #include <assert.h>
 #include <omp.h>
 
-int start_trace();
-int stop_trace();
-
 int main()
 {
   int initial_device=1;
 
-  start_trace();
-  
- #pragma omp target data map(tofrom: initial_device) 
+#pragma omp target data map(tofrom : initial_device)
   {
       int a;
       #pragma omp target
@@ -33,8 +28,6 @@ int main()
         }
       }
   }
-
-  stop_trace();
 
   return 0;
 }

--- a/test/smoke-limbo/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.c
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.c
@@ -2,10 +2,6 @@
 #include <assert.h>
 #include <omp.h>
 
-int start_trace();
-int flush_trace();
-int stop_trace();
-
 int main()
 {
   int N = 100000;
@@ -21,26 +17,17 @@ int main()
   for (i=0; i<N; i++)
     b[i]=i;
 
-  start_trace();
-  
 #pragma omp target parallel for
   {
     for (int j = 0; j< N; j++)
       a[j]=b[j];
   }
 
-  flush_trace();
-  stop_trace();
-
-  start_trace();
-  
 #pragma omp target teams distribute parallel for
   {
     for (int j = 0; j< N; j++)
       a[j]=b[j];
   }
-
-  stop_trace();
 
   int rc = 0;
   for (i=0; i<N; i++)


### PR DESCRIPTION
Fix warning / error related to (re-)registration of device tracing functions