### PR TITLE
[Flang] Remove -Dsimd= from babel test

### DIFF
--- a/test/smoke-fort/milestone-3-babel-noteams/buildit.sh
+++ b/test/smoke-fort/milestone-3-babel-noteams/buildit.sh
@@ -7,7 +7,7 @@ FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel-noteams
 
 FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
-DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME -Dsimd="
+DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x
 rm -f $EXE *.o *.mod

--- a/test/smoke-fort/milestone-3-babel/README
+++ b/test/smoke-fort/milestone-3-babel/README
@@ -1,6 +1,5 @@
 Fortran babelstream
 
 Modifications:
-  - build with -Dsimd= (to remove simd)
   - remove calls of IEEE_Is_Normal (not yet supported)
   - add map(tofrom:s) to the reduction (workaround)

--- a/test/smoke-fort/milestone-3-babel/buildit.sh
+++ b/test/smoke-fort/milestone-3-babel/buildit.sh
@@ -7,7 +7,7 @@ FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel
 
 FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
-DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME -Dsimd="
+DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x
 rm -f $EXE *.o *.mod


### PR DESCRIPTION
Upstream Flang can generate valid workshare code
for `omp do` pragma.

See: https://github.com/llvm/llvm-project/pull/79559 for more details.