### PR TITLE
[Smoke-limbo] Use SUPPORTS_USM for the list of supported archs

### DIFF
--- a/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-any/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-any/Makefile
@@ -14,7 +14,7 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-minus/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-minus/Makefile
@@ -14,7 +14,7 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-plus/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-disabled-xnack-plus/Makefile
@@ -14,7 +14,7 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-any/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-any/Makefile
@@ -16,7 +16,7 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-minus/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-minus/Makefile
@@ -15,7 +15,7 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-plus/Makefile
+++ b/test/smoke-limbo/usm-locals-pragma-xnack-enabled-xnack-plus/Makefile
@@ -15,7 +15,7 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-SUPPORTED    = gfx90a,gfx940,gfx941,gfx942
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"


### PR DESCRIPTION
Updates MakeFiles of USM tests to use SUPPORTS_USM for SUPPORTED list of architectures.