### PR TITLE
Patch for Legacy-Flang AOMP scripts for Asan.

### DIFF
--- a/bin/build_flang-legacy.sh
+++ b/bin/build_flang-legacy.sh
@@ -45,6 +45,12 @@ else
   _cxx_flag=""
 fi
 
+# Legacy Flang dosen't support building of compiler-rt so it
+# utilizes the clang runtime libraries build/install using build_project.sh.
+# The LLVM_VERSION_MAJOR of legacy flang driver has to match with the clang
+# binaries generated from build_project.sh.
+LLVM_VERSION_MAJOR=$(${AOMP}/llvm/bin/clang --version | grep -oP '(?<=clang version )[0-9]+')
+
 # We need a version of ROCM llvm that supports legacy flang 
 # via the link from flang to clang.  rocm 5.5 would be best. 
 # This will enable removal of legacy flang driver support 
@@ -69,6 +75,7 @@ LLVMCMAKEOPTS="\
 -DLLVM_ENABLE_ASSERTIONS=ON \
 -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD \
 -DCLANG_DEFAULT_LINKER=lld \
+-DLLVM_VERSION_MAJOR="$LLVM_VERSION_MAJOR" \
 -DLLVM_INCLUDE_BENCHMARKS=0 \
 -DLLVM_INCLUDE_RUNTIMES=0 \
 -DLLVM_INCLUDE_EXAMPLES=0 \

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# 
-#  build_flang.sh:  Script to build the flang component of the AOMP compiler. 
+#
+#  build_flang.sh:  Script to build the flang component of the AOMP compiler.
 #
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
@@ -26,22 +26,40 @@ fi
 REPO_DIR=$AOMP_REPOS/$AOMP_FLANG_REPO_NAME
 COMP_INC_DIR=$REPO_DIR/runtime/libpgmath/lib/common
 
-MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG -DLLVM_ENABLE_ASSERTIONS=ON $AOMP_ORIGIN_RPATH -DLLVM_CONFIG=$INSTALL_FLANG/bin/llvm-config -DCMAKE_CXX_COMPILER=$AOMP_INSTALL_DIR/bin/clang++ -DCMAKE_C_COMPILER=$AOMP_INSTALL_DIR/bin/clang -DCMAKE_Fortran_COMPILER=gfortran -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD -DFLANG_OPENMP_GPU_AMD=ON -DFLANG_OPENMP_GPU_NVIDIA=ON -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON -DFLANG_INCLUDE_TESTS=OFF "
+MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_CONFIG=$INSTALL_FLANG/bin/llvm-config \
+  -DCMAKE_CXX_COMPILER=$AOMP_INSTALL_DIR/bin/clang++ \
+  -DCMAKE_C_COMPILER=$AOMP_INSTALL_DIR/bin/clang \
+  -DCMAKE_Fortran_COMPILER=gfortran \
+  -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD \
+  -DFLANG_OPENMP_GPU_AMD=ON \
+  -DFLANG_OPENMP_GPU_NVIDIA=ON \
+  -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
+  -DFLANG_INCLUDE_TESTS=OFF"
 
 if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
   MYCMAKEOPTS="$MYCMAKEOPTS $OPENMP_EXTRAS_ORIGIN_RPATH
   -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON"
 fi
 
-if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
+if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+   ASAN_FLAGS="$ASAN_FLAGS -I$COMP_INC_DIR"
+   ASAN_CMAKE_OPTS="$MYCMAKEOPTS -DCMAKE_PREFIX_PATH=$AOMP/lib/asan/cmake $AOMP_ASAN_ORIGIN_RPATH -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF -DCMAKE_INSTALL_BINDIR=bin/asan -DCMAKE_INSTALL_LIBDIR=lib/asan"
+fi
+
+MYCMAKEOPTS="$MYCMAKEOPTS -DCMAKE_PREFIX_PATH=$AOMP/lib/cmake $AOMP_ORIGIN_RPATH"
+
+if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
 # Make sure we can update the install directory
-if [ "$1" == "install" ] ; then 
+if [ "$1" == "install" ] ; then
    $SUDO mkdir -p $INSTALL_FLANG
    $SUDO touch $INSTALL_FLANG/testfile
-   if [ $? != 0 ] ; then 
+   if [ $? != 0 ] ; then
       echo "ERROR: No update access to $INSTALL_FLANG"
       exit 1
    fi
@@ -50,15 +68,23 @@ fi
 
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
-   echo 
+   echo
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME"
    echo "Use ""$0 nocmake"" or ""$0 install"" to avoid FRESH START."
    rm -rf $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME
    mkdir -p $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      mkdir -p $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan
