### PR TITLE
[sollve] Start using -fopenmp --offload-arch flags

### DIFF
--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -84,7 +84,7 @@ else
   triple="amdgcn-amd-amdhsa"
 fi
 
-export MY_SOLLVE_FLAGS="-O2 -fopenmp -fopenmp-targets=$triple -Xopenmp-target=$triple -march=$AOMP_GPU"
+export MY_SOLLVE_FLAGS=${MY_SOLLVE_FLAGS:-"-O2 -fopenmp --offload-arch=$AOMP_GPU"}
 
 pushd $AOMP_REPOS_TEST/$AOMP_SOLVV_REPO_NAME
 


### PR DESCRIPTION
    - Use the newer/shorter:
        -fopenmp --offload-arch=$AOMP_GPU
      instead of:
        -fopenmp -fopenmp-targets=$triple -Xopenmp-target=$triple -march=$AOMP_GPU

    - flang-new does not support:
        -fopenmp-targets=$triple -Xopenmp-target=$triple -march=$AOMP_GPU
    - all compilers (including flang-new) support:
        --offload-arch=$AOMP_GPU