### PR TITLE
[Makefile] Remove run-recipe overrides from smoke-limbo and -dev

### DIFF
--- a/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/Makefile
+++ b/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/Makefile
@@ -12,6 +12,3 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
-run:
-	echo $(PATH)
-	$(RUNCMD)

--- a/test/smoke-limbo/aomp-issue531/Makefile
+++ b/test/smoke-limbo/aomp-issue531/Makefile
@@ -14,5 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(RUNCMD)

--- a/test/smoke-limbo/no-loop-1/Makefile
+++ b/test/smoke-limbo/no-loop-1/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-2/Makefile
+++ b/test/smoke-limbo/no-loop-2/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-3/Makefile
+++ b/test/smoke-limbo/no-loop-3/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-4/Makefile
+++ b/test/smoke-limbo/no-loop-4/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-5/Makefile
+++ b/test/smoke-limbo/no-loop-5/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-6/Makefile
+++ b/test/smoke-limbo/no-loop-6/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/no-loop-7/Makefile
+++ b/test/smoke-limbo/no-loop-7/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/opt-kernel-global-iv/Makefile
+++ b/test/smoke-limbo/opt-kernel-global-iv/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/opt-kernel-inner-pragma-1/Makefile
+++ b/test/smoke-limbo/opt-kernel-inner-pragma-1/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-default-device/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/Makefile
@@ -14,6 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	echo $(PATH)
-	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-devices/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-devices/Makefile
@@ -14,6 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	echo $(PATH)
-	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-emi-map/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-emi-map/Makefile
@@ -15,5 +15,3 @@ CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-emi/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-emi/Makefile
@@ -15,5 +15,3 @@ CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-map/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-map/Makefile
@@ -14,5 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-tracing/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-tracing/Makefile
@@ -14,6 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	echo $(PATH)
-	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target-translate-time/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-translate-time/Makefile
@@ -14,5 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(RUNCMD)

--- a/test/smoke-limbo/veccopy-ompt-target/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target/Makefile
@@ -14,6 +14,3 @@ CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	echo $(PATH)
-	$(RUNCMD)

--- a/test/smoke-limbo/workgroup_size_option1/Makefile
+++ b/test/smoke-limbo/workgroup_size_option1/Makefile
@@ -24,5 +24,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/workgroup_size_option2/Makefile
+++ b/test/smoke-limbo/workgroup_size_option2/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)

--- a/test/smoke-limbo/xteam-red-fast-1/Makefile
+++ b/test/smoke-limbo/xteam-red-fast-1/Makefile
@@ -16,5 +16,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	$(RUNENV) $(RUNCMD)


### PR DESCRIPTION
Remove unneccessary run-recipe overrides (as they also complicated debugging).