### PR TITLE
Add warning when TESTSRC_ALL is empty

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -1,3 +1,6 @@
+ifeq ($(TESTSRC_ALL),)
+    $(info    WARNING: TESTSRC_ALL is empty)
+endif
 TESTNAMES_ALL = $(basename $(TESTSRC_ALL))
 TIMEOUT ?= 60s
 SMOKE_TIMEOUT ?= timeout --foreground $(TIMEOUT)


### PR DESCRIPTION
Since TESTSRC_ALL is used in multiple places for automation, it seems reasonable to warn when the variable is actually empty.