### PR TITLE
[OpenMP][OMPT] Extend device tracing tests

### DIFF
--- a/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/callbacks.h
@@ -2,6 +2,8 @@
 #include <memory>
 #include <unordered_set>
 
+#define EMI 1
+
 // Tool related code below
 #include <omp-tools.h>
 
@@ -17,7 +19,7 @@
 
 #define OMPT_BUFFER_REQUEST_SIZE 256
 
-ompt_id_t  next_op_id = 0x8000000000000001;
+ompt_id_t next_op_id = 0x8000000000000001;
 
 // OMPT entry point handles
 static ompt_set_callback_t ompt_set_callback = 0;
@@ -29,55 +31,56 @@ static ompt_get_record_ompt_t ompt_get_record_ompt = 0;
 static ompt_advance_buffer_cursor_t ompt_advance_buffer_cursor = 0;
 
 // Map of devices traced
-typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
+typedef std::unordered_set<ompt_device_t *> DeviceMap_t;
 typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
 extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
-  if (rec == NULL) return;
-  
-  printf("rec=%p type=%2d time=%lu thread_id=%lu target_id=%lu\n",
-	 rec, rec->type, rec->time, rec->thread_id, rec->target_id);
+  if (rec == NULL)
+    return;
 
   switch (rec->type) {
   case ompt_callback_target:
-  case ompt_callback_target_emi:
-    {
-      ompt_record_target_t target_rec = rec->record.target;
-      printf("\tRecord Target task: target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu codeptr=%p\n",
-	     target_rec.target_id, 
-	     target_rec.kind, target_rec.endpoint, target_rec.device_num,
-	     target_rec.task_id, target_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_data_op:
-  case ompt_callback_target_data_op_emi:
-    {
-      ompt_record_target_data_op_t target_data_op_rec = rec->record.target_data_op;
-      printf("\t  Record Target data op: target_id=0x%lx host_op_id=0x%lx optype=%d src_addr=%p src_device=%d "
-	     "dest_addr=%p dest_device=%d bytes=%lu end_time=%lu duration=%lu ns codeptr=%p\n",
-             rec->target_id,
-	     target_data_op_rec.host_op_id, target_data_op_rec.optype,
-	     target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
-	     target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
-	     target_data_op_rec.bytes, target_data_op_rec.end_time,
-	     target_data_op_rec.end_time - rec->time,
-	     target_data_op_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_submit:
-  case ompt_callback_target_submit_emi:
-    {
-      ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
-      printf("\t  Record Target kernel:  target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u granted_num_teams=%u "
-	     "end_time=%lu duration=%lu ns\n",
-             rec->target_id,
-	     target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
-	     target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
-	     target_kernel_rec.end_time - rec->time);
+  case ompt_callback_target_emi: {
+    ompt_record_target_t target_rec = rec->record.target;
+    printf("rec=%p type=%d (Target task) time=%lu thread_id=%lu "
+           "target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu "
+           "codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_rec.kind, target_rec.endpoint, target_rec.device_num,
+           target_rec.task_id, target_rec.codeptr_ra);
     break;
-    }
+  }
+  case ompt_callback_target_data_op:
+  case ompt_callback_target_data_op_emi: {
+    ompt_record_target_data_op_t target_data_op_rec =
+        rec->record.target_data_op;
+    printf("rec=%p type=%d (Target data op) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx optype=%d "
+           "src_addr=%p src_device=%d dest_addr=%p dest_device=%d bytes=%lu "
+           "end_time=%lu duration=%lu ns codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_data_op_rec.host_op_id, target_data_op_rec.optype,
+           target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
+           target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
+           target_data_op_rec.bytes, target_data_op_rec.end_time,
+           target_data_op_rec.end_time - rec->time,
+           target_data_op_rec.codeptr_ra);
+    break;
+  }
+  case ompt_callback_target_submit:
+  case ompt_callback_target_submit_emi: {
+    ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
+    printf("rec=%p type=%d (Target kernel) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u "
+           "granted_num_teams=%u end_time=%lu duration=%lu ns\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
+           target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
+           target_kernel_rec.end_time - rec->time);
+    break;
+  }
   default:
     assert(0);
     break;
@@ -92,25 +95,21 @@ static void delete_buffer_ompt(ompt_buffer_t *buffer) {
 // OMPT callbacks
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request(int device_num,
+                                            ompt_buffer_t **buffer,
+                                            size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
-  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes, *buffer);
+  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes,
+         *buffer);
 }
 
-static void on_ompt_callback_buffer_complete (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
-  printf("Executing buffer complete callback: %d %p %lu %p %d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+static void on_ompt_callback_buffer_complete(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
+  printf("Executing buffer complete callback: %d %p %lu %p %d\n", device_num,
+         buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -118,18 +117,17 @@ static void on_ompt_callback_buffer_complete (
     ompt_record_ompt_t *rec = ompt_get_record_ompt(buffer, current);
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 static ompt_set_result_t set_trace_ompt() {
-  if (!ompt_set_trace_ompt) return ompt_set_error;
+  if (!ompt_set_trace_ompt)
+    return ompt_set_error;
 
-#if EMI  
+#if EMI
   ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
@@ -138,54 +136,54 @@ static ompt_set_result_t set_trace_ompt() {
   ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
 #endif
-  
+
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
-  if (!ompt_start_trace) return 0;
+  if (!ompt_start_trace)
+    return 0;
 
   // This device will be traced.
   assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
-	 "Device already present in the map");
+         "Device already present in the map");
   DeviceMapPtr->insert(Device);
-  
+
   return ompt_start_trace(Device, &on_ompt_callback_buffer_request,
-			  &on_ompt_callback_buffer_complete);
+                          &on_ompt_callback_buffer_complete);
 }
 
 static int flush_trace(ompt_device_t *Device) {
-  if (!ompt_flush_trace) return 0;
+  if (!ompt_flush_trace)
+    return 0;
   return ompt_flush_trace(Device);
 }
 
 static int stop_trace(ompt_device_t *Device) {
-  if (!ompt_stop_trace) return 0;
+  if (!ompt_stop_trace)
+    return 0;
   return ompt_stop_trace(Device);
 }
 
 // Synchronous callbacks
-static void on_ompt_callback_device_initialize
-(
-  int device_num,
-  const char *type,
-  ompt_device_t *device,
-  ompt_function_lookup_t lookup,
-  const char *documentation
- ) {
+static void on_ompt_callback_device_initialize(int device_num, const char *type,
+                                               ompt_device_t *device,
+                                               ompt_function_lookup_t lookup,
+                                               const char *documentation) {
   printf("Callback Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
-	 device_num, type, device, lookup, documentation);
+         device_num, type, device, lookup, documentation);
   if (!lookup) {
     printf("Trace collection disabled on device %d\n", device_num);
     return;
   }
 
-  ompt_set_trace_ompt = (ompt_set_trace_ompt_t) lookup("ompt_set_trace_ompt");
-  ompt_start_trace = (ompt_start_trace_t) lookup("ompt_start_trace");
-  ompt_flush_trace = (ompt_flush_trace_t) lookup("ompt_flush_trace");
-  ompt_stop_trace = (ompt_stop_trace_t) lookup("ompt_stop_trace");
-  ompt_get_record_ompt = (ompt_get_record_ompt_t) lookup("ompt_get_record_ompt");
-  ompt_advance_buffer_cursor = (ompt_advance_buffer_cursor_t) lookup("ompt_advance_buffer_cursor");
+  ompt_set_trace_ompt = (ompt_set_trace_ompt_t)lookup("ompt_set_trace_ompt");
+  ompt_start_trace = (ompt_start_trace_t)lookup("ompt_start_trace");
+  ompt_flush_trace = (ompt_flush_trace_t)lookup("ompt_flush_trace");
+  ompt_stop_trace = (ompt_stop_trace_t)lookup("ompt_stop_trace");
+  ompt_get_record_ompt = (ompt_get_record_ompt_t)lookup("ompt_get_record_ompt");
+  ompt_advance_buffer_cursor =
+      (ompt_advance_buffer_cursor_t)lookup("ompt_advance_buffer_cursor");
 
   // DeviceMap must be initialized only once. Ensure this logic does not
   // depend on external data structures because this init function may be
@@ -195,7 +193,7 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
+
   set_trace_ompt();
 
   // In many scenarios, this will be a good place to start the
@@ -207,127 +205,126 @@ static void on_ompt_callback_device_initialize
   start_trace(device_num, device);
 }
 
-static void on_ompt_callback_device_finalize
-(
-  int device_num
- ) {
+static void on_ompt_callback_device_finalize(int device_num) {
   printf("Callback Fini: device_num=%d\n", device_num);
 }
 
-static void on_ompt_callback_device_load
-    (
-     int device_num,
-     const char *filename,
-     int64_t offset_in_file,
-     void *vma_in_file,
-     size_t bytes,
-     void *host_addr,
-     void *device_addr,
-     uint64_t module_id
-     ) {
-  printf("Callback Load: device_num:%d filename:%s host_adddr:%p device_addr:%p bytes:%lu\n",
-	 device_num, filename, host_addr, device_addr, bytes);
+static void on_ompt_callback_device_load(int device_num, const char *filename,
+                                         int64_t offset_in_file,
+                                         void *vma_in_file, size_t bytes,
+                                         void *host_addr, void *device_addr,
+                                         uint64_t module_id) {
+  printf("Callback Load: device_num:%d filename:%s host_adddr:%p device_addr:%p"
+         " bytes:%lu\n",
+         device_num, filename, host_addr, device_addr, bytes);
 }
 
+static void on_ompt_callback_target_data_op(
+    ompt_id_t target_id, ompt_id_t host_op_id, ompt_target_data_op_t optype,
+    void *src_addr, int src_device_num, void *dest_addr, int dest_device_num,
+    size_t bytes, const void *codeptr_ra) {
+  printf("  Callback DataOp: host_op_id=%lu optype=%d src=%p src_device_num=%d "
+         "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         host_op_id, optype, src_addr, src_device_num, dest_addr,
+         dest_device_num, bytes, codeptr_ra);
+}
 
-static void on_ompt_callback_target_data_op_emi
-    (
-     ompt_scope_endpoint_t endpoint,
-     ompt_data_t *target_task_data,
-     ompt_data_t *target_data,
-     ompt_id_t *host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
-  assert(codeptr_ra != 0);
-  // Both src and dest must not be null
-  assert(src_addr != 0 || dest_addr != 0);
-  if (endpoint == ompt_scope_begin) *host_op_id = next_op_id++;
+static void on_ompt_callback_target_data_op_emi(
+    ompt_scope_endpoint_t endpoint, ompt_data_t *target_task_data,
+    ompt_data_t *target_data, ompt_id_t *host_op_id,
+    ompt_target_data_op_t optype, void *src_addr, int src_device_num,
+    void *dest_addr, int dest_device_num, size_t bytes,
+    const void *codeptr_ra) {
+  if (endpoint == ompt_scope_begin)
+    *host_op_id = next_op_id++;
   // target_task_data may be null, avoid dereferencing it
-  uint64_t target_task_data_value = (target_task_data) ? target_task_data->value : 0;
-  printf("  Callback DataOp EMI: endpoint=%d optype=%d target_task_data=%p (0x%lx) target_data=%p (0x%lx) host_op_id=%p (0x%lx) src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 endpoint, optype,
-         target_task_data, target_task_data_value,
-         target_data, target_data->value,
-         host_op_id, *host_op_id,
-         src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+  uint64_t target_task_data_value =
+      (target_task_data) ? target_task_data->value : 0;
+  printf("  Callback DataOp EMI: endpoint=%d optype=%d target_task_data=%p "
+         "(0x%lx) target_data=%p (0x%lx) host_op_id=%p (0x%lx) src=%p "
+         "src_device_num=%d dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         endpoint, optype, target_task_data, target_task_data_value,
+         target_data, target_data->value, host_op_id, *host_op_id, src_addr,
+         src_device_num, dest_addr, dest_device_num, bytes, codeptr_ra);
 }
 
+static void on_ompt_callback_target(ompt_target_t kind,
+                                    ompt_scope_endpoint_t endpoint,
+                                    int device_num, ompt_data_t *task_data,
+                                    ompt_id_t target_id,
+                                    const void *codeptr_ra) {
+  printf("Callback Target: kind=%d endpoint=%d device_num=%d target_id=%lu "
+         "code=%p\n",
+         kind, endpoint, device_num, target_id, codeptr_ra);
+}
 
-static void on_ompt_callback_target_emi
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_data_t *target_task_data,
-     ompt_data_t *target_data,
-     const void *codeptr_ra
-     ) {
-  assert(codeptr_ra != 0);
-  if (endpoint == ompt_scope_begin) target_data->value = next_op_id++;
+static void on_ompt_callback_target_emi(ompt_target_t kind,
+                                        ompt_scope_endpoint_t endpoint,
+                                        int device_num, ompt_data_t *task_data,
+                                        ompt_data_t *target_task_data,
+                                        ompt_data_t *target_data,
+                                        const void *codeptr_ra) {
+  if (endpoint == ompt_scope_begin)
+    target_data->value = next_op_id++;
   // target_task_data may be null, avoid dereferencing it
-  uint64_t target_task_data_value = (target_task_data) ? target_task_data->value : 0;
-  printf("Callback Target EMI: kind=%d endpoint=%d device_num=%d task_data=%p (0x%lx) target_task_data=%p (0x%lx) target_data=%p (0x%lx) code=%p\n",
-	 kind, endpoint, device_num,
-         task_data, task_data->value,
-         target_task_data, target_task_data_value,
-         target_data, target_data->value,
-         codeptr_ra);
+  uint64_t target_task_data_value =
+      (target_task_data) ? target_task_data->value : 0;
+  printf("Callback Target EMI: kind=%d endpoint=%d device_num=%d task_data=%p "
+         "(0x%lx) target_task_data=%p (0x%lx) target_data=%p (0x%lx) code=%p\n",
+         kind, endpoint, device_num, task_data, task_data->value,
+         target_task_data, target_task_data_value, target_data,
+         target_data->value, codeptr_ra);
 }
 
-static void on_ompt_callback_target_submit_emi
-    (
-     ompt_scope_endpoint_t endpoint,
-     ompt_data_t *target_data,
-     ompt_id_t *host_op_id,
-     unsigned int requested_num_teams
-     ) {
-  printf("  Callback Submit EMI: endpoint=%d  req_num_teams=%d target_data=%p (0x%lx) host_op_id=%p (0x%lx)\n",
-	 endpoint, requested_num_teams,
-	 target_data, target_data->value,
-	 host_op_id, *host_op_id);
+static void on_ompt_callback_target_submit(ompt_id_t target_id,
+                                           ompt_id_t host_op_id,
+                                           unsigned int requested_num_teams) {
+  printf("  Callback Submit: target_id=%lu host_op_id=%lu req_num_teams=%d\n",
+         target_id, host_op_id, requested_num_teams);
+}
+
+static void on_ompt_callback_target_submit_emi(
+    ompt_scope_endpoint_t endpoint, ompt_data_t *target_data,
+    ompt_id_t *host_op_id, unsigned int requested_num_teams) {
+  printf("  Callback Submit EMI: endpoint=%d req_num_teams=%d target_data=%p "
+         "(0x%lx) host_op_id=%p (0x%lx)\n",
+         endpoint, requested_num_teams, target_data, target_data->value,
+         host_op_id, *host_op_id);
 }
 
 // Init functions
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
 
-  if (!ompt_set_callback) return 0; // failed
+  if (!ompt_set_callback)
+    return 0; // failed
 
   register_ompt_callback(ompt_callback_device_initialize);
   register_ompt_callback(ompt_callback_device_finalize);
   register_ompt_callback(ompt_callback_device_load);
+#if EMI
   register_ompt_callback(ompt_callback_target_data_op_emi);
   register_ompt_callback(ompt_callback_target_emi);
   register_ompt_callback(ompt_callback_target_submit_emi);
+#else
+  register_ompt_callback(ompt_callback_target_data_op);
+  register_ompt_callback(ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_submit);
+#endif
 
-  return 1; //success
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{
-}
+void ompt_finalize(ompt_data_t *tool_data) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t *ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus

--- a/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/veccopy-ompt-target-data-tracing-emi.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/veccopy-ompt-target-data-tracing-emi.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include <assert.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 
@@ -38,7 +38,7 @@ int main() {
 
   for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-  
+
 #pragma omp target parallel for map(alloc : c)
   {
     for (int j = 0; j < N; j++)
@@ -47,11 +47,9 @@ int main() {
 #pragma omp target update from(c) nowait
 #pragma omp barrier
 
-  for (auto Dev : *DeviceMapPtr) {
+  for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-    stop_trace(Dev);
-  }
-  
+
   int rc = 0;
   for (i = 0; i < N; i++) {
     if (a[i] != i) {
@@ -73,26 +71,30 @@ int main() {
   return rc;
 }
 
+// clang-format off
+
+// > OMPT device callback related checks below. <
+
 /// CHECK-NOT: Callback Target EMI:
 /// CHECK-NOT: device_num=-1
 
 /// CHECK: Callback Init:
 /// CHECK: Callback Load:
 
-/// CHECK: Callback Target EMI: kind=2 endpoint=1
+/// CHECK-DAG: Callback Target EMI: kind=2 endpoint=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=2
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=2
 /// CHECK-DAG: Callback Target EMI: kind=2 endpoint=2
 
-/// CHECK: Callback Target EMI: kind=1 endpoint=1
+/// CHECK-DAG: Callback Target EMI: kind=1 endpoint=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=2
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=2
-/// CHECK-DAG: Callback Submit EMI: endpoint=1  req_num_teams=1
-/// CHECK-DAG: Callback Submit EMI: endpoint=2  req_num_teams=1
+/// CHECK-DAG: Callback Submit EMI: endpoint=1 req_num_teams=1
+/// CHECK-DAG: Callback Submit EMI: endpoint=2 req_num_teams=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=3
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=3
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=4
@@ -105,15 +107,121 @@ int main() {
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=4
 /// CHECK-DAG: Callback Target EMI: kind=3 endpoint=2
 
-/// CHECK: Callback Target EMI: kind=1 endpoint=1
-/// CHECK-DAG: Callback Submit EMI: endpoint=1  req_num_teams=1
-/// CHECK-DAG: Callback Submit EMI: endpoint=2  req_num_teams=1
+/// CHECK-DAG: Callback Target EMI: kind=1 endpoint=1
+/// CHECK-DAG: Callback Submit EMI: endpoint=1 req_num_teams=1
+/// CHECK-DAG: Callback Submit EMI: endpoint=2 req_num_teams=1
 /// CHECK-DAG: Callback Target EMI: kind=1 endpoint=2
 /// CHECK-DAG: Callback Target EMI: kind=4 endpoint=1
 /// CHECK-DAG: Callback DataOp EMI: endpoint=1 optype=3
 /// CHECK-DAG: Callback DataOp EMI: endpoint=2 optype=3
 /// CHECK-DAG: Callback Target EMI: kind=4 endpoint=2
 
-/// CHECK-DAG: Record Target kernel
+/// CHECK-DAG: Success
+/// CHECK-DAG: Callback Fini:
 
-/// CHECK: Callback Fini:
+// > OMPT device tracing related checks below. <
+
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_02:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_03:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_04:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_05:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_06:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_07:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_08:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_09:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_10:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_11:0x[0-f]+]] in buffer request callback
+
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}}
+
+// Note: This entry should happen due to the call to flush_trace.
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} {{.+}} {{[0-9]+}}
+
+// Note: Split checks for record address and content. That way we do not imply
+//       any order. Records 01-06 and 12-17 occur interleaved and belong to the
+//       first target region. 07-11 occur interleaved with 18-22 and belong to
+//       the second target region.
+/// CHECK-DAG: rec=[[ADDRX_01]]
+/// CHECK-DAG: rec=[[ADDRX_02]]
+/// CHECK-DAG: rec=[[ADDRX_03]]
+/// CHECK-DAG: rec=[[ADDRX_04]]
+/// CHECK-DAG: rec=[[ADDRX_05]]
+/// CHECK-DAG: rec=[[ADDRX_06]]
+/// CHECK-DAG: rec=[[ADDRX_07]]
+/// CHECK-DAG: rec=[[ADDRX_08]]
+/// CHECK-DAG: rec=[[ADDRX_09]]
+/// CHECK-DAG: rec=[[ADDRX_10]]
+/// CHECK-DAG: rec=[[ADDRX_11]]
+
+// Note: These addresses will only occur once. They are only captured to
+//       indicate their existence.
+/// CHECK-DAG: rec=[[ADDRX_12:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_13:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_14:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_15:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_16:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_17:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_18:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_19:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_20:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_21:0x[0-f]+]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=2 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=2 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=3 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=3 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=4 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=4 endpoint=2
+
+// Note: ADDRX_11 may not trigger a final callback.
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} (nil) {{[0-9]+}}
+
+// Note: ADDRX_11 may not be deallocated.
+/// CHECK-DAG: Deallocated [[ADDRX_01]]
+/// CHECK-DAG: Deallocated [[ADDRX_02]]
+/// CHECK-DAG: Deallocated [[ADDRX_03]]
+/// CHECK-DAG: Deallocated [[ADDRX_04]]
+/// CHECK-DAG: Deallocated [[ADDRX_05]]
+/// CHECK-DAG: Deallocated [[ADDRX_06]]
+/// CHECK-DAG: Deallocated [[ADDRX_07]]
+/// CHECK-DAG: Deallocated [[ADDRX_08]]
+/// CHECK-DAG: Deallocated [[ADDRX_09]]
+/// CHECK-DAG: Deallocated [[ADDRX_10]]
+
+/// CHECK-NOT: rec=
+/// CHECK-NOT: host_op_id=0x0

--- a/test/smoke-limbo/veccopy-ompt-target-default-device/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/callbacks.h
@@ -5,55 +5,72 @@
 // Tool related code below
 #include <omp-tools.h>
 
+// Enable / disable OMPT's 'External Monitoring Interface'
+#define EMI 0
+
+// From openmp/runtime/test/ompt/callback.h
+#define register_ompt_callback_t(name, type)                                   \
+  do {                                                                         \
+    type f_##name = &on_##name;                                                \
+    if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
+      printf("0: Could not register callback '" #name "'\n");                  \
+  } while (0)
+
+#define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
+
 #define OMPT_BUFFER_REQUEST_SIZE 256
 
 // Map of devices traced
-typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
+typedef std::unordered_set<ompt_device_t *> DeviceMap_t;
 typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
 extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
-  if (rec == NULL) return;
-  
-  printf("rec=%p type=%d time=%lu thread_id=%lu target_id=%lu\n",
-	 rec, rec->type, rec->time, rec->thread_id, rec->target_id);
+  if (rec == NULL)
+    return;
 
   switch (rec->type) {
   case ompt_callback_target:
-  case ompt_callback_target_emi:
-    {
-      ompt_record_target_t target_rec = rec->record.target;
-      printf("\tRecord Target: kind=%d endpoint=%d device=%d task_id=%lu target_id=%lu codeptr=%p\n",
-	     target_rec.kind, target_rec.endpoint, target_rec.device_num,
-	     target_rec.task_id, target_rec.target_id, target_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_data_op:
-  case ompt_callback_target_data_op_emi:
-    {
-      ompt_record_target_data_op_t target_data_op_rec = rec->record.target_data_op;
-      printf("\t  Record DataOp: host_op_id=%lu optype=%d src_addr=%p src_device=%d "
-	     "dest_addr=%p dest_device=%d bytes=%lu end_time=%lu duration=%lu ns codeptr=%p\n",
-	     target_data_op_rec.host_op_id, target_data_op_rec.optype,
-	     target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
-	     target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
-	     target_data_op_rec.bytes, target_data_op_rec.end_time,
-	     target_data_op_rec.end_time - rec->time,
-	     target_data_op_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_submit:
-  case ompt_callback_target_submit_emi:
-    {
-      ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
-      printf("\t  Record Submit: host_op_id=%lu requested_num_teams=%u granted_num_teams=%u "
-	     "end_time=%lu duration=%lu ns\n",
-	     target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
-	     target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
-	     target_kernel_rec.end_time - rec->time);
+  case ompt_callback_target_emi: {
+    ompt_record_target_t target_rec = rec->record.target;
+    printf("rec=%p type=%d (Target task) time=%lu thread_id=%lu "
+           "target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu "
+           "codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_rec.kind, target_rec.endpoint, target_rec.device_num,
+           target_rec.task_id, target_rec.codeptr_ra);
     break;
-    }
+  }
+  case ompt_callback_target_data_op:
+  case ompt_callback_target_data_op_emi: {
+    ompt_record_target_data_op_t target_data_op_rec =
+        rec->record.target_data_op;
+    printf("rec=%p type=%d (Target data op) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx optype=%d "
+           "src_addr=%p src_device=%d dest_addr=%p dest_device=%d bytes=%lu "
+           "end_time=%lu duration=%lu ns codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_data_op_rec.host_op_id, target_data_op_rec.optype,
+           target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
+           target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
+           target_data_op_rec.bytes, target_data_op_rec.end_time,
+           target_data_op_rec.end_time - rec->time,
+           target_data_op_rec.codeptr_ra);
+    break;
+  }
+  case ompt_callback_target_submit:
+  case ompt_callback_target_submit_emi: {
+    ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
+    printf("rec=%p type=%d (Target kernel) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u "
+           "granted_num_teams=%u end_time=%lu duration=%lu ns\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
+           target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
+           target_kernel_rec.end_time - rec->time);
+    break;
+  }
   default:
     assert(0);
     break;
@@ -77,30 +94,25 @@ static ompt_get_record_type_t ompt_get_record_type_fn = 0;
 // OMPT callbacks
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request_default_device (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request_default_device(
+    int device_num, ompt_buffer_t **buffer, size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
-  printf("Allocated %lu bytes at %p in buffer request callback for default device %d\n",
-	 *bytes, *buffer, device_num);
+  printf("Allocated %lu bytes at %p in buffer request callback for default "
+         "device %d\n",
+         *bytes, *buffer, device_num);
 }
 
 // Note: This callback must handle a null begin cursor. Currently,
 // ompt_get_record_ompt, print_record_ompt, and
 // ompt_advance_buffer_cursor handle a null cursor.
-static void on_ompt_callback_buffer_complete_default_device (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
+static void on_ompt_callback_buffer_complete_default_device(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
   printf("Executing buffer complete callback for default device: \
-device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+  device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
+         device_num, buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -112,16 +124,15 @@ device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
     }
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
-  if (!ompt_set_trace_ompt) return ompt_set_error;
+  if (!ompt_set_trace_ompt)
+    return ompt_set_error;
 
   ompt_set_trace_ompt(Device, /*enable=*/1, ompt_callback_target);
   ompt_set_trace_ompt(Device, /*enable=*/1, ompt_callback_target_data_op);
@@ -129,7 +140,7 @@ static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
 
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
   if (!ompt_start_trace)
     return 0;
@@ -138,49 +149,51 @@ static int start_trace(int device_num, ompt_device_t *Device) {
 
   // This device will be traced.
   assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
-	 "Device already present in the map");
+         "Device already present in the map");
   DeviceMapPtr->insert(Device);
-  
-  return ompt_start_trace(Device, &on_ompt_callback_buffer_request_default_device,
-			  &on_ompt_callback_buffer_complete_default_device);
+
+  return ompt_start_trace(Device,
+                          &on_ompt_callback_buffer_request_default_device,
+                          &on_ompt_callback_buffer_complete_default_device);
 }
 
 static int flush_trace(ompt_device_t *Device) {
-  if (!ompt_flush_trace) return 0;
+  if (!ompt_flush_trace)
+    return 0;
   return ompt_flush_trace(Device);
 }
 
 static int stop_trace(ompt_device_t *Device) {
-  if (!ompt_stop_trace) return 0;
+  if (!ompt_stop_trace)
+    return 0;
   return ompt_stop_trace(Device);
 }
 
 // Synchronous callbacks
-static void on_ompt_callback_device_initialize
-(
-  int device_num,
-  const char *type,
-  ompt_device_t *device,
-  ompt_function_lookup_t lookup,
-  const char *documentation
- ) {
-  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
-	 device_num, type, device, lookup, documentation);
+static void on_ompt_callback_device_initialize(int device_num, const char *type,
+                                               ompt_device_t *device,
+                                               ompt_function_lookup_t lookup,
+                                               const char *documentation) {
+  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n", device_num,
+         type, device, lookup, documentation);
   if (!lookup) {
     printf("Trace collection disabled on device %d\n", device_num);
     return;
   }
 
-  ompt_set_trace_ompt = (ompt_set_trace_ompt_t) lookup("ompt_set_trace_ompt");
-  ompt_start_trace = (ompt_start_trace_t) lookup("ompt_start_trace");
-  ompt_flush_trace = (ompt_flush_trace_t) lookup("ompt_flush_trace");
-  ompt_stop_trace = (ompt_stop_trace_t) lookup("ompt_stop_trace");
-  ompt_get_record_ompt = (ompt_get_record_ompt_t) lookup("ompt_get_record_ompt");
-  ompt_advance_buffer_cursor = (ompt_advance_buffer_cursor_t) lookup("ompt_advance_buffer_cursor");
+  ompt_set_trace_ompt = (ompt_set_trace_ompt_t)lookup("ompt_set_trace_ompt");
+  ompt_start_trace = (ompt_start_trace_t)lookup("ompt_start_trace");
+  ompt_flush_trace = (ompt_flush_trace_t)lookup("ompt_flush_trace");
+  ompt_stop_trace = (ompt_stop_trace_t)lookup("ompt_stop_trace");
+  ompt_get_record_ompt = (ompt_get_record_ompt_t)lookup("ompt_get_record_ompt");
+  ompt_advance_buffer_cursor =
+      (ompt_advance_buffer_cursor_t)lookup("ompt_advance_buffer_cursor");
 
-  ompt_get_record_type_fn = (ompt_get_record_type_t) lookup("ompt_get_record_type");
+  ompt_get_record_type_fn =
+      (ompt_get_record_type_t)lookup("ompt_get_record_type");
   if (!ompt_get_record_type_fn) {
-    printf("WARNING: No function ompt_get_record_type found in device callbacks\n");
+    printf("WARNING: No function ompt_get_record_type found in device "
+           "callbacks\n");
   }
 
   // DeviceMap must be initialized only once. Ensure this logic does not
@@ -191,100 +204,81 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
+
   set_trace_ompt(device);
-  
+
   start_trace(device_num, device);
 }
 
-static void on_ompt_callback_device_load
-    (
-     int device_num,
-     const char *filename,
-     int64_t offset_in_file,
-     void *vma_in_file,
-     size_t bytes,
-     void *host_addr,
-     void *device_addr,
-     uint64_t module_id
-     ) {
-  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p bytes:%lu\n",
-	 device_num, filename, host_addr, device_addr, bytes);
+static void on_ompt_callback_device_finalize(int device_num) {
+  printf("Callback Fini: device_num=%d\n", device_num);
 }
 
-static void on_ompt_callback_target_data_op
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
-  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 target_id, host_op_id, optype, src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+static void on_ompt_callback_device_load(int device_num, const char *filename,
+                                         int64_t offset_in_file,
+                                         void *vma_in_file, size_t bytes,
+                                         void *host_addr, void *device_addr,
+                                         uint64_t module_id) {
+  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p "
+         "bytes:%lu\n",
+         device_num, filename, host_addr, device_addr, bytes);
 }
 
-static void on_ompt_callback_target
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_id_t target_id,
-     const void *codeptr_ra
-     ) {
-  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d code=%p\n",
-	 target_id, kind, endpoint, device_num, codeptr_ra);
+static void on_ompt_callback_target_data_op(
+    ompt_id_t target_id, ompt_id_t host_op_id, ompt_target_data_op_t optype,
+    void *src_addr, int src_device_num, void *dest_addr, int dest_device_num,
+    size_t bytes, const void *codeptr_ra) {
+  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p "
+         "src_device_num=%d "
+         "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         target_id, host_op_id, optype, src_addr, src_device_num, dest_addr,
+         dest_device_num, bytes, codeptr_ra);
 }
 
-static void on_ompt_callback_target_submit
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     unsigned int requested_num_teams
-     ) {
+static void on_ompt_callback_target(ompt_target_t kind,
+                                    ompt_scope_endpoint_t endpoint,
+                                    int device_num, ompt_data_t *task_data,
+                                    ompt_id_t target_id,
+                                    const void *codeptr_ra) {
+  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d "
+         "code=%p\n",
+         target_id, kind, endpoint, device_num, codeptr_ra);
+}
+
+static void on_ompt_callback_target_submit(ompt_id_t target_id,
+                                           ompt_id_t host_op_id,
+                                           unsigned int requested_num_teams) {
   printf("  Callback Submit: target_id=%lu host_op_id=%lu req_num_teams=%d\n",
-     target_id, host_op_id, requested_num_teams);
+         target_id, host_op_id, requested_num_teams);
 }
 
 // Init functions
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
 
-  ompt_set_callback(ompt_callback_device_initialize,
-		    (ompt_callback_t)&on_ompt_callback_device_initialize);
-  ompt_set_callback(ompt_callback_device_load,
-		    (ompt_callback_t)&on_ompt_callback_device_load);
-  ompt_set_callback(ompt_callback_target_data_op,
-		    (ompt_callback_t)&on_ompt_callback_target_data_op);
-  ompt_set_callback(ompt_callback_target,
-		    (ompt_callback_t)&on_ompt_callback_target);
-  ompt_set_callback(ompt_callback_target_submit,
-		    (ompt_callback_t)&on_ompt_callback_target_submit);
-  return 1; //success
+  if (!ompt_set_callback)
+    return 0; // failed
+
+  register_ompt_callback(ompt_callback_device_initialize);
+  register_ompt_callback(ompt_callback_device_finalize);
+  register_ompt_callback(ompt_callback_device_load);
+  register_ompt_callback(ompt_callback_target_data_op);
+  register_ompt_callback(ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_submit);
+
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{}
+void ompt_finalize(ompt_data_t *tool_data) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t *ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus

--- a/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include <cassert>
 #include <omp.h>
+#include <stdio.h>
 
 // This test starts device tracing on the default device only (see
 // start_trace in callbacks.h). However, if more devices are
@@ -14,8 +14,7 @@
 // Map of devices traced
 DeviceMapPtr_t DeviceMapPtr;
 
-int main()
-{
+int main() {
   int N = 100000;
 
   int a[N];
@@ -23,38 +22,35 @@ int main()
 
   int i;
 
-  for (i=0; i<N; i++)
-    a[i]=0;
+  for (i = 0; i < N; i++)
+    a[i] = 0;
 
-  for (i=0; i<N; i++)
-    b[i]=i;
+  for (i = 0; i < N; i++)
+    b[i] = i;
 
-  // Warm up
-#pragma omp target 
-  {
+    // Warm up
+#pragma omp target
+  {}
+
+  for (auto Dev : *DeviceMapPtr)
+    flush_trace(Dev);
+
+  for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
+#pragma omp target teams distribute parallel for device(dev)
+    {
+      for (int j = 0; j < N; j++)
+        a[j] = b[j];
+    }
   }
 
   for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-  
-  for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
-#pragma omp target teams distribute parallel for device(dev)
-    {
-      for (int j = 0; j< N; j++)
-	a[j]=b[j];
-    }
-  }
 
-  for (auto Dev : *DeviceMapPtr) {
-    flush_trace(Dev);
-    stop_trace(Dev);
-  }
-  
   int rc = 0;
-  for (i=0; i<N; i++)
-    if (a[i] != b[i] ) {
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
       rc++;
-      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
     }
 
   if (!rc)
@@ -63,5 +59,79 @@ int main()
   return rc;
 }
 
-/// CHECK: Record Submit
+// clang-format off
 
+// > OMPT device tracing related checks below. <
+
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_02:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_03:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_04:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_05:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_06:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_07:0x[0-f]+]] in buffer request callback
+
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_01]], {{.+}} begin=[[ADDRX_01]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} begin=[[ADDRX_02]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_03]], {{.+}} begin=[[ADDRX_03]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_04]], {{.+}} begin=[[ADDRX_04]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_05]], {{.+}} begin=[[ADDRX_05]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=[[ADDRX_06]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_07]], {{.+}} begin=[[ADDRX_07]]
+
+// Note: This entry should happen due to the call to flush_trace.
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} buffer_owned=0
+
+// Note: Split checks for record address and content. That way we do not imply
+//       any order. Records may / will occur interleaved.
+/// CHECK-DAG: rec=[[ADDRX_01]]
+/// CHECK-DAG: rec=[[ADDRX_02]]
+/// CHECK-DAG: rec=[[ADDRX_03]]
+/// CHECK-DAG: rec=[[ADDRX_04]]
+/// CHECK-DAG: rec=[[ADDRX_05]]
+/// CHECK-DAG: rec=[[ADDRX_06]]
+/// CHECK-DAG: rec=[[ADDRX_07]]
+
+// Note: These addresses will only occur once. They are only captured to
+//       indicate their existence.
+/// CHECK-DAG: rec=[[ADDRX_08:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_09:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_10:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_11:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_12:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_13:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_14:0x[0-f]+]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=0
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+
+// Note: ADDRX_07 may not trigger a final callback.
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_01]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_03]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_04]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_05]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=(nil)
+
+// Note: ADDRX_07 may not be deallocated.
+/// CHECK-DAG: Deallocated [[ADDRX_01]]
+/// CHECK-DAG: Deallocated [[ADDRX_02]]
+/// CHECK-DAG: Deallocated [[ADDRX_03]]
+/// CHECK-DAG: Deallocated [[ADDRX_04]]
+/// CHECK-DAG: Deallocated [[ADDRX_05]]
+/// CHECK-DAG: Deallocated [[ADDRX_06]]
+
+/// CHECK-NOT: rec=
+/// CHECK-NOT: host_op_id=0x0