+   fi
 else
-   if [ ! -d $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME ] ; then 
+   if [ ! -d $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME ] ; then
       echo "ERROR: The build directory $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME does not exist"
-      echo "       run $0 without nocmake or install options. " 
+      echo "       run $0 without nocmake or install options. "
+      exit 1
+   fi
+   if [ "$AOMP_BUILD_SANITIZER"  == 1 ] && [ ! -d $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan ] ; then
+      echo "ERROR: The build directory $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan does not exist"
+      echo "       run $0 without nocmake or install options. "
       exit 1
    fi
 fi
@@ -70,44 +96,89 @@ export PATH=$AOMP_INSTALL_DIR/bin:$PATH
 
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo
-   echo " -----Running cmake ---- " 
-   echo ${AOMP_CMAKE} $MYCMAKEOPTS  \
-       -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
-       -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
-       $AOMP_REPOS/$AOMP_FLANG_REPO_NAME
+   echo " -----Running cmake ---- "
+   echo ${AOMP_CMAKE} $MYCMAKEOPTS \
+        -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
+        -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
+        $AOMP_REPOS/$AOMP_FLANG_REPO_NAME
 
-   ${AOMP_CMAKE} $MYCMAKEOPTS  \
-       -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
-       -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
-       $AOMP_REPOS/$AOMP_FLANG_REPO_NAME 2>&1
-   if [ $? != 0 ] ; then 
+   ${AOMP_CMAKE} $MYCMAKEOPTS \
+   -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
+   -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
+   $AOMP_REPOS/$AOMP_FLANG_REPO_NAME 2>&1
+   if [ $? != 0 ] ; then
       echo "ERROR cmake failed. Cmake flags"
       echo "      $MYCMAKEOPTS"
       exit 1
    fi
+
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      cd $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan
+      echo
+      echo " ----Running cmake for flang-asan ----- "
+      echo ${AOMP_CMAKE} $ASAN_CMAKE_OPTS \
+           -DCMAKE_C_FLAGS="$CFLAGS $ASAN_FLAGS" \
+           -DCMAKE_CXX_FLAGS="$CXXFLAGS $ASAN_FLAGS" \
+           $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME
+
+      ${AOMP_CMAKE} $ASAN_CMAKE_OPTS  \
+      -DCMAKE_C_FLAGS="$CFLAGS $ASAN_FLAGS" \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS $ASAN_FLAGS" \
+      $AOMP_REPOS/$AOMP_FLANG_REPO_NAME 2>&1
+      if [ $? != 0 ] ; then
+         echo "ERROR flang-asan cmake failed. Cmake flags"
+         echo "      $ASAN_CMAKE_OPTS"
+         exit 1
+      fi
+   fi
 fi
 
 echo
-echo " -----Running make ---- " 
-echo make -j $AOMP_JOB_THREADS 
-make -j $AOMP_JOB_THREADS 
-if [ $? != 0 ] ; then 
+echo " ----- Running make ---- "
+cd $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME
+echo make -j $AOMP_JOB_THREADS
+make -j $AOMP_JOB_THREADS
+if [ $? != 0 ] ; then
    echo "ERROR make -j $AOMP_JOB_THREADS failed"
    exit 1
 fi
 
+if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+   cd $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan
+   echo
+   echo " ----- Running make for flang-asan ---- "
+   echo make -j $AOMP_JOB_THREADS
+   make -j $AOMP_JOB_THREADS
+   if [ $? != 0 ] ; then
+      echo "ERROR make -j $AOMP_JOB_THREADS failed"
+      exit 1
+   fi
+fi
+
 if [ "$1" == "install" ] ; then
-   echo " -----Installing to $INSTALL_FLANG ---- " 
-   $SUDO make install 
-   if [ $? != 0 ] ; then 
+   cd $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME
+   echo " -----Installing to $INSTALL_FLANG ---- "
+   $SUDO make install
+   if [ $? != 0 ] ; then
       echo "ERROR make install failed "
       exit 1
    fi
    echo "SUCCESSFUL INSTALL to $INSTALL_FLANG "
+
    echo
-else 
-   echo 
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      cd $BUILD_DIR/build/$AOMP_FLANG_REPO_NAME/asan
+      echo " -----Installing to $INSTALL_FLANG/lib/asan ---- "
+      $SUDO make install
+      if [ $? != 0 ] ; then
+         echo "ERROR make install failed "
+         exit 1
+      fi
+      echo "SUCCESSFUL INSTALL to $INSTALL_FLANG/lib/asan"
+   fi
+else
+   echo
    echo "SUCCESSFUL BUILD, please run:  $0 install"
    echo "  to install into $AOMP"
