### PR TITLE
[OpenMP][OMPT] Fix macro usage and adapt to suite mode EnVar

### DIFF
--- a/test/smoke-fails/omptest-testsuite-emi/Makefile
+++ b/test/smoke-fails/omptest-testsuite-emi/Makefile
@@ -8,6 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 RUNENV       += OMPTEST_USE_OMPT_EMI=1
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 RUNCMD       = ./$(TESTNAME)
 CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #-ccc-print-phases

--- a/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
+++ b/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
@@ -5,7 +5,7 @@
 using namespace omptest;
 using namespace internal;
 
-OMPTTESTCASE(SequenceSuite, uut_target) {
+TEST(SequenceSuite, uut_target) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
@@ -26,7 +26,7 @@ OMPTTESTCASE(SequenceSuite, uut_target) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, uut_target_dataop) {
+TEST(SequenceSuite, uut_target_dataop) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
@@ -69,7 +69,7 @@ OMPTTESTCASE(SequenceSuite, uut_target_dataop) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, uut_target_submit) {
+TEST(SequenceSuite, uut_target_submit) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
@@ -90,7 +90,7 @@ OMPTTESTCASE(SequenceSuite, uut_target_submit) {
   }
 }
 
-OMPTTESTCASE(SetSuite, uut_target) {
+TEST(SetSuite, uut_target) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
@@ -111,7 +111,7 @@ OMPTTESTCASE(SetSuite, uut_target) {
   }
 }
 