--- a/test/smoke-limbo/veccopy-ompt-target-devices/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-devices/callbacks.h
@@ -5,55 +5,72 @@
 // Tool related code below
 #include <omp-tools.h>
 
+// Enable / disable OMPT's 'External Monitoring Interface'
+#define EMI 0
+
+// From openmp/runtime/test/ompt/callback.h
+#define register_ompt_callback_t(name, type)                                   \
+  do {                                                                         \
+    type f_##name = &on_##name;                                                \
+    if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
+      printf("0: Could not register callback '" #name "'\n");                  \
+  } while (0)
+
+#define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
+
 #define OMPT_BUFFER_REQUEST_SIZE 256
 
 // Map of devices traced
-typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
+typedef std::unordered_set<ompt_device_t *> DeviceMap_t;
 typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
 extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
-  if (rec == NULL) return;
-  
-  printf("rec=%p type=%d time=%lu thread_id=%lu target_id=%lu\n",
-	 rec, rec->type, rec->time, rec->thread_id, rec->target_id);
+  if (rec == NULL)
+    return;
 
   switch (rec->type) {
   case ompt_callback_target:
-  case ompt_callback_target_emi:
-    {
-      ompt_record_target_t target_rec = rec->record.target;
-      printf("\tRecord Target: kind=%d endpoint=%d device=%d task_id=%lu target_id=%lu codeptr=%p\n",
-	     target_rec.kind, target_rec.endpoint, target_rec.device_num,
-	     target_rec.task_id, target_rec.target_id, target_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_data_op:
-  case ompt_callback_target_data_op_emi:
-    {
-      ompt_record_target_data_op_t target_data_op_rec = rec->record.target_data_op;
-      printf("\t  Record DataOp: host_op_id=%lu optype=%d src_addr=%p src_device=%d "
-	     "dest_addr=%p dest_device=%d bytes=%lu end_time=%lu duration=%lu ns codeptr=%p\n",
-	     target_data_op_rec.host_op_id, target_data_op_rec.optype,
-	     target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
-	     target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
-	     target_data_op_rec.bytes, target_data_op_rec.end_time,
-	     target_data_op_rec.end_time - rec->time,
-	     target_data_op_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_submit:
-  case ompt_callback_target_submit_emi:
-    {
-      ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
-      printf("\t  Record Submit: host_op_id=%lu requested_num_teams=%u granted_num_teams=%u "
-	     "end_time=%lu duration=%lu ns\n",
-	     target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
-	     target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
-	     target_kernel_rec.end_time - rec->time);
+  case ompt_callback_target_emi: {
+    ompt_record_target_t target_rec = rec->record.target;
+    printf("rec=%p type=%d (Target task) time=%lu thread_id=%lu "
+           "target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu "
+           "codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_rec.kind, target_rec.endpoint, target_rec.device_num,
+           target_rec.task_id, target_rec.codeptr_ra);
     break;
-    }
+  }
+  case ompt_callback_target_data_op:
+  case ompt_callback_target_data_op_emi: {
+    ompt_record_target_data_op_t target_data_op_rec =
+        rec->record.target_data_op;
+    printf("rec=%p type=%d (Target data op) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx optype=%d "
+           "src_addr=%p src_device=%d dest_addr=%p dest_device=%d bytes=%lu "
+           "end_time=%lu duration=%lu ns codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_data_op_rec.host_op_id, target_data_op_rec.optype,
+           target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
+           target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
+           target_data_op_rec.bytes, target_data_op_rec.end_time,
+           target_data_op_rec.end_time - rec->time,
+           target_data_op_rec.codeptr_ra);
+    break;
+  }
+  case ompt_callback_target_submit:
+  case ompt_callback_target_submit_emi: {
+    ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
+    printf("rec=%p type=%d (Target kernel) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u "
+           "granted_num_teams=%u end_time=%lu duration=%lu ns\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
+           target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
+           target_kernel_rec.end_time - rec->time);
+    break;
+  }
   default:
     assert(0);
     break;
@@ -77,42 +94,35 @@ static ompt_get_record_type_t ompt_get_record_type_fn = 0;
 // OMPT callbacks
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request_default_device (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request_default_device(
+    int device_num, ompt_buffer_t **buffer, size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
-  printf("Allocated %lu bytes at %p in buffer request callback for default device %d\n",
-	 *bytes, *buffer, device_num);
+  printf("Allocated %lu bytes at %p in buffer request callback for default "
+         "device %d\n",
+         *bytes, *buffer, device_num);
 }
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request(int device_num,
+                                            ompt_buffer_t **buffer,
+                                            size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
   printf("Allocated %lu bytes at %p in buffer request callback for device %d\n",
-	 *bytes, *buffer, device_num);
+         *bytes, *buffer, device_num);
 }
 
 // Note: This callback must handle a null begin cursor. Currently,
 // ompt_get_record_ompt, print_record_ompt, and
 // ompt_advance_buffer_cursor handle a null cursor.
-static void on_ompt_callback_buffer_complete_default_device (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
+static void on_ompt_callback_buffer_complete_default_device(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
   printf("Executing buffer complete callback for default device: \
-device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+  device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
+         device_num, buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -124,27 +134,22 @@ device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
     }
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 // Note: This callback must handle a null begin cursor. Currently,
 // ompt_get_record_ompt, print_record_ompt, and
 // ompt_advance_buffer_cursor handle a null cursor.
-static void on_ompt_callback_buffer_complete (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
+static void on_ompt_callback_buffer_complete(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
   printf("Executing buffer complete callback: \
-device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+  device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
+         device_num, buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -156,16 +161,15 @@ device_num=%d, buffer=%p, num_bytes=%lu, begin=%p, buffer_owned=%d\n",
     }
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
-  if (!ompt_set_trace_ompt) return ompt_set_error;
+  if (!ompt_set_trace_ompt)
+    return ompt_set_error;
 
   ompt_set_trace_ompt(Device, /*enable=*/1, ompt_callback_target);
   ompt_set_trace_ompt(Device, /*enable=*/1, ompt_callback_target_data_op);
@@ -173,58 +177,61 @@ static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
 
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
-  if (!ompt_start_trace) return 0;
+  if (!ompt_start_trace)
+    return 0;
 
   // This device will be traced.
   assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
-	 "Device already present in the map");
+         "Device already present in the map");
   DeviceMapPtr->insert(Device);
-  
+
   if (device_num == omp_get_default_device())
-    return ompt_start_trace(Device, &on_ompt_callback_buffer_request_default_device,
-			    &on_ompt_callback_buffer_complete_default_device);
+    return ompt_start_trace(Device,
+                            &on_ompt_callback_buffer_request_default_device,
+                            &on_ompt_callback_buffer_complete_default_device);
   return ompt_start_trace(Device, &on_ompt_callback_buffer_request,
-			  &on_ompt_callback_buffer_complete);
+                          &on_ompt_callback_buffer_complete);
 }
 
 static int flush_trace(ompt_device_t *Device) {
-  if (!ompt_flush_trace) return 0;
+  if (!ompt_flush_trace)
+    return 0;
   return ompt_flush_trace(Device);
 }
 
 static int stop_trace(ompt_device_t *Device) {
-  if (!ompt_stop_trace) return 0;
+  if (!ompt_stop_trace)
+    return 0;
   return ompt_stop_trace(Device);
 }
 
 // Synchronous callbacks
-static void on_ompt_callback_device_initialize
-(
-  int device_num,
-  const char *type,
-  ompt_device_t *device,
-  ompt_function_lookup_t lookup,
-  const char *documentation
- ) {
-  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
-	 device_num, type, device, lookup, documentation);
+static void on_ompt_callback_device_initialize(int device_num, const char *type,
+                                               ompt_device_t *device,
+                                               ompt_function_lookup_t lookup,
+                                               const char *documentation) {
+  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n", device_num,
+         type, device, lookup, documentation);
   if (!lookup) {
     printf("Trace collection disabled on device %d\n", device_num);
     return;
   }
 
-  ompt_set_trace_ompt = (ompt_set_trace_ompt_t) lookup("ompt_set_trace_ompt");
-  ompt_start_trace = (ompt_start_trace_t) lookup("ompt_start_trace");
-  ompt_flush_trace = (ompt_flush_trace_t) lookup("ompt_flush_trace");
-  ompt_stop_trace = (ompt_stop_trace_t) lookup("ompt_stop_trace");
-  ompt_get_record_ompt = (ompt_get_record_ompt_t) lookup("ompt_get_record_ompt");
-  ompt_advance_buffer_cursor = (ompt_advance_buffer_cursor_t) lookup("ompt_advance_buffer_cursor");
+  ompt_set_trace_ompt = (ompt_set_trace_ompt_t)lookup("ompt_set_trace_ompt");
+  ompt_start_trace = (ompt_start_trace_t)lookup("ompt_start_trace");
+  ompt_flush_trace = (ompt_flush_trace_t)lookup("ompt_flush_trace");
+  ompt_stop_trace = (ompt_stop_trace_t)lookup("ompt_stop_trace");
+  ompt_get_record_ompt = (ompt_get_record_ompt_t)lookup("ompt_get_record_ompt");
+  ompt_advance_buffer_cursor =
+      (ompt_advance_buffer_cursor_t)lookup("ompt_advance_buffer_cursor");
 
-  ompt_get_record_type_fn = (ompt_get_record_type_t) lookup("ompt_get_record_type");
+  ompt_get_record_type_fn =
+      (ompt_get_record_type_t)lookup("ompt_get_record_type");
   if (!ompt_get_record_type_fn) {
-    printf("WARNING: No function ompt_get_record_type found in device callbacks\n");
+    printf("WARNING: No function ompt_get_record_type found in device "
+           "callbacks\n");
   }
 
   // DeviceMap must be initialized only once. Ensure this logic does not
@@ -235,100 +242,81 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
+
   set_trace_ompt(device);
-  
+
   start_trace(device_num, device);
 }
 
-static void on_ompt_callback_device_load
-    (
-     int device_num,
-     const char *filename,
-     int64_t offset_in_file,
-     void *vma_in_file,
-     size_t bytes,
-     void *host_addr,
-     void *device_addr,
-     uint64_t module_id
-     ) {
-  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p bytes:%lu\n",
-	 device_num, filename, host_addr, device_addr, bytes);
+static void on_ompt_callback_device_finalize(int device_num) {
+  printf("Callback Fini: device_num=%d\n", device_num);
 }
 
-static void on_ompt_callback_target_data_op
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
-  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 target_id, host_op_id, optype, src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+static void on_ompt_callback_device_load(int device_num, const char *filename,
+                                         int64_t offset_in_file,
+                                         void *vma_in_file, size_t bytes,
+                                         void *host_addr, void *device_addr,
+                                         uint64_t module_id) {
+  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p "
+         "bytes:%lu\n",
+         device_num, filename, host_addr, device_addr, bytes);
 }
 
-static void on_ompt_callback_target
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_id_t target_id,
-     const void *codeptr_ra
-     ) {
-  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d code=%p\n",
-	 target_id, kind, endpoint, device_num, codeptr_ra);
+static void on_ompt_callback_target_data_op(
+    ompt_id_t target_id, ompt_id_t host_op_id, ompt_target_data_op_t optype,
+    void *src_addr, int src_device_num, void *dest_addr, int dest_device_num,
+    size_t bytes, const void *codeptr_ra) {
+  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p "
+         "src_device_num=%d "
+         "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         target_id, host_op_id, optype, src_addr, src_device_num, dest_addr,
+         dest_device_num, bytes, codeptr_ra);
 }
 
-static void on_ompt_callback_target_submit
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     unsigned int requested_num_teams
-     ) {
+static void on_ompt_callback_target(ompt_target_t kind,
+                                    ompt_scope_endpoint_t endpoint,
+                                    int device_num, ompt_data_t *task_data,
+                                    ompt_id_t target_id,
+                                    const void *codeptr_ra) {
+  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d "
+         "code=%p\n",
+         target_id, kind, endpoint, device_num, codeptr_ra);
+}
+
+static void on_ompt_callback_target_submit(ompt_id_t target_id,
+                                           ompt_id_t host_op_id,
+                                           unsigned int requested_num_teams) {
   printf("  Callback Submit: target_id=%lu host_op_id=%lu req_num_teams=%d\n",
-     target_id, host_op_id, requested_num_teams);
+         target_id, host_op_id, requested_num_teams);
 }
 
 // Init functions
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
 
