### PR TITLE
[NFC] Refactor dynamic_module_load test

### DIFF
--- a/test/smoke-fails/dynamic_module_load/Makefile
+++ b/test/smoke-fails/dynamic_module_load/Makefile
@@ -1,25 +1,27 @@
 include ../../Makefile.defs
 
-TEST_SRC    := dynamic_module_load.c
-TEST_BIN    := dynamic_module_load
-TEST_SO     := dynamic_module_load.so
+TESTNAME      = dynamic_module_load
+TESTSRC_MAIN := dynamic_module_load.c
+TESTSRC_SO   := dynamic_module_load_shared.c
+TEST_SO      := dynamic_module_load.so
+TESTSRC_ALL  := $(TESTSRC_MAIN)
+ARGS         := ./$(TEST_SO)
 
 # We do not get double free detected in tcache 2 with clang-linker-wrapper
 # which is used with --no-opaque-offload-linker
-#FIXARG       := --no-opaque-offload-linker
-FIXARG       :=
+# FIXARG       := --no-opaque-offload-linker
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+CFLAGS       =
+OMP_FLAGS    =
+LINK_FLAGS   = -ldl
 
-run : $(TEST_BIN) 
-	./$(TEST_BIN) ./$(TEST_SO)
+include ../Makefile.rules
 
-$(TEST_BIN) : $(TEST_SRC) $(TEST_SO)
-	$(CC) $(TEST_SRC) -ldl -o $(TEST_BIN)
-$(TEST_SO) : $(TEST_SRC)
-	$(CC) -fopenmp $(TARGET) $(FIXARG) -DSHARED -fPIC -shared $(TEST_SRC) -o $(TEST_SO)
+# Indirectly add prerequisite TEST_SO to general TESTNAME recipe via TESTSRC_ALL
+$(TESTSRC_ALL) : $(TEST_SO)
 
-clean: 
-	rm -f $(TEST_SO) $(TEST_BIN)
+$(TEST_SO) : $(TESTSRC_SO)
+	$(CC) -fopenmp $(TARGET) $(FIXARG) -fPIC -shared $(TESTSRC_SO) -o $(TEST_SO)

--- a/test/smoke-fails/dynamic_module_load/dynamic_module_load.c
+++ b/test/smoke-fails/dynamic_module_load/dynamic_module_load.c
@@ -1,15 +1,6 @@
-// RUN: %libomptarget-compile-generic -DSHARED -fPIC -shared -o %t.so && %clang %flags %s -o %t -ldl && %libomptarget-run-generic %t.so 2>&1 | %fcheck-generic
-
-#ifdef SHARED
-#include <stdio.h>
-int foo() {
-#pragma omp target
-  ;
-  return 0;
-}
-#else
 #include <dlfcn.h>
 #include <stdio.h>
+
 int main(int argc, char **argv) {
 #pragma omp target
   ;
@@ -26,8 +17,9 @@ int main(int argc, char **argv) {
     printf("dlsym() failed: %s\n", dlerror());
     return 1;
   }
-  // CHECK: DONE.
-  // CHECK-NOT: {{abort|fault}}
+
   return Foo();
 }
-#endif
+
+// CHECK: DONE.
+// CHECK-NOT: {{abort|fault}}

--- a/test/smoke-fails/dynamic_module_load/dynamic_module_load_shared.c
+++ b/test/smoke-fails/dynamic_module_load/dynamic_module_load_shared.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int foo() {
+#pragma omp target
+  ;
+
+  return 0;
+}


### PR DESCRIPTION
Observed that this test did not provide a 'check' recipe
Due to that it did not execute correctly using `check_smoke_fails.sh`
(But at its core this should basically be a NFC.)