### PR TITLE
[Flang] Add test for `omp target teams distribute`

### DIFF
--- a/test/smoke-fort/teams-distribute-no-parallel/Makefile
+++ b/test/smoke-fort/teams-distribute-no-parallel/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.f95
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort/teams-distribute-no-parallel/main.f95
+++ b/test/smoke-fort/teams-distribute-no-parallel/main.f95
@@ -1,0 +1,26 @@
+program main
+        integer :: hostArray(10), errors = 0
+        do i = 1, 10
+                hostArray(i) = 0
+        end do
+        call writeIndex(hostArray)
+        do i = 1, 10
+                if ( hostArray(i) /= i ) then
+                        errors = errors + 1
+                end if
+        end do
+        if ( errors /= 0 ) then
+                stop 1
+        end if
+        print*, "======= FORTRAN Test passed! ======="
+end program main
+subroutine writeIndex(int_array)
+        integer :: int_array(*)
+!$omp target teams distribute map(tofrom:int_array(1:10))
+        do index_ = 1, 10
+          int_array(index_) = index_
+        end do
+!$omp end target teams distribute
+
+end subroutine writeIndex
+


### PR DESCRIPTION
Check if flang-new can generate code for pragma `omp target teams distribute`.

This PR depends on: https://github.com/ROCm/llvm-project/pull/29