-  ompt_set_callback(ompt_callback_device_initialize,
-		    (ompt_callback_t)&on_ompt_callback_device_initialize);
-  ompt_set_callback(ompt_callback_device_load,
-		    (ompt_callback_t)&on_ompt_callback_device_load);
-  ompt_set_callback(ompt_callback_target_data_op,
-		    (ompt_callback_t)&on_ompt_callback_target_data_op);
-  ompt_set_callback(ompt_callback_target,
-		    (ompt_callback_t)&on_ompt_callback_target);
-  ompt_set_callback(ompt_callback_target_submit,
-		    (ompt_callback_t)&on_ompt_callback_target_submit);
-  return 1; //success
+  if (!ompt_set_callback)
+    return 0; // failed
+
+  register_ompt_callback(ompt_callback_device_initialize);
+  register_ompt_callback(ompt_callback_device_finalize);
+  register_ompt_callback(ompt_callback_device_load);
+  register_ompt_callback(ompt_callback_target_data_op);
+  register_ompt_callback(ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_submit);
+
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{}
+void ompt_finalize(ompt_data_t *tool_data) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t *ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus

--- a/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
 #include <cassert>
 #include <omp.h>
+#include <stdio.h>
 
 // This test starts device tracing on all available devices (see
 // start_trace in callbacks.h). It subsequently calls flush and stop
