### PR TITLE
Create list of targetIDs that support USM

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -1,5 +1,7 @@
 SHELL=/bin/bash -o pipefail
 
+# target IDs that support OpenMP 'requires unified_shared_memory'
+SUPPORTS_USM=gfx90a,gfx90c,gfx940,gfx941,gfx942,gfx1100,gfx1103,gfx90a:xnack+,gfx940:xnack+,gfx941:xnack+,gfx942:xnack+
 ifeq ($(AOMP),)
 # --- Standard Makefile check for AOMP installation ---
 ifeq ("$(wildcard $(AOMP))","")

--- a/test/smoke/flang-usm/Makefile
+++ b/test/smoke/flang-usm/Makefile
@@ -1,5 +1,4 @@
 USE_OFFLOAD_ARCH = 1
-AOMP_TARGET_FEATURES=:xnack-
 
 include ../../Makefile.defs
 
@@ -12,7 +11,7 @@ FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-UNSUPPORTED  = gfx1030,gfx1031,gfx1032,gfx1033,gfx1034,gfx1035,gfx1036,gfx1100,gfx1101,gfx1102,gfx1103,gfx1150,gfx1151
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke/flang-usm/flang-usm.f90
+++ b/test/smoke/flang-usm/flang-usm.f90
@@ -1,9 +1,7 @@
 program test
       integer :: i(5)
       i(2) = 0
-#if defined(__OFFLOAD_ARCH_gfx90a__)
   !$omp requires unified_shared_memory
-#endif
      !$omp target
       i(2) = 1
      !$omp end target


### PR DESCRIPTION
So only those machines/targetIDs in the list will be tested if the Makefile sets SUPPORTED=$(SUPPORTS_USM)