-OMPTTESTCASE_XFAIL(SetSuite, uut_target_xfail_banned_begin_end) {
+TEST_XFAIL(SetSuite, uut_target_xfail_banned_begin_end) {
   /* The Test Body */
   int N = 128;
   int a[N];
@@ -134,7 +134,7 @@ OMPTTESTCASE_XFAIL(SetSuite, uut_target_xfail_banned_begin_end) {
   }
 }
 
-OMPTTESTCASE(SetSuite, uut_target_ignore_non_emi_events) {
+TEST(SetSuite, uut_target_ignore_non_emi_events) {
   /* The Test Body */
   int N = 128;
   int a[N];
@@ -157,7 +157,7 @@ OMPTTESTCASE(SetSuite, uut_target_ignore_non_emi_events) {
   }
 }
 
-OMPTTESTCASE(SetSuite, uut_target_dataop) {
+TEST(SetSuite, uut_target_dataop) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
@@ -200,7 +200,7 @@ OMPTTESTCASE(SetSuite, uut_target_dataop) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, veccopy_ompt_target) {
+TEST(SequenceSuite, veccopy_ompt_target) {
   /* The Test Body */
 
   // Define testcase variables before events, so we can refer to them.
@@ -380,7 +380,7 @@ OMPTTESTCASE(SequenceSuite, veccopy_ompt_target) {
 }
 
 // Leave this suite down here so it gets discovered last and executed first.
-OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
+TEST(InitialTestSuite, uut_device_init_load) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
@@ -391,8 +391,6 @@ OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
 
   OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_SET(DeviceInitialize, /*DeviceNum=*/0)
-
 #pragma omp target parallel for
   {
     for (int j = 0; j < N; j++)
@@ -401,7 +399,6 @@ OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
 }
 
 int main(int argc, char **argv) {
-  libomptest_global_eventreporter_set_active(false);
   Runner R;
   R.run();
 

--- a/test/smoke-fails/omptest-testsuite/Makefile
+++ b/test/smoke-fails/omptest-testsuite/Makefile
@@ -7,6 +7,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #-ccc-print-phases
 #"-\#\#\#"

--- a/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
+++ b/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
@@ -5,7 +5,7 @@
 using namespace omptest;
 using namespace internal;
 
-OMPTTESTCASE_XFAIL(SequenceSuite, uut_target_xfail_wrong_order) {
+TEST_XFAIL(SequenceSuite, uut_target_xfail_wrong_order) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -26,7 +26,7 @@ OMPTTESTCASE_XFAIL(SequenceSuite, uut_target_xfail_wrong_order) {
   }
 }
 
-OMPTTESTCASE_XFAIL(SequenceSuite, uut_target_xfail_banned_begin_end) {
+TEST_XFAIL(SequenceSuite, uut_target_xfail_banned_begin_end) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -47,7 +47,7 @@ OMPTTESTCASE_XFAIL(SequenceSuite, uut_target_xfail_banned_begin_end) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, uut_target) {
+TEST(SequenceSuite, uut_target) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -67,7 +67,7 @@ OMPTTESTCASE(SequenceSuite, uut_target) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, uut_target_dataop) {
+TEST(SequenceSuite, uut_target_dataop) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::Target)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -92,7 +92,7 @@ OMPTTESTCASE(SequenceSuite, uut_target_dataop) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, uut_target_submit) {
+TEST(SequenceSuite, uut_target_submit) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::Target)
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
@@ -109,7 +109,7 @@ OMPTTESTCASE(SequenceSuite, uut_target_submit) {
   }
 }
 
-OMPTTESTCASE(SequenceSuite, veccopy_ompt_target) {
+TEST(SequenceSuite, veccopy_ompt_target) {
   /* The Test Body */
 
   // Define testcase variables before events, so we can refer to them.
@@ -217,7 +217,7 @@ OMPTTESTCASE(SequenceSuite, veccopy_ompt_target) {
 }
 
 // Leave this suite down here so it gets discovered last and executed first.
-OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
+TEST(InitialTestSuite, uut_device_init_load) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::Target)
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
@@ -226,7 +226,6 @@ OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
   int N = 128;
   int a[N];
 
-  OMPT_ASSERT_SEQUENCE(DeviceInitialize, /*DeviceNum=*/0)
   OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
 
 #pragma omp target parallel for
@@ -237,7 +236,6 @@ OMPTTESTCASE(InitialTestSuite, uut_device_init_load) {
 }
 
 int main(int argc, char **argv) {
-  libomptest_global_eventreporter_set_active(false);
   Runner R;
   R.run();
 

--- a/test/smoke-fails/omptest-unittest/Makefile
+++ b/test/smoke-fails/omptest-unittest/Makefile
@@ -7,7 +7,8 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
-CC           = $(OMP_BIN) $(VERBOSE) -I$(AOMP_REPOS)/llvm-project/openmp/libomptarget/test/ompTest/include -L$(AOMP_REPOS)/build/openmp/libomptarget -lomptest
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/omptest-unittest/omptest.cpp
+++ b/test/smoke-fails/omptest-unittest/omptest.cpp
@@ -2,56 +2,56 @@
 
 #include "OmptTester.h"
 
-OMPTTESTCASE(ManualSuite, ParallelFor) {
+TEST(ManualSuite, ParallelFor) {
   /* The Test Body */
   int arr[10] = {0};
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin(
-      /*NumThreads=*/2, "User Parallel Begin"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+      /*NumThreads=*/2));
   SequenceAsserter.insert(omptest::OmptAssertEvent::ThreadBegin(
-      ompt_thread_initial, "User Thread Begin"));
+      "User Thread Begin", "Group", omptest::ObserveState::always, ompt_thread_initial));
   SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End"));
+      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
 
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelEnd(""));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelEnd("User Parallel End 2", "Group", omptest::ObserveState::always));
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 }
 
-OMPTTESTCASE(ManualSuite, ParallelForActivation) {
+TEST(ManualSuite, ParallelForActivation) {
   /* The Test Body */
   int arr[10] = {0};
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin(
-      /*NumThreads=*/2, "User Parallel Begin"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+      /*NumThreads=*/2));
   SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End"));
+      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
 
   // The last sequence we want to observe does not contain
   // another thread begin.
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin(
-      /*NumThreads=*/2, "User Parallel Begin"));
+  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+      /*NumThreads=*/2));
   SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End"));
+      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 
-  OMPT_SEQ_ASSERT_DISABLE()
+  OMPT_ASSERT_SEQUENCE_DISABLE();
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 
-  OMPT_SEQ_ASSERT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_ENABLE();
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 }
 