@@ -11,8 +11,7 @@
 // Map of devices traced
 DeviceMapPtr_t DeviceMapPtr;
 
-int main()
-{
+int main() {
   int N = 100000;
 
   int a[N];
@@ -20,38 +19,35 @@ int main()
 
   int i;
 
-  for (i=0; i<N; i++)
-    a[i]=0;
+  for (i = 0; i < N; i++)
+    a[i] = 0;
 
-  for (i=0; i<N; i++)
-    b[i]=i;
+  for (i = 0; i < N; i++)
+    b[i] = i;
 
-  // Warm up
-#pragma omp target 
-  {
+    // Warm up
+#pragma omp target
+  {}
+
+  for (auto Dev : *DeviceMapPtr)
+    flush_trace(Dev);
+
+  for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
+#pragma omp target teams distribute parallel for device(dev)
+    {
+      for (int j = 0; j < N; j++)
+        a[j] = b[j];
+    }
   }
 
   for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-  
-  for (int dev = 0; dev < omp_get_num_devices(); ++dev) {
-#pragma omp target teams distribute parallel for device(dev)
-    {
-      for (int j = 0; j< N; j++)
-	a[j]=b[j];
-    }
-  }
 
-  for (auto Dev : *DeviceMapPtr) {
-    flush_trace(Dev);
-    stop_trace(Dev);
-  }
-  
   int rc = 0;
-  for (i=0; i<N; i++)
-    if (a[i] != b[i] ) {
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
       rc++;
-      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
     }
 
   if (!rc)
@@ -60,5 +56,81 @@ int main()
   return rc;
 }
 
-/// CHECK: Record Submit
+// clang-format off
 
+// > OMPT device tracing related checks below. <
+
+// Note: Since this test may (theoretically) run on an arbitrary number of
+//       devices, we may only check for the minimal set of records.
+
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_02:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_03:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_04:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_05:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_06:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_07:0x[0-f]+]] in buffer request callback
+
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_01]], {{.+}} begin=[[ADDRX_01]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} begin=[[ADDRX_02]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_03]], {{.+}} begin=[[ADDRX_03]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_04]], {{.+}} begin=[[ADDRX_04]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_05]], {{.+}} begin=[[ADDRX_05]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=[[ADDRX_06]]
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_07]], {{.+}} begin=[[ADDRX_07]]
+
+// Note: This entry should happen due to the call to flush_trace.
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} buffer_owned=0
+
+// Note: Split checks for record address and content. That way we do not imply
+//       any order. Records may / will occur interleaved.
+/// CHECK-DAG: rec=[[ADDRX_01]]
+/// CHECK-DAG: rec=[[ADDRX_02]]
+/// CHECK-DAG: rec=[[ADDRX_03]]
+/// CHECK-DAG: rec=[[ADDRX_04]]
+/// CHECK-DAG: rec=[[ADDRX_05]]
+/// CHECK-DAG: rec=[[ADDRX_06]]
+/// CHECK-DAG: rec=[[ADDRX_07]]
+
+// Note: These addresses will only occur once. They are only captured to
+//       indicate their existence.
+/// CHECK-DAG: rec=[[ADDRX_08:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_09:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_10:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_11:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_12:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_13:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_14:0x[0-f]+]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=0
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+
+// Note: ADDRX_07 may not trigger a final callback.
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_01]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_03]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_04]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_05]], {{.+}} begin=(nil)
+/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=(nil)
+
+// Note: ADDRX_07 may not be deallocated.
+/// CHECK-DAG: Deallocated [[ADDRX_01]]
+/// CHECK-DAG: Deallocated [[ADDRX_02]]
+/// CHECK-DAG: Deallocated [[ADDRX_03]]
+/// CHECK-DAG: Deallocated [[ADDRX_04]]
+/// CHECK-DAG: Deallocated [[ADDRX_05]]
+/// CHECK-DAG: Deallocated [[ADDRX_06]]
+
+/// CHECK-NOT: host_op_id=0x0

