### PR TITLE
run_rocm_test.sh warnings fix.

### DIFF
--- a/bin/rocm-test/passes/5.4.3/smoke/smoke_passes.txt
+++ b/bin/rocm-test/passes/5.4.3/smoke/smoke_passes.txt
@@ -5,7 +5,6 @@ c-heatx
 clang-262701
 clang-296953-ornla-38
 clang-310869-scan
-clang-325070
 clang-326105
 clang-337336
 clang-ifaces

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -345,22 +345,24 @@ function copyresults(){
         # This can happen if there is a test binary that is not cleaned up, which keeps the test directory present.
         if [ -e "$resultsdir/$1/$1_make_fail.txt" ]; then
           for fail in $fails; do
-            notpresent=0
-            if [ ! -d "$2/$fail" ]; then
-              notpresent=1
-            else
-              pushd "$2/$fail" > /dev/null
-              # If no Makefile then assume this is a recently deleted test.
-              if [ ! -e Makefile ]; then
+	    if [ "$2" != "" ]; then
+              notpresent=0
+              if [ ! -d "$2/$fail" ]; then
                 notpresent=1
+              else
+                pushd "$2/$fail" > /dev/null
+                # If no Makefile then assume this is a recently deleted test.
+                if [ ! -e Makefile ]; then
+                  notpresent=1
+                fi
+                popd > /dev/null
               fi
-              popd > /dev/null
-            fi
-            if [ "$notpresent" == 1 ]; then
-              warnings[$1]+="$fail, "
-              ((unexpectedfails--))
-              ((warningcount++))
-            fi
+              if [ "$notpresent" == 1 ]; then
+                warnings[$1]+="$fail, "
+                ((unexpectedfails--))
+                ((warningcount++))
+              fi
+	    fi
           done
         fi
       elif [[ "$1" =~ sollve|ovo|LLNL|openmpapps ]]; then
@@ -477,7 +479,7 @@ function smoke(){
   cd "$aompdir"/test/smoke
   AOMP_PARALLEL_SMOKE=1 CLEANUP=0 AOMPHIP=$AOMPROCM ./check_smoke.sh
   checkrc $?
-  copyresults smoke
+  copyresults smoke "$aompdir"/test/smoke
 }
 
 SMOKE_FAILS=${SMOKE_FAILS:-1}

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -70,10 +70,10 @@ ifneq (,$(findstring $(GPU_W_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 	$(RUNENV) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND) 2>&1 | tee $@.log
 else
-	@echo "  $(SKIP_RUN_UNSUPPORTED)"
+	@echo "  $(SKIP_RUN_UNSUPPORTED)" 2>&1 | tee $@.log
 endif
 else
-	@echo "  $(SKIP_RUN_SUPPORTED)"
+	@echo "  $(SKIP_RUN_SUPPORTED)" 2>&1 | tee $@.log
 endif
 
 $(TESTNAME)_og11: $(TESTSRC_ALL)

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -313,8 +313,8 @@ for directory in $SMOKE_DIRS; do
   set_my_nrun
   while [ $run -lt $my_nrun ]; do
   #---
-  make
-  if [ $? -ne 0 ]; then
+  make 2>&1 | tee make-log.txt
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
     echo "$base: Make Failed" >> ../make-fail.txt
     if [ -r "TEST_STATUS" ]; then
       test_status=`cat TEST_STATUS`


### PR DESCRIPTION
- Tests were inadvertently being taken off the unexpected fails if they were on the make-fail.txt log.
- Added support for tests that had SUPPORTED/UNSUPPORTED variables in makefiles. For example, there are about 7 smoke tests that the gfx906 is not supported on. Those tests were counted as unexpected failures, but they should be removed from the overall failing list as they were skipped.
- Remove clang-325070 from expected passes until we determine if this is indeed an expected pass.
- Added empty HIP_PATH for smoke tests on run_rocm_test.sh. The dockers have the wrong HIP_PATH set by default.