### PR TITLE
[Smoke-fails] Use SUPPORTS_USM for the list of supported archs

### DIFF
--- a/test/smoke-fails/clang-317896/Makefile
+++ b/test/smoke-fails/clang-317896/Makefile
@@ -8,6 +8,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        = clang++ -D__HIP_PLATFORM_AMD__   -lamdhip64 -DUSE_HIP_MALLOC -DUSE_POSSIX_MEMALIGN
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/clang-328537/Makefile
+++ b/test/smoke-fails/clang-328537/Makefile
@@ -9,7 +9,8 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
-HSA_XNACK ?= 1
+HSA_XNACK    ?= 1
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-fails/clang-341190/Makefile
+++ b/test/smoke-fails/clang-341190/Makefile
@@ -14,6 +14,8 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 HSA_XNACK ?= 1
 
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/clang-388296/Makefile
+++ b/test/smoke-fails/clang-388296/Makefile
@@ -12,6 +12,8 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 HSA_XNACK ?= 1
 
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/clang-434259/Makefile
+++ b/test/smoke-fails/clang-434259/Makefile
@@ -9,6 +9,9 @@ CLANG        = clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 OMP_FLAGS 	 += -O3 --offload-arch=gfx942 -fopenmp-version=51 -D__HIP_PLATFORM_AMD__ -DUSE_DEVICE_ALLOC__ -DUSE_DEVICE_ALWAYS
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/correct_remapping_usm/Makefile
+++ b/test/smoke-fails/correct_remapping_usm/Makefile
@@ -10,6 +10,8 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 HSA_XNACK ?= 1
 
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/flang-367296/Makefile
+++ b/test/smoke-fails/flang-367296/Makefile
@@ -8,6 +8,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/flang-usm-235/Makefile
+++ b/test/smoke-fails/flang-usm-235/Makefile
@@ -11,6 +11,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        = flang 
 OMP_BIN      = $(AOMP)/bin/$(FLANG)  -Mx,235,1
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/flang-usm1/Makefile
+++ b/test/smoke-fails/flang-usm1/Makefile
@@ -11,6 +11,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        = flang 
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/flang-usm2/Makefile
+++ b/test/smoke-fails/flang-usm2/Makefile
@@ -11,6 +11,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        = flang 
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/imperfect-loop-collapse/Makefile
+++ b/test/smoke-fails/imperfect-loop-collapse/Makefile
@@ -10,6 +10,7 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
 HSA_XNACK ?= 1
+SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-fails/mix_fine_grain_and_maps/Makefile
+++ b/test/smoke-fails/mix_fine_grain_and_maps/Makefile
@@ -8,6 +8,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        = clang++ -DREQUIRES_USM
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/requires_directive/Makefile
+++ b/test/smoke-fails/requires_directive/Makefile
@@ -8,6 +8,9 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/vector_usm/Makefile
+++ b/test/smoke-fails/vector_usm/Makefile
@@ -12,6 +12,8 @@ CC           = $(OMP_BIN) $(VERBOSE)
 RUNENV       ?= HSA_XNACK=1
 RUNCMD       = ./$(TESTNAME)
 
+SUPPORTED    = $(SUPPORTS_USM)
+
 #-ccc-print-phases
 #"-\#\#\#"
 


### PR DESCRIPTION
Updates MakeFiles of USM tests to use SUPPORTS_USM for SUPPORTED list of architectures.