### PR TITLE
[Examples] Add READMEs for stdpar and OpenCL

### DIFF
--- a/examples/opencl/README.md
+++ b/examples/opencl/README.md
@@ -1,0 +1,3 @@
+# AOMP -- Examples for OpenCL
+
+This directory contains examples for OpenCL.

--- a/examples/stdpar/README.md
+++ b/examples/stdpar/README.md
@@ -1,0 +1,3 @@
+# AOMP -- Examples for stdpar
+
+This directory contains examples for stdpar.


### PR DESCRIPTION
Adding these READMEs makes the links in the top-level README work and no longer receive a 404 because the directories do not exist.