### PR TITLE
[build][trunk] Add triple lib to config, lib symlink workaround

### DIFF
--- a/trunk/build_project.sh
+++ b/trunk/build_project.sh
@@ -48,7 +48,7 @@ $_targets_to_build \
 $AOMP_CCACHE_OPTS \
 -DLLVM_ENABLE_PROJECTS='$TRUNK_PROJECTS_LIST' \
 -DLLVM_INSTALL_UTILS=ON \
--DBUILD_SHARED_LIBS=OFF \
+-DBUILD_SHARED_LIBS=ON \
 -DCMAKE_CXX_STANDARD=17 \
 $_cuda_plugin \
 -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
@@ -149,6 +149,12 @@ EOD
 -Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
 EOD
    ln -sf flang.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
+   (
+   # workaround for issue with triple subdir and shared builds
+   # problem with libomptarget.so finding dependent libLLVM* libs
+   cd ${TRUNK_INSTALL_DIR}/lib
+   ln -sf x86_64-unknown-linux-gnu/*{.bc,.so,git} .
+   )
    echo
    echo "SUCCESSFUL INSTALL to $TRUNK_INSTALL_DIR with link to $TRUNK"
    echo

--- a/trunk/build_project.sh
+++ b/trunk/build_project.sh
@@ -145,7 +145,7 @@ EOD
    # Do not add -L option to flang-new because it's not currently allowed
    # flang-new also appears to be reading flang.cfg
    cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/flang.cfg
--Wl,-rpath=<CFGDIR>/../lib"
+-Wl,-rpath=<CFGDIR>/../lib
 -Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
 EOD
    ln -sf flang.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg

--- a/trunk/build_project.sh
+++ b/trunk/build_project.sh
@@ -48,7 +48,7 @@ $_targets_to_build \
 $AOMP_CCACHE_OPTS \
 -DLLVM_ENABLE_PROJECTS='$TRUNK_PROJECTS_LIST' \
 -DLLVM_INSTALL_UTILS=ON \
--DBUILD_SHARED_LIBS=ON \
+-DBUILD_SHARED_LIBS=OFF \
 -DCMAKE_CXX_STANDARD=17 \
 $_cuda_plugin \
 -DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
@@ -134,13 +134,20 @@ if [ "$1" == "install" ] ; then
    fi
    ln -sf $TRUNK_INSTALL_DIR $TRUNK_LINK
    # Create binary configs to avoid need to set LD_LIBRARY_PATH
-   echo "-Wl,-rpath=<CFGDIR>/../lib" > ${TRUNK_INSTALL_DIR}/bin/rpath.cfg
-   echo "-L<CFGDIR>/../lib" >> ${TRUNK_INSTALL_DIR}/bin/rpath.cfg
+   cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/rpath.cfg
+-Wl,-rpath=<CFGDIR>/../lib
+-Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
+-L<CFGDIR>/../lib
+-L<CFGDIR>/../lib/x86_64-unknown-linux-gnu
+EOD
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang++.cfg
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang.cfg
    # Do not add -L option to flang-new because it's not currently allowed
    # flang-new also appears to be reading flang.cfg
-   echo "-Wl,-rpath=<CFGDIR>/../lib" > ${TRUNK_INSTALL_DIR}/bin/flang.cfg
+   cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/flang.cfg
+-Wl,-rpath=<CFGDIR>/../lib"
+-Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
+EOD
    ln -sf flang.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
    echo
    echo "SUCCESSFUL INSTALL to $TRUNK_INSTALL_DIR with link to $TRUNK"


### PR DESCRIPTION
    - Upstream has introduced a triple lib subdir for target libraries
      (requires another search path in the cfg)
    - Building with -DBUILD_SHARED_LIBS=ON causes compiler so's to appear
      as dependencies in libomptarget.so which are no longer found
    - add triple lib to cfg
    - symlink triple lib subdir objects back to lib to allow for libs to be found
      (workaround until -frtlib-add-rpath solution can be made)