### PR TITLE
[UMT] Fixed cmake error "the source directory ~/git/aomp-test/UMT/build_umt does not exist"

### DIFF
--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -86,14 +86,13 @@ if [ "$1" == "build_umt" ]; then
             -DMPI_CXX_COMPILER=${MPI_PATH}/bin/mpicxx \
             -DMPI_Fortran_COMPILER=${MPI_PATH}/bin/mpifort \
             -DCMAKE_INSTALL_PREFIX=${UMT_INSTALL_PATH} \
-            -DCONDUIT_ROOT=${UMT_INSTALL_PATH} $1
+            -DCONDUIT_ROOT=${UMT_INSTALL_PATH}
     
     cmake --build build_umt --parallel
     cmake --install build_umt
     
     # undo patch
     removepatch ${AOMP_REPOS_TEST}/UMT
-    popd
 
 popd
 exit 1


### PR DESCRIPTION
The build process failed due to a cmake error that was only reproducible on r6. After removing $1 from the cmake command the build process runs fine. On Dell and HPE-37 were no such issues.

Also removed a redundant popd. 