### PR TITLE
[smoke-fort] Adjust milestone-3-babel* runtime, use RUNENV

### DIFF
--- a/test/smoke-fort/milestone-3-babel-drop-1/Makefile
+++ b/test/smoke-fort/milestone-3-babel-drop-1/Makefile
@@ -11,6 +11,7 @@ CC           = AOMP=${AOMP} AOMP_GPU=${AOMP_GPU} FLANG=${FLANG} ./buildit.sh
 #-ccc-print-phases
 #"-\#\#\#"
 
-RUNCMD       = AOMP_GPU=${AOMP_GPU} ./doit.sh 2>&1 | tee ${TESTNAME}.perf 2>&1 && ./chkit.sh ${TESTNAME}.perf
+RUNENV       = AOMP_GPU=${AOMP_GPU}
+RUNCMD       = ./doit.sh 2>&1 | tee ${TESTNAME}.perf 2>&1 && ./chkit.sh ${TESTNAME}.perf
 
 include ../Makefile.rules

--- a/test/smoke-fort/milestone-3-babel-drop-1/doit.sh
+++ b/test/smoke-fort/milestone-3-babel-drop-1/doit.sh
@@ -8,9 +8,9 @@ if [[ "$AOMP_GPU" =~ ^gfx10.* ]]; then
     echo "$AOMP_GPU: Skipping remaining larger memory tests"
     exit 0
 fi
-./milestone-3-babel -n 20 -s 500000000  # 12000.0 MB
+./milestone-3-babel -n 10 -s 500000000  # 12000.0 MB
 if [[ "$AOMP_GPU" =~ ^gfx11.* ]]; then
     echo "$AOMP_GPU: Skipping remaining larger memory tests"
     exit 0
 fi
-./milestone-3-babel -n 20 -s 1000000000 # 24000.0 MB
+./milestone-3-babel -n 5  -s 1000000000 # 24000.0 MB

--- a/test/smoke-fort/milestone-3-babel-noteams/Makefile
+++ b/test/smoke-fort/milestone-3-babel-noteams/Makefile
@@ -11,6 +11,7 @@ CC           = AOMP=${AOMP} AOMP_GPU=${AOMP_GPU} FLANG=${FLANG} ./buildit.sh
 #-ccc-print-phases
 #"-\#\#\#"
 
+RUNENV       = AOMP_GPU=${AOMP_GPU}
 RUNCMD       = ./doit.sh 2>&1 | tee ${TESTNAME}.perf 2>&1 && ./chkit.sh ${TESTNAME}.perf
 
 include ../Makefile.rules

--- a/test/smoke-fort/milestone-3-babel/Makefile
+++ b/test/smoke-fort/milestone-3-babel/Makefile
@@ -11,6 +11,7 @@ CC           = AOMP=${AOMP} AOMP_GPU=${AOMP_GPU} FLANG=${FLANG} ./buildit.sh
 #-ccc-print-phases
 #"-\#\#\#"
 
-RUNCMD       = AOMP_GPU=${AOMP_GPU} ./doit.sh 2>&1 | tee ${TESTNAME}.perf 2>&1 && ./chkit.sh ${TESTNAME}.perf
+RUNENV       = AOMP_GPU=${AOMP_GPU}
+RUNCMD       = ./doit.sh 2>&1 | tee ${TESTNAME}.perf 2>&1 && ./chkit.sh ${TESTNAME}.perf
 
 include ../Makefile.rules

--- a/test/smoke-fort/milestone-3-babel/doit.sh
+++ b/test/smoke-fort/milestone-3-babel/doit.sh
@@ -8,9 +8,9 @@ if [[ "$AOMP_GPU" =~ ^gfx10.* ]]; then
     echo "$AOMP_GPU: Skipping remaining larger memory tests"
     exit 0
 fi
-./milestone-3-babel -n 20 -s 500000000  # 12000.0 MB
+./milestone-3-babel -n 10 -s 500000000  # 12000.0 MB
 if [[ "$AOMP_GPU" =~ ^gfx11.* ]]; then
     echo "$AOMP_GPU: Skipping remaining larger memory tests"
     exit 0
 fi
-./milestone-3-babel -n 20 -s 1000000000 # 24000.0 MB
+./milestone-3-babel -n 5  -s 1000000000 # 24000.0 MB


### PR DESCRIPTION
    - RUNENV needed for 'make check'