### PR TITLE
Fix TargetID format for clang-274983

### DIFF
--- a/test/smoke/clang-274983/Makefile
+++ b/test/smoke/clang-274983/Makefile
@@ -15,7 +15,7 @@ endif
 
 SUPPORTED    = $(SUPPORTS_USM)
 
-TARGET       = -fopenmp -O3 -fopenmp-targets=$(_gputriple) -Xopenmp-target=$(_gputriple) -march=$(AOMP_GPU)$(AOMP_TARGET_FEATURES)
+TARGET       = -fopenmp -O3 -fopenmp-targets=$(_gputriple) -Xopenmp-target=$(_gputriple) -march=$(AOMP_GPU):$(AOMP_TARGET_FEATURES)
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)


### PR DESCRIPTION
There needs to be a colon between the architecture and the target feature in a valid TargetID.