### PR TITLE
[smoke-fort-fails] flang-457354: Remove save-temps flag

### DIFF
--- a/test/smoke-fort-fails/flang-457354/Makefile
+++ b/test/smoke-fort-fails/flang-457354/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = main.f95
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-FLANG        ?= flang-new -save-temps
+FLANG        ?= flang-new
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases


### PR DESCRIPTION
Save-temps flag is not supported by upstream flang.