--- a/test/smoke-limbo/veccopy-ompt-target-emi-tracing-dag/veccopy-ompt-target-emi-tracing-dag.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-tracing-dag/veccopy-ompt-target-emi-tracing-dag.cpp
@@ -96,17 +96,17 @@ int main() {
 /// CHECK-DAG: rec=[[ADDRX_10]]
 /// CHECK-DAG: rec=[[ADDRX_11]]
 
-/// CHECK-DAG: type= 8 (Target task) {{.+}} kind=1 endpoint=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=2
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
 /// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=3
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=3
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=4
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=4
-/// CHECK-DAG: type= 8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
 
 // Note: These addresses will only occur once. They are only captured to
 //       indicate their existence.
@@ -122,17 +122,17 @@ int main() {
 /// CHECK-DAG: rec=[[ADDRX_21:0x[0-f]+]]
 /// CHECK-DAG: rec=[[ADDRX_22:0x[0-f]+]]
 
-/// CHECK-DAG: type= 8 (Target task) {{.+}} kind=1 endpoint=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=2
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=1
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
 /// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=0
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=3
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=3
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=4
-/// CHECK-DAG: type= 9 (Target data op) {{.+}} optype=4
-/// CHECK-DAG: type= 8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
 
 // Note: ADDRX_11 may not trigger a final callback.
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} (nil) {{[0-9]+}}
@@ -162,5 +162,3 @@ int main() {
 
 /// CHECK-NOT: rec=
 /// CHECK-NOT: host_op_id=0x0
-
-// clang-format on

--- a/test/smoke-limbo/veccopy-ompt-target-tracing/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-tracing/callbacks.h
@@ -5,55 +5,72 @@
 // Tool related code below
 #include <omp-tools.h>
 
-#define OMPT_BUFFER_REQUEST_SIZE (4*1024)
+// Enable / disable OMPT's 'External Monitoring Interface'
+#define EMI 0
+
+// From openmp/runtime/test/ompt/callback.h
+#define register_ompt_callback_t(name, type)                                   \
+  do {                                                                         \
+    type f_##name = &on_##name;                                                \
+    if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
+      printf("0: Could not register callback '" #name "'\n");                  \
+  } while (0)
+
+#define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
+
+#define OMPT_BUFFER_REQUEST_SIZE (4 * 1024)
 
 // Map of devices traced
-typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
+typedef std::unordered_set<ompt_device_t *> DeviceMap_t;
 typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
 extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
-  if (rec == NULL) return;
-  
-  printf("rec=%p type=%d time=%lu thread_id=%lu target_id=%lu\n",
-	 rec, rec->type, rec->time, rec->thread_id, rec->target_id);
+  if (rec == NULL)
+    return;
 
   switch (rec->type) {
   case ompt_callback_target:
-  case ompt_callback_target_emi:
-    {
-      ompt_record_target_t target_rec = rec->record.target;
-      printf("\tRecord Target: kind=%d endpoint=%d device=%d task_id=%lu target_id=%lu codeptr=%p\n",
-	     target_rec.kind, target_rec.endpoint, target_rec.device_num,
-	     target_rec.task_id, target_rec.target_id, target_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_data_op:
-  case ompt_callback_target_data_op_emi:
-    {
-      ompt_record_target_data_op_t target_data_op_rec = rec->record.target_data_op;
-      printf("\t  Record DataOp: host_op_id=%lu optype=%d src_addr=%p src_device=%d "
-	     "dest_addr=%p dest_device=%d bytes=%lu end_time=%lu duration=%lu ns codeptr=%p\n",
-	     target_data_op_rec.host_op_id, target_data_op_rec.optype,
-	     target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
-	     target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
-	     target_data_op_rec.bytes, target_data_op_rec.end_time,
-	     target_data_op_rec.end_time - rec->time,
-	     target_data_op_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_submit:
-  case ompt_callback_target_submit_emi:
-    {
-      ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
-      printf("\t  Record Submit: host_op_id=%lu requested_num_teams=%u granted_num_teams=%u "
-	     "end_time=%lu duration=%lu ns\n",
-	     target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
-	     target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
-	     target_kernel_rec.end_time - rec->time);
+  case ompt_callback_target_emi: {
+    ompt_record_target_t target_rec = rec->record.target;
+    printf("rec=%p type=%d (Target task) time=%lu thread_id=%lu "
+           "target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu "
+           "codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_rec.kind, target_rec.endpoint, target_rec.device_num,
+           target_rec.task_id, target_rec.codeptr_ra);
     break;
-    }
+  }
+  case ompt_callback_target_data_op:
+  case ompt_callback_target_data_op_emi: {
+    ompt_record_target_data_op_t target_data_op_rec =
+        rec->record.target_data_op;
+    printf("rec=%p type=%d (Target data op) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx optype=%d "
+           "src_addr=%p src_device=%d dest_addr=%p dest_device=%d bytes=%lu "
+           "end_time=%lu duration=%lu ns codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_data_op_rec.host_op_id, target_data_op_rec.optype,
+           target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
+           target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
+           target_data_op_rec.bytes, target_data_op_rec.end_time,
+           target_data_op_rec.end_time - rec->time,
+           target_data_op_rec.codeptr_ra);
+    break;
+  }
+  case ompt_callback_target_submit:
+  case ompt_callback_target_submit_emi: {
+    ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
+    printf("rec=%p type=%d (Target kernel) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u "
+           "granted_num_teams=%u end_time=%lu duration=%lu ns\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
+           target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
+           target_kernel_rec.end_time - rec->time);
+    break;
+  }
   default:
     assert(0);
     break;
@@ -77,28 +94,24 @@ static ompt_get_record_type_t ompt_get_record_type_fn = 0;
 // OMPT callbacks
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request(int device_num,
+                                            ompt_buffer_t **buffer,
+                                            size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
-  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes, *buffer);
+  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes,
+         *buffer);
 }
 
 // Note: This callback must handle a null begin cursor. Currently,
 // ompt_get_record_ompt, print_record_ompt, and
 // ompt_advance_buffer_cursor handle a null cursor.
-static void on_ompt_callback_buffer_complete (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
-  printf("Executing buffer complete callback: %d %p %lu %p %d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+static void on_ompt_callback_buffer_complete(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
+  printf("Executing buffer complete callback: %d %p %lu %p %d\n", device_num,
+         buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -110,16 +123,15 @@ static void on_ompt_callback_buffer_complete (
     }
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 static ompt_set_result_t set_trace_ompt() {
-  if (!ompt_set_trace_ompt) return ompt_set_error;
+  if (!ompt_set_trace_ompt)
+    return ompt_set_error;
 
   ompt_set_trace_ompt(0, 1, ompt_callback_target);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
@@ -127,55 +139,57 @@ static ompt_set_result_t set_trace_ompt() {
 
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
-  if (!ompt_start_trace) return 0;
+  if (!ompt_start_trace)
+    return 0;
 
   // This device will be traced.
   assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
-	 "Device already present in the map");
+         "Device already present in the map");
   DeviceMapPtr->insert(Device);
-  
+
   return ompt_start_trace(Device, &on_ompt_callback_buffer_request,
-			  &on_ompt_callback_buffer_complete);
+                          &on_ompt_callback_buffer_complete);
 }
 
 static int flush_trace(ompt_device_t *Device) {
-  if (!ompt_flush_trace) return 0;
+  if (!ompt_flush_trace)
+    return 0;
   return ompt_flush_trace(Device);
 }
 
 static int stop_trace(ompt_device_t *Device) {
-  if (!ompt_stop_trace) return 0;
+  if (!ompt_stop_trace)
+    return 0;
   return ompt_stop_trace(Device);
 }
 
 // Synchronous callbacks
-static void on_ompt_callback_device_initialize
-(
-  int device_num,
-  const char *type,
-  ompt_device_t *device,
-  ompt_function_lookup_t lookup,
-  const char *documentation
- ) {
-  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
-	 device_num, type, device, lookup, documentation);
+static void on_ompt_callback_device_initialize(int device_num, const char *type,
+                                               ompt_device_t *device,
+                                               ompt_function_lookup_t lookup,
+                                               const char *documentation) {
+  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n", device_num,
+         type, device, lookup, documentation);
   if (!lookup) {
     printf("Trace collection disabled on device %d\n", device_num);
     return;
   }
 
-  ompt_set_trace_ompt = (ompt_set_trace_ompt_t) lookup("ompt_set_trace_ompt");
-  ompt_start_trace = (ompt_start_trace_t) lookup("ompt_start_trace");
-  ompt_flush_trace = (ompt_flush_trace_t) lookup("ompt_flush_trace");
-  ompt_stop_trace = (ompt_stop_trace_t) lookup("ompt_stop_trace");
-  ompt_get_record_ompt = (ompt_get_record_ompt_t) lookup("ompt_get_record_ompt");
-  ompt_advance_buffer_cursor = (ompt_advance_buffer_cursor_t) lookup("ompt_advance_buffer_cursor");
+  ompt_set_trace_ompt = (ompt_set_trace_ompt_t)lookup("ompt_set_trace_ompt");
+  ompt_start_trace = (ompt_start_trace_t)lookup("ompt_start_trace");
+  ompt_flush_trace = (ompt_flush_trace_t)lookup("ompt_flush_trace");
+  ompt_stop_trace = (ompt_stop_trace_t)lookup("ompt_stop_trace");
+  ompt_get_record_ompt = (ompt_get_record_ompt_t)lookup("ompt_get_record_ompt");
+  ompt_advance_buffer_cursor =
+      (ompt_advance_buffer_cursor_t)lookup("ompt_advance_buffer_cursor");
 
-  ompt_get_record_type_fn = (ompt_get_record_type_t) lookup("ompt_get_record_type");
+  ompt_get_record_type_fn =
+      (ompt_get_record_type_t)lookup("ompt_get_record_type");
   if (!ompt_get_record_type_fn) {
-    printf("WARNING: No function ompt_get_record_type found in device callbacks\n");
+    printf("WARNING: No function ompt_get_record_type found in device "
+           "callbacks\n");
   }
 
   // DeviceMap must be initialized only once. Ensure this logic does not
@@ -186,9 +200,9 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
+
   set_trace_ompt();
-  
+
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this
   // callback is dispatched, the start_trace handle will be null. This
@@ -198,94 +212,75 @@ static void on_ompt_callback_device_initialize
   start_trace(device_num, device);
 }
 
-static void on_ompt_callback_device_load
-    (
-     int device_num,
-     const char *filename,
-     int64_t offset_in_file,
-     void *vma_in_file,
-     size_t bytes,
-     void *host_addr,
-     void *device_addr,
-     uint64_t module_id
-     ) {
-  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p bytes:%lu\n",
-	 device_num, filename, host_addr, device_addr, bytes);
+static void on_ompt_callback_device_finalize(int device_num) {
+  printf("Callback Fini: device_num=%d\n", device_num);
 }
 
-static void on_ompt_callback_target_data_op
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
-  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 target_id, host_op_id, optype, src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+static void on_ompt_callback_device_load(int device_num, const char *filename,
+                                         int64_t offset_in_file,
+                                         void *vma_in_file, size_t bytes,
+                                         void *host_addr, void *device_addr,
+                                         uint64_t module_id) {
+  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p "
+         "bytes:%lu\n",
+         device_num, filename, host_addr, device_addr, bytes);
 }
 
-static void on_ompt_callback_target
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_id_t target_id,
-     const void *codeptr_ra
-     ) {
-  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d code=%p\n",
-	 target_id, kind, endpoint, device_num, codeptr_ra);
+static void on_ompt_callback_target_data_op(
+    ompt_id_t target_id, ompt_id_t host_op_id, ompt_target_data_op_t optype,
+    void *src_addr, int src_device_num, void *dest_addr, int dest_device_num,
+    size_t bytes, const void *codeptr_ra) {
+  printf("  Callback DataOp: target_id=%lu host_op_id=%lu optype=%d src=%p "
+         "src_device_num=%d "
+         "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         target_id, host_op_id, optype, src_addr, src_device_num, dest_addr,
+         dest_device_num, bytes, codeptr_ra);
 }
 
-static void on_ompt_callback_target_submit
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     unsigned int requested_num_teams
-     ) {
+static void on_ompt_callback_target(ompt_target_t kind,
+                                    ompt_scope_endpoint_t endpoint,
+                                    int device_num, ompt_data_t *task_data,
+                                    ompt_id_t target_id,
+                                    const void *codeptr_ra) {
+  printf("Callback Target: target_id=%lu kind=%d endpoint=%d device_num=%d "
+         "code=%p\n",
+         target_id, kind, endpoint, device_num, codeptr_ra);
+}
+
+static void on_ompt_callback_target_submit(ompt_id_t target_id,
+                                           ompt_id_t host_op_id,
+                                           unsigned int requested_num_teams) {
   printf("  Callback Submit: target_id=%lu host_op_id=%lu req_num_teams=%d\n",
-     target_id, host_op_id, requested_num_teams);
+         target_id, host_op_id, requested_num_teams);
 }
 
 // Init functions
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
 
-  ompt_set_callback(ompt_callback_device_initialize,
-		    (ompt_callback_t)&on_ompt_callback_device_initialize);
-  ompt_set_callback(ompt_callback_device_load,
-		    (ompt_callback_t)&on_ompt_callback_device_load);
-  ompt_set_callback(ompt_callback_target_data_op,
-		    (ompt_callback_t)&on_ompt_callback_target_data_op);
-  ompt_set_callback(ompt_callback_target,
-		    (ompt_callback_t)&on_ompt_callback_target);
-  ompt_set_callback(ompt_callback_target_submit,
-		    (ompt_callback_t)&on_ompt_callback_target_submit);
-  return 1; //success
+  if (!ompt_set_callback)
+    return 0; // failed
+
+  register_ompt_callback(ompt_callback_device_initialize);
+  register_ompt_callback(ompt_callback_device_finalize);
+  register_ompt_callback(ompt_callback_device_load);
+  register_ompt_callback(ompt_callback_target_data_op);
+  register_ompt_callback(ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_submit);
+
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{}
+void ompt_finalize(ompt_data_t *tool_data) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t *ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus

--- a/test/smoke-limbo/veccopy-ompt-target-tracing/veccopy-ompt-target-tracing.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-tracing/veccopy-ompt-target-tracing.cpp
@@ -1,14 +1,13 @@
-#include <stdio.h>
 #include <assert.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 
 // Map of devices traced
 DeviceMapPtr_t DeviceMapPtr;
 
-int main()
-{
+int main() {
   int N = 100000;
 
   int a[N];
@@ -16,29 +15,29 @@ int main()
 
   int i;
 
-  for (i=0; i<N; i++)
-    a[i]=0;
+  for (i = 0; i < N; i++)
+    a[i] = 0;
 
-  for (i=0; i<N; i++)
-    b[i]=i;
+  for (i = 0; i < N; i++)
+    b[i] = i;
 
 #pragma omp target parallel for
   {
-    for (int j = 0; j< N; j++)
-      a[j]=b[j];
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
   }
 
 #pragma omp target teams distribute parallel for
   {
-    for (int j = 0; j< N; j++)
-      a[j]=b[j];
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
   }
 
   int rc = 0;
-  for (i=0; i<N; i++)
-    if (a[i] != b[i] ) {
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
       rc++;
-      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
     }
 
   if (!rc)
@@ -47,5 +46,69 @@ int main()
   return rc;
 }
 
-/// CHECK: Record Submit
+// clang-format off
 
+// > OMPT device tracing related checks below. <
+
+// Note: This test will allocate one buffer, big enough to hold all trace
+//       records, hence there will be only one allocation.
+
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}}
+
+// Note: Split checks for record address and content. That way we do not imply
+//       any order. Records may / will occur interleaved.
+/// CHECK-DAG: rec=[[ADDRX_01]]
+
+// Note: These addresses will only occur once. They are only captured to
+//       indicate their existence.
+/// CHECK-DAG: rec=[[ADDRX_12:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_13:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_14:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_15:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_16:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_17:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_18:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_19:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_20:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_21:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_22:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_02:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_03:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_04:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_05:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_06:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_07:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_08:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_09:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_10:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_11:0x[0-f]+]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=0
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+
+// Note: ADDRX_01 may not trigger a final callback.
+// Note: ADDRX_01 may not be deallocated.
+
+/// CHECK-NOT: rec=
+/// CHECK-NOT: host_op_id=0x0

--- a/test/smoke/veccopy-ompt-target-emi-tracing/callbacks.h
+++ b/test/smoke/veccopy-ompt-target-emi-tracing/callbacks.h
@@ -7,60 +7,80 @@
 // Tool related code below
 #include <omp-tools.h>
 
-ompt_id_t  next_op_id = 0x8000000000000001;
+// From openmp/runtime/test/ompt/callback.h
+#define register_ompt_callback_t(name, type)                                   \
+  do {                                                                         \
+    type f_##name = &on_##name;                                                \
+    if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
+      printf("0: Could not register callback '" #name "'\n");                  \
+  } while (0)
+
+#define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
 
 #define OMPT_BUFFER_REQUEST_SIZE 256
 
+ompt_id_t next_op_id = 0x8000000000000001;
+
+// OMPT entry point handles
+static ompt_set_callback_t ompt_set_callback = 0;
+static ompt_set_trace_ompt_t ompt_set_trace_ompt = 0;
+static ompt_start_trace_t ompt_start_trace = 0;
+static ompt_flush_trace_t ompt_flush_trace = 0;
+static ompt_stop_trace_t ompt_stop_trace = 0;
+static ompt_get_record_ompt_t ompt_get_record_ompt = 0;
+static ompt_advance_buffer_cursor_t ompt_advance_buffer_cursor = 0;
+
 // Map of devices traced
-typedef std::unordered_set<ompt_device_t*> DeviceMap_t;
+typedef std::unordered_set<ompt_device_t *> DeviceMap_t;
 typedef std::unique_ptr<DeviceMap_t> DeviceMapPtr_t;
 extern DeviceMapPtr_t DeviceMapPtr;
 
 // Utilities
 static void print_record_ompt(ompt_record_ompt_t *rec) {
-  if (rec == NULL) return;
-  
-  printf("rec=%p type=%2d time=%lu thread_id=%lu target_id=%lu\n",
-	 rec, rec->type, rec->time, rec->thread_id, rec->target_id);
+  if (rec == NULL)
+    return;
 
   switch (rec->type) {
   case ompt_callback_target:
-  case ompt_callback_target_emi:
-    {
-      ompt_record_target_t target_rec = rec->record.target;
-      printf("\tRecord Target task: target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu codeptr=%p\n",
-	     target_rec.target_id, 
-	     target_rec.kind, target_rec.endpoint, target_rec.device_num,
-	     target_rec.task_id, target_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_data_op:
-  case ompt_callback_target_data_op_emi:
-    {
-      ompt_record_target_data_op_t target_data_op_rec = rec->record.target_data_op;
-      printf("\t  Record Target data op: target_id=0x%lx host_op_id=0x%lx optype=%d src_addr=%p src_device=%d "
-	     "dest_addr=%p dest_device=%d bytes=%lu end_time=%lu duration=%lu ns codeptr=%p\n",
-             rec->target_id,
-	     target_data_op_rec.host_op_id, target_data_op_rec.optype,
-	     target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
-	     target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
-	     target_data_op_rec.bytes, target_data_op_rec.end_time,
-	     target_data_op_rec.end_time - rec->time,
-	     target_data_op_rec.codeptr_ra);
-      break;
-    }
-  case ompt_callback_target_submit:
-  case ompt_callback_target_submit_emi:
-    {
-      ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
-      printf("\t  Record Target kernel:  target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u granted_num_teams=%u "
-	     "end_time=%lu duration=%lu ns\n",
-             rec->target_id,
-	     target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
-	     target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
-	     target_kernel_rec.end_time - rec->time);
+  case ompt_callback_target_emi: {
+    ompt_record_target_t target_rec = rec->record.target;
+    printf("rec=%p type=%d (Target task) time=%lu thread_id=%lu "
+           "target_id=0x%lx kind=%d endpoint=%d device=%d task_id=%lu "
+           "codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_rec.kind, target_rec.endpoint, target_rec.device_num,
+           target_rec.task_id, target_rec.codeptr_ra);
     break;
-    }
+  }
+  case ompt_callback_target_data_op:
+  case ompt_callback_target_data_op_emi: {
+    ompt_record_target_data_op_t target_data_op_rec =
+        rec->record.target_data_op;
+    printf("rec=%p type=%d (Target data op) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx optype=%d "
+           "src_addr=%p src_device=%d dest_addr=%p dest_device=%d bytes=%lu "
+           "end_time=%lu duration=%lu ns codeptr=%p\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_data_op_rec.host_op_id, target_data_op_rec.optype,
+           target_data_op_rec.src_addr, target_data_op_rec.src_device_num,
+           target_data_op_rec.dest_addr, target_data_op_rec.dest_device_num,
+           target_data_op_rec.bytes, target_data_op_rec.end_time,
+           target_data_op_rec.end_time - rec->time,
+           target_data_op_rec.codeptr_ra);
+    break;
+  }
+  case ompt_callback_target_submit:
+  case ompt_callback_target_submit_emi: {
+    ompt_record_target_kernel_t target_kernel_rec = rec->record.target_kernel;
+    printf("rec=%p type=%d (Target kernel) time=%lu thread_id=%lu "
+           "target_id=0x%lx host_op_id=0x%lx requested_num_teams=%u "
+           "granted_num_teams=%u end_time=%lu duration=%lu ns\n",
+           rec, rec->type, rec->time, rec->thread_id, rec->target_id,
+           target_kernel_rec.host_op_id, target_kernel_rec.requested_num_teams,
+           target_kernel_rec.granted_num_teams, target_kernel_rec.end_time,
+           target_kernel_rec.end_time - rec->time);
+    break;
+  }
   default:
     assert(0);
     break;
@@ -72,37 +92,24 @@ static void delete_buffer_ompt(ompt_buffer_t *buffer) {
   printf("Deallocated %p\n", buffer);
 }
 
-// OMPT entry point handles
-static ompt_set_callback_t ompt_set_callback = 0;
-static ompt_set_trace_ompt_t ompt_set_trace_ompt = 0;
-static ompt_start_trace_t ompt_start_trace = 0;
-static ompt_flush_trace_t ompt_flush_trace = 0;
-static ompt_stop_trace_t ompt_stop_trace = 0;
-static ompt_get_record_ompt_t ompt_get_record_ompt = 0;
-static ompt_advance_buffer_cursor_t ompt_advance_buffer_cursor = 0;
-
 // OMPT callbacks
 
 // Trace record callbacks
-static void on_ompt_callback_buffer_request (
-  int device_num,
-  ompt_buffer_t **buffer,
-  size_t *bytes
-) {
+static void on_ompt_callback_buffer_request(int device_num,
+                                            ompt_buffer_t **buffer,
+                                            size_t *bytes) {
   *bytes = OMPT_BUFFER_REQUEST_SIZE;
   *buffer = malloc(*bytes);
-  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes, *buffer);
+  printf("Allocated %lu bytes at %p in buffer request callback\n", *bytes,
+         *buffer);
 }
 
-static void on_ompt_callback_buffer_complete (
-  int device_num,
-  ompt_buffer_t *buffer,
-  size_t bytes, /* bytes returned in this callback */
-  ompt_buffer_cursor_t begin,
-  int buffer_owned
-) {
-  printf("Executing buffer complete callback: %d %p %lu %p %d\n",
-	 device_num, buffer, bytes, (void*)begin, buffer_owned);
+static void on_ompt_callback_buffer_complete(
+    int device_num, ompt_buffer_t *buffer,
+    size_t bytes, /* bytes returned in this callback */
+    ompt_buffer_cursor_t begin, int buffer_owned) {
+  printf("Executing buffer complete callback: %d %p %lu %p %d\n", device_num,
+         buffer, bytes, (void *)begin, buffer_owned);
 
   int status = 1;
   ompt_buffer_cursor_t current = begin;
@@ -110,18 +117,17 @@ static void on_ompt_callback_buffer_complete (
     ompt_record_ompt_t *rec = ompt_get_record_ompt(buffer, current);
     print_record_ompt(rec);
     status = ompt_advance_buffer_cursor(NULL, /* TODO device */
-					buffer,
-					bytes,
-					current,
-					&current);
+                                        buffer, bytes, current, &current);
   }
-  if (buffer_owned) delete_buffer_ompt(buffer);
+  if (buffer_owned)
+    delete_buffer_ompt(buffer);
 }
 
 static ompt_set_result_t set_trace_ompt() {
-  if (!ompt_set_trace_ompt) return ompt_set_error;
+  if (!ompt_set_trace_ompt)
+    return ompt_set_error;
 
-#if EMI  
+#if EMI
   ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
@@ -130,54 +136,54 @@ static ompt_set_result_t set_trace_ompt() {
   ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
   ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
 #endif
-  
+
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
-  if (!ompt_start_trace) return 0;
+  if (!ompt_start_trace)
+    return 0;
 
   // This device will be traced.
   assert(DeviceMapPtr->find(Device) == DeviceMapPtr->end() &&
-	 "Device already present in the map");
+         "Device already present in the map");
   DeviceMapPtr->insert(Device);
-  
+
   return ompt_start_trace(Device, &on_ompt_callback_buffer_request,
-			  &on_ompt_callback_buffer_complete);
+                          &on_ompt_callback_buffer_complete);
 }
 
 static int flush_trace(ompt_device_t *Device) {
-  if (!ompt_flush_trace) return 0;
+  if (!ompt_flush_trace)
+    return 0;
   return ompt_flush_trace(Device);
 }
 
 static int stop_trace(ompt_device_t *Device) {
-  if (!ompt_stop_trace) return 0;
+  if (!ompt_stop_trace)
+    return 0;
   return ompt_stop_trace(Device);
 }
 
 // Synchronous callbacks
-static void on_ompt_callback_device_initialize
-(
-  int device_num,
-  const char *type,
-  ompt_device_t *device,
-  ompt_function_lookup_t lookup,
-  const char *documentation
- ) {
-  printf("Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
-	 device_num, type, device, lookup, documentation);
+static void on_ompt_callback_device_initialize(int device_num, const char *type,
+                                               ompt_device_t *device,
+                                               ompt_function_lookup_t lookup,
+                                               const char *documentation) {
+  printf("Callback Init: device_num=%d type=%s device=%p lookup=%p doc=%p\n",
+         device_num, type, device, lookup, documentation);
   if (!lookup) {
     printf("Trace collection disabled on device %d\n", device_num);
     return;
   }
 
-  ompt_set_trace_ompt = (ompt_set_trace_ompt_t) lookup("ompt_set_trace_ompt");
-  ompt_start_trace = (ompt_start_trace_t) lookup("ompt_start_trace");
-  ompt_flush_trace = (ompt_flush_trace_t) lookup("ompt_flush_trace");
-  ompt_stop_trace = (ompt_stop_trace_t) lookup("ompt_stop_trace");
-  ompt_get_record_ompt = (ompt_get_record_ompt_t) lookup("ompt_get_record_ompt");
-  ompt_advance_buffer_cursor = (ompt_advance_buffer_cursor_t) lookup("ompt_advance_buffer_cursor");
+  ompt_set_trace_ompt = (ompt_set_trace_ompt_t)lookup("ompt_set_trace_ompt");
+  ompt_start_trace = (ompt_start_trace_t)lookup("ompt_start_trace");
+  ompt_flush_trace = (ompt_flush_trace_t)lookup("ompt_flush_trace");
+  ompt_stop_trace = (ompt_stop_trace_t)lookup("ompt_stop_trace");
+  ompt_get_record_ompt = (ompt_get_record_ompt_t)lookup("ompt_get_record_ompt");
+  ompt_advance_buffer_cursor =
+      (ompt_advance_buffer_cursor_t)lookup("ompt_advance_buffer_cursor");
 
   // DeviceMap must be initialized only once. Ensure this logic does not
   // depend on external data structures because this init function may be
@@ -187,7 +193,7 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
+
   set_trace_ompt();
 
   // In many scenarios, this will be a good place to start the
@@ -199,175 +205,128 @@ static void on_ompt_callback_device_initialize
   start_trace(device_num, device);
 }
 
-static void on_ompt_callback_device_load
-    (
-     int device_num,
-     const char *filename,
-     int64_t offset_in_file,
-     void *vma_in_file,
-     size_t bytes,
-     void *host_addr,
-     void *device_addr,
-     uint64_t module_id
-     ) {
-  printf("Load: device_num:%d filename:%s host_adddr:%p device_addr:%p bytes:%lu\n",
-	 device_num, filename, host_addr, device_addr, bytes);
+static void on_ompt_callback_device_finalize(int device_num) {
+  printf("Callback Fini: device_num=%d\n", device_num);
 }
 
+static void on_ompt_callback_device_load(int device_num, const char *filename,
+                                         int64_t offset_in_file,
+                                         void *vma_in_file, size_t bytes,
+                                         void *host_addr, void *device_addr,
+                                         uint64_t module_id) {
+  printf("Callback Load: device_num:%d filename:%s host_adddr:%p device_addr:%p"
+         " bytes:%lu\n",
+         device_num, filename, host_addr, device_addr, bytes);
+}
 
-static void on_ompt_callback_target_data_op
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
+static void on_ompt_callback_target_data_op(
+    ompt_id_t target_id, ompt_id_t host_op_id, ompt_target_data_op_t optype,
+    void *src_addr, int src_device_num, void *dest_addr, int dest_device_num,
+    size_t bytes, const void *codeptr_ra) {
   printf("  Callback DataOp: host_op_id=%lu optype=%d src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 host_op_id, optype, src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+         "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         host_op_id, optype, src_addr, src_device_num, dest_addr,
+         dest_device_num, bytes, codeptr_ra);
 }
 
-
-static void on_ompt_callback_target_data_op_emi
-    (
-     ompt_scope_endpoint_t endpoint,
-     ompt_data_t *target_task_data,
-     ompt_data_t *target_data,
-     ompt_id_t *host_op_id,
-     ompt_target_data_op_t optype,
-     void *src_addr,
-     int src_device_num,
-     void *dest_addr,
-     int dest_device_num,
-     size_t bytes,
-     const void *codeptr_ra
-     ) {
-     if (endpoint == ompt_scope_begin) *host_op_id = next_op_id++;
-     // target_task_data may be null, avoid dereferencing it
-     uint64_t target_task_data_value = (target_task_data) ? target_task_data->value : 0;
-  printf("  Callback DataOp EMI: endpoint=%d target_task_data=%p (0x%lx) target_data=%p (0x%lx) host_op_id=%p (0x%lx) optype=%d src=%p src_device_num=%d "
-	 "dest=%p dest_device_num=%d bytes=%lu code=%p\n",
-	 endpoint, 
-         target_task_data, target_task_data_value, 
-         target_data, target_data->value, 
-         host_op_id, *host_op_id, 
-         optype, src_addr, src_device_num,
-	 dest_addr, dest_device_num, bytes, codeptr_ra);
+static void on_ompt_callback_target_data_op_emi(
+    ompt_scope_endpoint_t endpoint, ompt_data_t *target_task_data,
+    ompt_data_t *target_data, ompt_id_t *host_op_id,
+    ompt_target_data_op_t optype, void *src_addr, int src_device_num,
+    void *dest_addr, int dest_device_num, size_t bytes,
+    const void *codeptr_ra) {
+  if (endpoint == ompt_scope_begin)
+    *host_op_id = next_op_id++;
+  // target_task_data may be null, avoid dereferencing it
+  uint64_t target_task_data_value =
+      (target_task_data) ? target_task_data->value : 0;
+  printf("  Callback DataOp EMI: endpoint=%d optype=%d target_task_data=%p "
+         "(0x%lx) target_data=%p (0x%lx) host_op_id=%p (0x%lx) src=%p "
+         "src_device_num=%d dest=%p dest_device_num=%d bytes=%lu code=%p\n",
+         endpoint, optype, target_task_data, target_task_data_value,
+         target_data, target_data->value, host_op_id, *host_op_id, src_addr,
+         src_device_num, dest_addr, dest_device_num, bytes, codeptr_ra);
 }
 
-
-static void on_ompt_callback_target
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_id_t target_id,
-     const void *codeptr_ra
-     ) {
-  printf("Callback Target: kind=%d endpoint=%d device_num=%d target_id=%lu code=%p\n",
-	 kind, endpoint, device_num, target_id, codeptr_ra);
+static void on_ompt_callback_target(ompt_target_t kind,
+                                    ompt_scope_endpoint_t endpoint,
+                                    int device_num, ompt_data_t *task_data,
+                                    ompt_id_t target_id,
+                                    const void *codeptr_ra) {
+  printf("Callback Target: kind=%d endpoint=%d device_num=%d target_id=%lu "
+         "code=%p\n",
+         kind, endpoint, device_num, target_id, codeptr_ra);
 }
 
-
-static void on_ompt_callback_target_emi
-    (
-     ompt_target_t kind,
-     ompt_scope_endpoint_t endpoint,
-     int device_num,
-     ompt_data_t *task_data,
-     ompt_data_t *target_task_data,
-     ompt_data_t *target_data,
-     const void *codeptr_ra
-     ) {
-     if (endpoint == ompt_scope_begin) target_data->value = next_op_id++;
-     // target_task_data may be null, avoid dereferencing it
-     uint64_t target_task_data_value = (target_task_data) ? target_task_data->value : 0;
-  printf("Callback Target EMI: kind=%d endpoint=%d device_num=%d task_data=%p (0x%lx) target_task_data=%p (0x%lx) target_data=%p (0x%lx) code=%p\n",
-	 kind, endpoint, device_num, 
-         task_data, task_data->value, 
-         target_task_data, target_task_data_value, 
-         target_data, target_data->value, 
-         codeptr_ra);
+static void on_ompt_callback_target_emi(ompt_target_t kind,
+                                        ompt_scope_endpoint_t endpoint,
+                                        int device_num, ompt_data_t *task_data,
+                                        ompt_data_t *target_task_data,
+                                        ompt_data_t *target_data,
+                                        const void *codeptr_ra) {
+  if (endpoint == ompt_scope_begin)
+    target_data->value = next_op_id++;
+  // target_task_data may be null, avoid dereferencing it
+  uint64_t target_task_data_value =
+      (target_task_data) ? target_task_data->value : 0;
+  printf("Callback Target EMI: kind=%d endpoint=%d device_num=%d task_data=%p "
+         "(0x%lx) target_task_data=%p (0x%lx) target_data=%p (0x%lx) code=%p\n",
+         kind, endpoint, device_num, task_data, task_data->value,
+         target_task_data, target_task_data_value, target_data,
+         target_data->value, codeptr_ra);
 }
 
-static void on_ompt_callback_target_submit
-    (
-     ompt_id_t target_id,
-     ompt_id_t host_op_id,
-     unsigned int requested_num_teams
-     ) {
+static void on_ompt_callback_target_submit(ompt_id_t target_id,
+                                           ompt_id_t host_op_id,
+                                           unsigned int requested_num_teams) {
   printf("  Callback Submit: target_id=%lu host_op_id=%lu req_num_teams=%d\n",
-     target_id, host_op_id, requested_num_teams);
+         target_id, host_op_id, requested_num_teams);
 }
 
-
-static void on_ompt_callback_target_submit_emi
-    (
-     ompt_scope_endpoint_t endpoint,
-     ompt_data_t *target_data,
-     ompt_id_t *host_op_id,
-     unsigned int requested_num_teams
-     ) {
-  printf("  Callback Submit EMI: endpoint=%d target_data=%p (0x%lx) host_op_id=%p (0x%lx) req_num_teams=%d\n",
-     endpoint, 
-     target_data, target_data->value, 
-     host_op_id, *host_op_id, 
-     requested_num_teams);
+static void on_ompt_callback_target_submit_emi(
+    ompt_scope_endpoint_t endpoint, ompt_data_t *target_data,
+    ompt_id_t *host_op_id, unsigned int requested_num_teams) {
+  printf("  Callback Submit EMI: endpoint=%d req_num_teams=%d target_data=%p "
+         "(0x%lx) host_op_id=%p (0x%lx)\n",
+         endpoint, requested_num_teams, target_data, target_data->value,
+         host_op_id, *host_op_id);
 }
 
 // Init functions
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
 
-  ompt_set_callback(ompt_callback_device_initialize,
-		    (ompt_callback_t)&on_ompt_callback_device_initialize);
-  ompt_set_callback(ompt_callback_device_load,
-		    (ompt_callback_t)&on_ompt_callback_device_load);
+  if (!ompt_set_callback)
+    return 0; // failed
+
+  register_ompt_callback(ompt_callback_device_initialize);
+  register_ompt_callback(ompt_callback_device_finalize);
+  register_ompt_callback(ompt_callback_device_load);
 #if EMI
-  ompt_set_callback(ompt_callback_target_submit_emi,
-		    (ompt_callback_t)&on_ompt_callback_target_submit_emi);
-  ompt_set_callback(ompt_callback_target_data_op_emi,
-		    (ompt_callback_t)&on_ompt_callback_target_data_op_emi);
-  ompt_set_callback(ompt_callback_target_emi,
-		    (ompt_callback_t)&on_ompt_callback_target_emi);
+  register_ompt_callback(ompt_callback_target_data_op_emi);
+  register_ompt_callback(ompt_callback_target_emi);
+  register_ompt_callback(ompt_callback_target_submit_emi);
 #else
-  ompt_set_callback(ompt_callback_target_submit,
-		    (ompt_callback_t)&on_ompt_callback_target_submit);
-  ompt_set_callback(ompt_callback_target_data_op,
-		    (ompt_callback_t)&on_ompt_callback_target_data_op);
-  ompt_set_callback(ompt_callback_target,
-		    (ompt_callback_t)&on_ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_data_op);
+  register_ompt_callback(ompt_callback_target);
+  register_ompt_callback(ompt_callback_target_submit);
 #endif
-  return 1; //success
+
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{
-}
+void ompt_finalize(ompt_data_t *tool_data) {}
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t *ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus
 }
 #endif
-
-

--- a/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
@@ -1,14 +1,13 @@
-#include <stdio.h>
 #include <assert.h>
 #include <omp.h>
+#include <stdio.h>
 
 #include "callbacks.h"
 
 // Map of devices traced
 DeviceMapPtr_t DeviceMapPtr;
 
-int main()
-{
+int main() {
   int N = 100000;
 
   int a[N];
@@ -16,32 +15,32 @@ int main()
 
   int i;
 
-  for (i=0; i<N; i++)
-    a[i]=0;
+  for (i = 0; i < N; i++)
+    a[i] = 0;
 
-  for (i=0; i<N; i++)
-    b[i]=i;
+  for (i = 0; i < N; i++)
+    b[i] = i;
 
 #pragma omp target parallel for
   {
-    for (int j = 0; j< N; j++)
-      a[j]=b[j];
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
   }
 
   for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
-  
+
 #pragma omp target teams distribute parallel for
   {
-    for (int j = 0; j< N; j++)
-      a[j]=b[j];
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
   }
 
   int rc = 0;
-  for (i=0; i<N; i++)
-    if (a[i] != b[i] ) {
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
       rc++;
-      printf ("Wrong value: a[%d]=%d\n", i, a[i]);
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
     }
 
   if (!rc)
@@ -50,6 +49,118 @@ int main()
   return rc;
 }
 
-/// CHECK-NOT: host_op_id=0x0
-/// CHECK: Record Target kernel
+// clang-format off
 
+// clang-format off
+
+/// CHECK-NOT: host_op_id=0x0
+
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_02:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_03:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_04:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_05:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_06:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_07:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_08:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_09:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_10:0x[0-f]+]] in buffer request callback
+/// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_11:0x[0-f]+]] in buffer request callback
+
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}}
+
+// Note: This entry should happen due to the call to flush_trace.
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} {{.+}} {{[0-9]+}}
+
+// Note: Split checks for record address and content. That way we do not imply
+//       any order. Records 01-06 and 12-17 occur interleaved and belong to the
+//       first target region. 07-11 occur interleaved with 18-22 and belong to
+//       the second target region.
+/// CHECK-DAG: rec=[[ADDRX_01]]
+/// CHECK-DAG: rec=[[ADDRX_02]]
+/// CHECK-DAG: rec=[[ADDRX_03]]
+/// CHECK-DAG: rec=[[ADDRX_04]]
+/// CHECK-DAG: rec=[[ADDRX_05]]
+/// CHECK-DAG: rec=[[ADDRX_06]]
+/// CHECK-DAG: rec=[[ADDRX_07]]
+/// CHECK-DAG: rec=[[ADDRX_08]]
+/// CHECK-DAG: rec=[[ADDRX_09]]
+/// CHECK-DAG: rec=[[ADDRX_10]]
+/// CHECK-DAG: rec=[[ADDRX_11]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+
+// Note: These addresses will only occur once. They are only captured to
+//       indicate their existence.
+/// CHECK-DAG: rec=[[ADDRX_12:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_13:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_14:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_15:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_16:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_17:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_18:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_19:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_20:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_21:0x[0-f]+]]
+/// CHECK-DAG: rec=[[ADDRX_22:0x[0-f]+]]
+
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=1
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=2
+/// CHECK-DAG: type=10 (Target kernel) {{.+}} requested_num_teams=0
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=3
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=9 (Target data op) {{.+}} optype=4
+/// CHECK-DAG: type=8 (Target task) {{.+}} kind=1 endpoint=2
+
+// Note: ADDRX_11 may not trigger a final callback.
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_01]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_02]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_03]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_04]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_05]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_07]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}} (nil) {{[0-9]+}}
+/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} (nil) {{[0-9]+}}
+
+// Note: ADDRX_11 may not be deallocated.
+/// CHECK-DAG: Deallocated [[ADDRX_01]]
+/// CHECK-DAG: Deallocated [[ADDRX_02]]
+/// CHECK-DAG: Deallocated [[ADDRX_03]]
+/// CHECK-DAG: Deallocated [[ADDRX_04]]
+/// CHECK-DAG: Deallocated [[ADDRX_05]]
+/// CHECK-DAG: Deallocated [[ADDRX_06]]
+/// CHECK-DAG: Deallocated [[ADDRX_07]]
+/// CHECK-DAG: Deallocated [[ADDRX_08]]
+/// CHECK-DAG: Deallocated [[ADDRX_09]]
+/// CHECK-DAG: Deallocated [[ADDRX_10]]
+
+/// CHECK-DAG: Success
+
+/// CHECK-NOT: rec=
+/// CHECK-NOT: host_op_id=0x0


### PR DESCRIPTION
Extend existing device tracing tests to be more restrictive. Until now only single kernel submits were checked.

Using 'CHECK-DAG' we try to allow asynchronous delivery of trace records, while checking specific allocations, optype, etc. and especially their addresses.

Extended tests:
 * smoke-limbo/veccopy-ompt-target-data-tracing-emi
 * smoke-limbo/veccopy-ompt-target-default-device
 * smoke-limbo/veccopy-ompt-target-devices
 * smoke-limbo/veccopy-ompt-target-tracing
 * smoke/veccopy-ompt-target-emi-tracing (DAG variant already in smoke-limbo)