### PR TITLE
[smoke] - Fix tests that use rocprof in a local run target

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -10,6 +10,7 @@ SKIP_COMPILE_SUPPORTED   = Skipped compiling $(TESTNAME) for $(GPU_W_FEATURES) (
 SKIP_COMPILE_UNSUPPORTED = Skipped compiling $(TESTNAME): not supported on $(UNSUPPORTED)
 SKIP_RUN_SUPPORTED       = Skipped running $(TESTNAME) on $(GPU_W_FEATURES) (supported only on $(SUPPORTED))
 SKIP_RUN_UNSUPPORTED     = Skipped running $(TESTNAME): not supported on $(UNSUPPORTED)
+POSTRUN ?= echo
 
 all: $(TESTNAME)
 
@@ -69,6 +70,7 @@ run: $(TESTNAME)
 ifneq (,$(findstring $(GPU_W_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 	$(RUNENV) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND) 2>&1 | tee $@.log
+	$(POSTRUN) 2>&1 | tee -a $@.log
 else
 	@echo "  $(SKIP_RUN_UNSUPPORTED)" 2>&1 | tee $@.log
 endif
@@ -112,6 +114,7 @@ ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 	  flock -e 9 && echo  "" >> ../check-smoke.txt; \
 	  $(RUNENV) $(SMOKE_TIMEOUT) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND); \
 	  test_status=$$?; \
+	  $(POSTRUN); \
 	  echo "$$test_status" > TEST_STATUS; \
 	  echo $$base $$test_num return code: $$test_status >> ../check-smoke.txt; \
 	  echo  "" >> ../check-smoke.txt; \

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -10,7 +10,7 @@ SKIP_COMPILE_SUPPORTED   = Skipped compiling $(TESTNAME) for $(GPU_W_FEATURES) (
 SKIP_COMPILE_UNSUPPORTED = Skipped compiling $(TESTNAME): not supported on $(UNSUPPORTED)
 SKIP_RUN_SUPPORTED       = Skipped running $(TESTNAME) on $(GPU_W_FEATURES) (supported only on $(SUPPORTED))
 SKIP_RUN_UNSUPPORTED     = Skipped running $(TESTNAME): not supported on $(UNSUPPORTED)
-POSTRUN ?= echo
+POSTRUN ?= echo > /dev/null
 
 all: $(TESTNAME)
 

--- a/test/smoke/flang-tracekernel/Makefile
+++ b/test/smoke/flang-tracekernel/Makefile
@@ -16,8 +16,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 LIBPATH = $(AOMPHIP)/lib:/opt/rocm/lib
 RUNENV += PATH=$(ROCM)/bin:$(PATH) LD_LIBRARY_PATH=$(LIBPATH):$(LD_LIBRARY_PATH) LIBOMPTARGET_KERNEL_TRACE=2
-RUNPROF = rocprof --roctx-trace --sys-trace
+RUNPROF = $(AOMPHIP)/bin/rocprof
+RUNPROF_FLAGS = --roctx-trace --sys-trace
 
 include ../Makefile.rules
-run:
-	$(RUNENV) $(RUNPROF) ./$(TESTNAME)

--- a/test/smoke/launch_latency/Makefile
+++ b/test/smoke/launch_latency/Makefile
@@ -8,11 +8,12 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+RUNENV       = ulimit -s unlimited;
+RUNPROF      = $(AOMPHIP)/bin/rocprof
+RUNPROF_FLAGS = --stats
+POSTRUN = python3 printLatency.py
+
 #-ccc-print-phases
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	ulimit -s unlimited ; \
-	$(AOMP)/bin/rocprof --stats ./$(TESTNAME) > run.log 2>&1 ; \
-	python3 printLatency.py

--- a/test/smoke/vmulsum-hsa-stats/Makefile
+++ b/test/smoke/vmulsum-hsa-stats/Makefile
@@ -8,9 +8,11 @@ TESTSRC_ALL    = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG          ?= clang
 OMP_BIN        = $(AOMP)/bin/$(CLANG)
 CC             = $(OMP_BIN) $(VERBOSE)
+RUNPROF = $(AOMP)/bin/rocprof
+RUNPROF_FLAGS = --hsa-trace
+
 #-ccc-print-phases
 #"-\#\#\#"
 
 include ../Makefile.rules
-run:
-	$(AOMP)/bin/rocprof --hsa-trace ./$(TESTNAME)
+


### PR DESCRIPTION
Get rid of run target overrides in favor of
RUNPROF and RUNPROF_FLAGS.
Introduce POSTRUN variable that can run
scripts/commands after run has completed to avoid
'make check' not getting the proper return code from the executable.