### PR TITLE
[smoke-fort] Workaround stacksize issue on olcf-tc-5

### DIFF
--- a/test/smoke-fort/olcf-tc-5-openmp-gpu-implicit/jacobi.cpp
+++ b/test/smoke-fort/olcf-tc-5-openmp-gpu-implicit/jacobi.cpp
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <time.h>
 
-const unsigned int n_cells = 4096;
+const unsigned int n_cells = 512;
 const unsigned int SIZE = (n_cells + 2) * (n_cells +2);
 
 #define MAX(X, Y) ((X) > (Y) ? (X) : (Y))


### PR DESCRIPTION
  - on nightly test systems when ulimit -s can't be changed
  - runs fine with 'ulimit -s unlimited' to relax limit