-   echo 
+   echo
 fi

--- a/bin/build_pgmath.sh
+++ b/bin/build_pgmath.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# 
-#  build_pgmath.sh:  Script to build the pgmath component of the AOMP compiler. 
+#
+#  build_pgmath.sh:  Script to build the pgmath component of the AOMP compiler.
 #
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
@@ -12,7 +12,6 @@ thisdir=`dirname $realpath`
 # --- end standard header ----
 
 INSTALL_FLANG=${INSTALL_FLANG:-$AOMP_INSTALL_DIR}
-
 
 if [ "$AOMP_PROC" == "ppc64le" ] ; then
    TARGETS_TO_BUILD="AMDGPU;${AOMP_NVPTX_TARGET}PowerPC"
@@ -27,27 +26,33 @@ fi
 COMP_INC_DIR=$(ls -d $AOMP_INSTALL_DIR/lib/clang/*/include )
 
 if [ "$AOMP_PROC" == "ppc64le" ] ; then
-    MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG -DLLVM_ENABLE_ASSERTIONS=ON $AOMP_ORIGIN_RPATH -DCMAKE_Fortran_COMPILER=$AOMP_INSTALL_DIR/bin/flang -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD "
+    MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG -DLLVM_ENABLE_ASSERTIONS=ON -DCMAKE_Fortran_COMPILER=$AOMP_INSTALL_DIR/bin/flang -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD "
 else
-    MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG -DLLVM_ENABLE_ASSERTIONS=ON $AOMP_ORIGIN_RPATH -DLLVM_CONFIG=$INSTALL_FLANG/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang  -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD "
+    MYCMAKEOPTS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_FLANG -DLLVM_ENABLE_ASSERTIONS=ON -DLLVM_CONFIG=$INSTALL_FLANG/bin/llvm-config -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang  -DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD "
 fi
 
 if [ "$AOMP_STANDALONE_BUILD" == 0 ]; then
-  MYCMAKEOPTS="$MYCMAKEOPTS
-  -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON $OPENMP_EXTRAS_ORIGIN_RPATH"
+  MYCMAKEOPTS="$MYCMAKEOPTS -DENABLE_DEVEL_PACKAGE=ON -DENABLE_RUN_PACKAGE=ON $OPENMP_EXTRAS_ORIGIN_RPATH"
 fi
 
-if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
+if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+   ASAN_FLAGS="$ASAN_FLAGS -I$COMP_INC_DIR"
+   ASAN_CMAKE_OPTS="$MYCMAKEOPTS -DCMAKE_PREFIX_PATH=$AOMP/lib/asan/cmake $AOMP_ASAN_ORIGIN_RPATH -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF -DCMAKE_INSTALL_BINDIR=bin/asan -DCMAKE_INSTALL_LIBDIR=lib/asan"
+fi
+
+MYCMAKEOPTS="$MYCMAKEOPTS -DCMAKE_PREFIX_PATH=$AOMP/lib/cmake $AOMP_ORIGIN_RPATH"
+
+if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
 REPO_DIR=$AOMP_REPOS/$AOMP_FLANG_REPO_NAME
 
 # Make sure we can update the install directory
-if [ "$1" == "install" ] ; then 
+if [ "$1" == "install" ] ; then
    $SUDO mkdir -p $INSTALL_FLANG
    $SUDO touch $INSTALL_FLANG/testfile
-   if [ $? != 0 ] ; then 
+   if [ $? != 0 ] ; then
       echo "ERROR: No update access to $INSTALL_FLANG"
       exit 1
    fi
@@ -56,63 +61,114 @@ fi
 
 # Skip synchronization from git repos if nocmake or install are specified
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
-   echo 
+   echo
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/build/pgmath"
    echo "Use ""$0 nocmake"" or ""$0 install"" to avoid FRESH START."
    rm -rf $BUILD_DIR/build/pgmath
    mkdir -p $BUILD_DIR/build/pgmath
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      mkdir -p $BUILD_DIR/build/pgmath/asan
+   fi
 else
-   if [ ! -d $BUILD_DIR/build/pgmath ] ; then 
+   if [ ! -d $BUILD_DIR/build/pgmath ] ; then
       echo "ERROR: The build directory $BUILD_DIR/build/pgmath does not exist"
-      echo "       run $0 without nocmake or install options. " 
+      echo "       run $0 without nocmake or install options. "
+      exit 1
+   fi
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ] && [ ! -d $BUILD_DIR/build/pgmath/asan ] ; then
+      echo "ERROR: The build directory $BUILD_DIR/build/pgmath/asan does not exist"
+      echo "       run $0 without nocmake or install options. "
       exit 1
    fi
 fi
-
-cd $BUILD_DIR/build/pgmath 
 
 #  Need llvm-config to come from previous LLVM build
 export PATH=$AOMP_INSTALL_DIR/bin:$PATH
 
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo
-   echo " -----Running cmake ---- " 
+   cd $BUILD_DIR/build/pgmath
+   echo " -----Running cmake ---- "
    echo ${AOMP_CMAKE} $MYCMAKEOPTS  \
-	  -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
-	  -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
-          $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath
+        -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
+        -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
+        $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath
    ${AOMP_CMAKE} $MYCMAKEOPTS  \
-	  -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
-	  -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
-          $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath  2>&1
-   if [ $? != 0 ] ; then 
+   -DCMAKE_C_FLAGS="$CFLAGS -I$COMP_INC_DIR" \
+   -DCMAKE_CXX_FLAGS="$CXXFLAGS -I$COMP_INC_DIR" \
+   $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath  2>&1
+   if [ $? != 0 ] ; then
       echo "ERROR cmake failed. Cmake flags"
       echo "      $MYCMAKEOPTS"
       exit 1
    fi
+
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      echo
+      cd $BUILD_DIR/build/pgmath/asan
+      echo " -----Running cmake pgmath-asan ---- "
+      echo ${AOMP_CMAKE} $ASAN_CMAKE_OPTS \
+      -DCMAKE_C_FLAGS="$CFLAGS $ASAN_FLAGS" \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS $ASAN_FLAGS" \
+      $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath
+      ${AOMP_CMAKE} $ASAN_CMAKE_OPTS  \
+      -DCMAKE_C_FLAGS="$CFLAGS $ASAN_FLAGS" \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS $ASAN_FLAGS" \
+      $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/runtime/libpgmath  2>&1
+      if [ $? != 0 ] ; then
+         echo "ERROR pgmath-asan cmake failed. Cmake flags"
+         echo "      $ASAN_CMAKE_OPTS"
+         exit 1
+      fi
+   fi
 fi
 
 echo
-echo " -----Running make ---- " 
-echo make -j $AOMP_JOB_THREADS 
-make -j $AOMP_JOB_THREADS 
-if [ $? != 0 ] ; then 
+cd $BUILD_DIR/build/pgmath
+echo " -----Running make ---- "
+echo make -j $AOMP_JOB_THREADS
+make -j $AOMP_JOB_THREADS
+if [ $? != 0 ] ; then
    echo "ERROR make -j $AOMP_JOB_THREADS failed"
    exit 1
 fi
 
+if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+echo
+cd $BUILD_DIR/build/pgmath/asan
+echo " -----Running make ---- "
+echo make -j $AOMP_JOB_THREADS
+make -j $AOMP_JOB_THREADS
+if [ $? != 0 ] ; then
+   echo "ERROR make -j $AOMP_JOB_THREADS failed"
+   exit 1
+fi
+fi
+
 if [ "$1" == "install" ] ; then
-   echo " -----Installing to $INSTALL_FLANG ---- " 
-   $SUDO make install 
-   if [ $? != 0 ] ; then 
+   cd $BUILD_DIR/build/pgmath
+   echo " -----Installing to $INSTALL_FLANG ---- "
+   $SUDO make install
+   if [ $? != 0 ] ; then
       echo "ERROR make install failed "
       exit 1
    fi
    echo "SUCCESSFUL INSTALL to $INSTALL_FLANG "
    echo
-else 
-   echo 
+   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
+      cd $BUILD_DIR/build/pgmath/asan
+      echo " -----Installing to $INSTALL_FLANG/lib/asan ---- "
+      $SUDO make install
+      if [ $? != 0 ] ; then
+         echo "ERROR make install failed "
+         exit 1
+      fi
+      echo "SUCCESSFUL INSTALL to $INSTALL_FLANG/lib/asan"
+      echo
+   fi
+else
+   echo
    echo "SUCCESSFUL BUILD, please run:  $0 install"
    echo "  to install into $AOMP"
-   echo 
+   echo
 fi


### PR DESCRIPTION
Requirement to ship ASan instrumented Legacy-Flang libraries Build & Install support.  The patch achieves the following objectives:-

1. Build & Install support Flang{libflang.so(llvm/lib/asan)}.
2. Build & Install support Flang-Runtime{libflangrti.so(llvm/lib/asan)}.
3. Build & Install support PGMath{libpgmath.so(llvm/lib/asan)}.