### PR TITLE
Use system's default rocgdb instead of AOMP's

### DIFF
--- a/test/smoke/clang-325070/Makefile
+++ b/test/smoke/clang-325070/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = clang-325070.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-RUNCMD       = $(AOMP)/bin/rocgdb -x doit.gdb --args ./$(TESTNAME) 0
+RUNCMD       = rocgdb -x doit.gdb --args ./$(TESTNAME) 0
 
 CLANG        = clang++
 CFLAGS       = -g -O0


### PR DESCRIPTION
rocgdb requires libpython.so which is more likely to be found by the system's default rocgdb.

The one in AOMP/bin/rocgdb complains about missing libpython.so file.