### PR TITLE
[OpenMP] Fix hsa-lazy-queue test by setting ROCR_VISIBLE_DEVICES

### DIFF
--- a/test/smoke/hsa-lazy-queues/Makefile
+++ b/test/smoke/hsa-lazy-queues/Makefile
@@ -5,17 +5,28 @@ TESTSRC_MAIN = async-events.cpp
 TESTSRC_AUX  = empty-sink.c
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-AOMPROCM ?= $(AOMP)
+AOMPROCM     ?= $(AOMP)
 ifneq (,$(wildcard $(AOMPROCM)/bin/rocprof))
 	RUNPROF   = $(AOMPROCM)/bin/rocprof
 else
 	RUNPROF   = $(AOMPROCM)/../bin/rocprof
 endif
 
+# If 'ROCR_VISIBLE_DEVICES' is empty, default to zero. Otherwise, split on ','
+# and use the first device marked visible by the environmental variable. The
+# latter will keep a given value if it does not contain ','.
+ifeq ($(ROCR_VISIBLE_DEVICES),)
+    RUNENV    = ROCR_VISIBLE_DEVICES=0
+else
+    comma    := ,
+    DEVICE    =$(word 1,$(subst $(comma), ,$(ROCR_VISIBLE_DEVICES)))
+    RUNENV    = ROCR_VISIBLE_DEVICES=$(DEVICE)
+endif
+
 RUNPROF_FLAGS = --hsa-trace
 
-RUNENV      = OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
-RUNCMD      = ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
+RUNENV       += OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
+RUNCMD       = ./$(TESTNAME) && python3 countQueueCreateEvents.py 2
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)


### PR DESCRIPTION
Currently, all devices will be initialized during OpenMP plugin creation. This leads to test fails, when multiple GPUs are present. (N GPUs -> N+1 calls to hsa_queue_create)

Hence, if ROCR_VISIBLE_DEVICES is not already set, we use '0' as default. This will limit test execution to a single GPU and the test will pass as the expected number of hsa_queue_create calls is observed.