### PR TITLE
[llvm-link] Add test for error message when linking a non-existent file

### DIFF
--- a/test/smoke-limbo/link-missing-file/Makefile
+++ b/test/smoke-limbo/link-missing-file/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+# This particular test will try to link a non-existent file and check for the
+# expected error message using FileCheck.
+
+# The TESTSRC_ALL does only contain a dummy program to allow automatic checking
+# as well as returning a zero error-code.
+
+TESTNAME     = link-missing-file
+TESTSRC_ALL  = link-missing-file.c
+
+# Since llvm-link would return a non-zero exit-code, use the dummy program to
+# indicate 'success'.
+RUNCMD       = $(AOMP)/bin/llvm-link MissingFile.bc 2>&1 | \
+               $(AOMP)/bin/FileCheck $(TESTSRC_ALL); ./$(TESTNAME)
+
+include ../Makefile.rules

--- a/test/smoke-limbo/link-missing-file/link-missing-file.c
+++ b/test/smoke-limbo/link-missing-file/link-missing-file.c
@@ -1,0 +1,11 @@
+
+// This is just a dummy.
+int main(void) { return 0; }
+
+// Note: The error message we are looking for should be:
+//       /path/to/llvm-link: No such file or directory: 'MissingFile.bc'
+
+/// CHECK: llvm-link
+/// CHECK-SAME: No such file or directory:
+/// CHECK-SAME: 'MissingFile.bc'
+/// CHECK-NOT: {{.+}}


### PR DESCRIPTION
Add a simple test, which is trying to link a non-existent file, since the error message will be expanded by the missing file's name.

Depends: https://github.com/llvm/llvm-project/pull/82514