### PR TITLE
[OpenMP] Add basic interop test

### DIFF
--- a/test/smoke-fails/omp-interop/Makefile
+++ b/test/smoke-fails/omp-interop/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = omp-interop
+TESTSRC_MAIN = omp-interop.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+RUNCMD       = ./$(TESTNAME) | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules
+

--- a/test/smoke-fails/omp-interop/omp-interop.c
+++ b/test/smoke-fails/omp-interop/omp-interop.c
@@ -1,0 +1,46 @@
+#include <omp.h>
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  int EC;
+  omp_interop_t IObj = omp_interop_none;
+
+#pragma omp interop init(targetsync : IObj)
+
+  const char *Type = omp_get_interop_str(IObj, omp_ipr_fr_id, &EC);
+  if (EC) {
+    printf("omp_get_interop_str failed: %d\n", EC);
+    return -1;
+  }
+
+  printf("Interop Type: %s\n", Type);
+
+  const char *Vendor = omp_get_interop_str(IObj, omp_ipr_vendor_name, &EC);
+  if (EC) {
+    printf("omp_get_interop_str failed: %d\n", EC);
+    return -1;
+  }
+
+  printf("Interop Vendor ID: %s\n", Vendor);
+
+  const char *Backend = omp_get_interop_str(IObj, omp_ipr_fr_name, &EC);
+  if (EC) {
+    printf("omp_get_interop_str failed: %d\n", EC);
+    return -1;
+  }
+
+  printf("Interop Backend ID: %s\n", Backend);
+
+#pragma omp interop destroy(IObj)
+
+  return 0;
+}
+
+/// CHECK-NOT: failed
+/// CHECK: Type: tasksync
+
+/// CHECK-NOT: failed
+/// CHECK: Vendor ID: amdhsa
+
+/// CHECK-NOT: failed
+/// CHECK: Backend ID: amdhsa backend


### PR DESCRIPTION
Based on a small reproducer; we should be able to emit 'amdhsa'.

Related to: https://github.com/ROCm/ROCm/issues/2897