### PR TITLE
[USM] Fixed typo in CHECK string.

### DIFF
--- a/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-any/usm_locals.cpp
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-any/usm_locals.cpp
@@ -38,7 +38,7 @@ int main() {
   /// CHECK-NOT: __tgt_rtl_data_retrieve_async: {{.*}} 0 ({{.*}} 4, {{.*}})
   #pragma omp target update from(z[:10])
 
-  /// CHECK: AMDGPU error: Running a program that requries XNACK on a system where XNACK is disabled. This may cause problems when using a OS-allocated pointer inside a target region. Re-run with HSA_XNACK=1 to remove this warning.
+  /// CHECK: AMDGPU error: Running a program that requires XNACK on a system where XNACK is disabled. This may cause problems when using a OS-allocated pointer inside a target region. Re-run with HSA_XNACK=1 to remove this warning.
 
   // Note: when the output is redirected rather than printed at the console,
   // the printf'd strings are printed AFTER all the OpenMP runtime library

--- a/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-minus/usm_locals.cpp
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-minus/usm_locals.cpp
@@ -38,7 +38,7 @@ int main() {
   /// CHECK-NOT: __tgt_rtl_data_retrieve_async: {{.*}} 0 ({{.*}} 4, {{.*}})
   #pragma omp target update from(z[:10])
 
-  /// CHECK: AMDGPU error: Running a program that requries XNACK on a system where XNACK is disabled. This may cause problems when using a OS-allocated pointer inside a target region. Re-run with HSA_XNACK=1 to remove this warning.
+  /// CHECK: AMDGPU error: Running a program that requires XNACK on a system where XNACK is disabled. This may cause problems when using a OS-allocated pointer inside a target region. Re-run with HSA_XNACK=1 to remove this warning.
 
   // Note: when the output is redirected rather than printed at the console,
   // the printf'd strings are printed AFTER all the OpenMP runtime library


### PR DESCRIPTION
The tests usm-locals-pragma-xnack-disabled-xnack-any and usm-locals-pragma-xnack-disabled-xnack-minus fail due to a typo in one of the CHECK strings. (requries -> requires) This patch fixes the typo. 