-OMPTTESTCASE(ManualSuite, AnotherTest) {
+TEST(ManualSuite, AnotherTest) {
   int arr[12] = {0};
 
 #pragma omp parallel for num_threads(2)
@@ -60,13 +60,13 @@ OMPTTESTCASE(ManualSuite, AnotherTest) {
   }
 }
 
-OMPTTESTCASE(ManualSuite, ParallelForToString) {
+TEST(ManualSuite, ParallelForToString) {
   /* The Test Body */
   int arr[10] = {0};
 
-  OMPT_SEQ_ASSERT_DISABLE()
+  OMPT_ASSERT_SEQUENCE_DISABLE();
 
-  OMPT_EVENT_REPORT_DISABLE()
+  OMPT_REPORT_EVENT_DISABLE();
 
   EventReporter.permitEvent(omptest::internal::EventTy::ParallelBegin);
   EventReporter.permitEvent(omptest::internal::EventTy::ParallelEnd);
@@ -77,7 +77,7 @@ OMPTTESTCASE(ManualSuite, ParallelForToString) {
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 
-  OMPT_EVENT_REPORT_ENABLE()
+  OMPT_REPORT_EVENT_ENABLE();
 
 #pragma omp parallel for num_threads(3)
   for (int i = 0; i < 10; ++i)
@@ -96,27 +96,27 @@ OMPTTESTCASE(ManualSuite, ParallelForToString) {
   EventReporter.suppressEvent(omptest::internal::EventTy::ThreadBegin);
   EventReporter.suppressEvent(omptest::internal::EventTy::ThreadEnd);
 
-  OMPT_SEQ_ASSERT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_ENABLE();
 }
 
-OMPTTESTCASE(ManualSuite, TargetParallelToString) {
+TEST(ManualSuite, TargetParallelToString) {
   /* The Test Body */
   int arr[10] = {0};
 
-  OMPT_SEQ_ASSERT_DISABLE()
-  OMPT_EVENT_REPORT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_DISABLE();
+  OMPT_REPORT_EVENT_ENABLE();
 
 #pragma omp target parallel for num_threads(1)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 
-  OMPT_SEQ_ASSERT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_ENABLE();
 }
 
-OMPTTESTCASE(ManualSuite, veccopy_ompt_target) {
+TEST(ManualSuite, veccopy_ompt_target) {
   /* The Test Body */
-  OMPT_SEQ_ASSERT_DISABLE()
-  OMPT_EVENT_REPORT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_DISABLE();
+  OMPT_REPORT_EVENT_ENABLE();
 
   int N = 100000;
 
@@ -153,7 +153,7 @@ OMPTTESTCASE(ManualSuite, veccopy_ompt_target) {
   if (!rc)
     printf("Success\n");
 
-  OMPT_SEQ_ASSERT_ENABLE()
+  OMPT_ASSERT_SEQUENCE_ENABLE();
 }
 
 int main(int argc, char **argv) {

--- a/test/smoke-limbo/veccopy-ompt-target-cmake/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/Makefile
@@ -14,6 +14,7 @@ RUNCMD       = ./performBuildRun.sh -a $(AOMP) -t $(AOMP_GPU)
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 DUMMYOPT     = $(VERBOSE) -x c -
 CC           = $(DUMMYSRC) | $(OMP_BIN) $(DUMMYOPT)
 

--- a/test/smoke-limbo/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
@@ -226,7 +226,6 @@ TEST(InitialTestSuite, uut_device_init_load) {
   int N = 128;
   int a[N];
 
-  OMPT_ASSERT_SEQUENCE(DeviceInitialize, /*DeviceNum=*/0)
   OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
 
 #pragma omp target parallel for
@@ -237,7 +236,6 @@ TEST(InitialTestSuite, uut_device_init_load) {
 }
 
 int main(int argc, char **argv) {
-  libomptest_global_eventreporter_set_active(false);
   Runner R;
   R.run();
 


### PR DESCRIPTION
There was a critical oversight in the usage of the TEST macro
 * used OMPTTESTCASE instead

EventReporter is now silenced via EnVar 'OMPTEST_MODE_SUITE'
 * this will prevent unwanted prints (e.g. from device init)