### PR TITLE
Disable coarse graining on clang-317896.

### DIFF
--- a/test/smoke-fails/clang-317896/Makefile
+++ b/test/smoke-fails/clang-317896/Makefile
@@ -9,6 +9,8 @@ CLANG        = clang++ -D__HIP_PLATFORM_AMD__   -lamdhip64 -DUSE_HIP_MALLOC -DUS
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
+RUNENV      += OMPX_DISABLE_USM_MAPS=1
+
 SUPPORTED    = $(SUPPORTS_USM)
 
 #-ccc-print-phases


### PR DESCRIPTION
hipMalloc'ed pointers need not to be coarse grained, as they are already coarse grain memory.