### PR TITLE
Do not call stop_trace too early.

### DIFF
--- a/test/smoke-fails/aomp-issue374/aomp-issue374.cpp
+++ b/test/smoke-fails/aomp-issue374/aomp-issue374.cpp
@@ -37,10 +37,8 @@ int main()
     }
   }
 
-  for (auto Dev : *DeviceMapPtr) {
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-    stop_trace(Dev);
-  }
 
   int rc = 0;
   for (i=0; i<N; i++)

--- a/test/smoke/aomp-issue376/aomp-issue376.cpp
+++ b/test/smoke/aomp-issue376/aomp-issue376.cpp
@@ -34,10 +34,8 @@ int main()
       }
   }
 
-  for (auto Dev : *DeviceMapPtr) {
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-    stop_trace(Dev);
-  }
 
   return 0;
 }

--- a/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
@@ -28,10 +28,8 @@ int main()
       a[j]=b[j];
   }
 
-  for (auto Dev : *DeviceMapPtr) {
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-    stop_trace(Dev);
-  }
   
 #pragma omp target teams distribute parallel for
   {


### PR DESCRIPTION
Stopping the tracing may result in termination of the helper threads. Unless a subsequent start_trace is called, trace records are not going to be delivered to the tool.