### PR TITLE
[offload][OMPT] Fix sporadic fails of device tracing tests

### DIFF
--- a/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/veccopy-ompt-target-emi-tracing-dag.cpp
+++ b/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/veccopy-ompt-target-emi-tracing-dag.cpp
@@ -77,9 +77,6 @@ int main() {
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}}
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}}
 
-// Note: This entry should happen due to the call to flush_trace.
-/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} {{.+}} {{[0-9]+}}
-
 // Note: Split checks for record address and content. That way we do not imply
 //       any order. Records 01-06 and 12-17 occur interleaved and belong to the
 //       first target region. 07-11 occur interleaved with 18-22 and belong to

--- a/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/veccopy-ompt-target-data-tracing-emi.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/veccopy-ompt-target-data-tracing-emi.cpp
@@ -145,9 +145,6 @@ int main() {
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}}
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}}
 
-// Note: This entry should happen due to the call to flush_trace.
-/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_08]] {{[0-9]+}} {{.+}} {{[0-9]+}}
-
 // Note: Split checks for record address and content. That way we do not imply
 //       any order. Records 01-06 and 12-17 occur interleaved and belong to the
 //       first target region. 07-11 occur interleaved with 18-22 and belong to

--- a/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-default-device/veccopy-ompt-target-default-device.cpp
@@ -79,9 +79,6 @@ int main() {
 /// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=[[ADDRX_06]]
 /// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_07]], {{.+}} begin=[[ADDRX_07]]
 
-// Note: This entry should happen due to the call to flush_trace.
-/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} buffer_owned=0
-
 // Note: Split checks for record address and content. That way we do not imply
 //       any order. Records may / will occur interleaved.
 /// CHECK-DAG: rec=[[ADDRX_01]]

--- a/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-devices/veccopy-ompt-target-devices.cpp
@@ -79,9 +79,6 @@ int main() {
 /// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_06]], {{.+}} begin=[[ADDRX_06]]
 /// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_07]], {{.+}} begin=[[ADDRX_07]]
 
-// Note: This entry should happen due to the call to flush_trace.
-/// CHECK-DAG: Executing buffer complete callback {{.+}} device_num=0, buffer=[[ADDRX_02]], {{.+}} buffer_owned=0
-
 // Note: Split checks for record address and content. That way we do not imply
 //       any order. Records may / will occur interleaved.
 /// CHECK-DAG: rec=[[ADDRX_01]]

--- a/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke/veccopy-ompt-target-emi-tracing/veccopy-ompt-target-emi-tracing.cpp
@@ -51,8 +51,6 @@ int main() {
 
 // clang-format off
 
-// clang-format off
-
 /// CHECK-NOT: host_op_id=0x0
 
 /// CHECK-DAG: Allocated {{[0-9]+}} bytes at [[ADDRX_01:0x[0-f]+]] in buffer request callback
@@ -78,9 +76,6 @@ int main() {
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}} [[ADDRX_09]] {{[0-9]+}}
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}} [[ADDRX_10]] {{[0-9]+}}
 /// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}} [[ADDRX_11]] {{[0-9]+}}
-
-// Note: This entry should happen due to the call to flush_trace.
-/// CHECK-DAG: Executing buffer complete callback: {{[0-9]+}} [[ADDRX_06]] {{[0-9]+}} {{.+}} {{[0-9]+}}
 
 // Note: Split checks for record address and content. That way we do not imply
 //       any order. Records 01-06 and 12-17 occur interleaved and belong to the


### PR DESCRIPTION
Removed checks for certain 'buffer complete callbacks'

We observed sporadic fails for tracing tests with calls to flush_trace.
These tests *may* emit certain buffer callbacks because of these calls.
But it seems that the occurrences are actually non-deterministic.