### PR TITLE
[offload][OMPT] Add device tracing ompTest suite

### DIFF
--- a/test/smoke-fails/omptest-testsuite-emi-tracing/Makefile
+++ b/test/smoke-fails/omptest-testsuite-emi-tracing/Makefile
@@ -1,0 +1,16 @@
+include ../../Makefile.defs
+
+TESTNAME     = omptest-testsuite-emi-tracing
+TESTSRC_MAIN = omptest_testsuite_emi_tracing.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+CLANG        ?= clang++
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+RUNENV       += OMPTEST_USE_OMPT_EMI=1
+RUNENV       += OMPTEST_USE_OMPT_TRACING=1
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
+RUNCMD       = ./$(TESTNAME)
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
+
+include ../Makefile.rules

--- a/test/smoke-fails/omptest-testsuite-emi-tracing/omptest_testsuite_emi_tracing.cpp
+++ b/test/smoke-fails/omptest-testsuite-emi-tracing/omptest_testsuite_emi_tracing.cpp
@@ -1,0 +1,233 @@
+#include "OmptTester.h"
+
+using namespace omptest;
+using namespace internal;
+
+TEST(DisabledSuite, DISABLED_uut_target_disabled) {
+  assert(false && "This test should have been disabled");
+}
+
+TEST(SequenceAssertion, uut_target_sequence) {
+  /* The Test Body */
+  int N = 128;
+  int a[N];
+
+  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::DeviceLoad)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete)
+
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_TARGET, /*Kind=*/TARGET,
+                       /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_DATAOP,
+                       /*OpType=*/ALLOC, /*Bytes=*/sizeof(a),
+                       /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_DATAOP,
+                       /*OpType=*/H2D, /*Bytes=*/sizeof(a),
+                       /*Timeframe=*/{10, 100000})
+
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_KERNEL)
+
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_DATAOP, /*OpType=*/D2H)
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_DATAOP, /*OpType=*/DELETE)
+  OMPT_ASSERT_SEQUENCE(BufferRecord, /*Type=*/CB_TARGET, /*Kind=*/TARGET,
+                       /*Endpoint=*/END)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+
+  OMPT_ASSERT_SYNC_POINT("C1")
+}
+
+TEST(SetAssertion, uut_target_set) {
+  /* The Test Body */
+  int N = 128;
+  int a[N];
+
+  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::DeviceLoad)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete)
+
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_TARGET, /*Kind=*/TARGET,
+                  /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_DATAOP,
+                  /*OpType=*/ALLOC, /*Bytes=*/sizeof(a),
+                  /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_DATAOP,
+                  /*OpType=*/H2D, /*Bytes=*/sizeof(a),
+                  /*Timeframe=*/{10, 100000})
+
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_KERNEL, /*MinimumTimeDelta=*/100)
+
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_DATAOP, /*OpType=*/D2H,
+                  /*Bytes=*/sizeof(a), /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_DATAOP, /*OpType=*/DELETE,
+                  /*Bytes=*/0, /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_TARGET, /*Kind=*/TARGET,
+                  /*Endpoint=*/END)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
+TEST(SetAssertion, uut_target_set_generic_duplicates) {
+  /* The Test Body */
+  int N = 128;
+  int a[N];
+
+  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::DeviceLoad)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete)
+
+  OMPT_GENERATE_EVENTS(2, OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_TARGET))
+  OMPT_GENERATE_EVENTS(4, OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_DATAOP))
+  OMPT_GENERATE_EVENTS(1, OMPT_ASSERT_SET(BufferRecord, /*Type=*/CB_KERNEL))
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
+TEST(MixedAssertionSuite, uut_target_sequence_and_set) {
+  /* The Test Body */
+  int N = 128;
+  int a[N];
+  int b[N];
+
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::DeviceLoad)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete)
+
+  // This will create / delete groups using sequential asserter
+  OMPT_ASSERT_SEQUENCE_GROUPED_ONLY("R1", TargetEmi, /*Kind=*/TARGET,
+                             /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SEQUENCE_GROUPED_ONLY("R1", TargetEmi, /*Kind=*/TARGET,
+                               /*Endpoint=*/END)
+
+  // Set asserter may also create all groups in parallel
+  OMPT_ASSERT_SET_GROUPED("R1", TargetEmi, /*Kind=*/TARGET,
+                          /*Endpoint=*/BEGIN)
+
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_TARGET,
+                          /*Kind=*/TARGET,
+                          /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/ALLOC, /*Bytes=*/sizeof(a),
+                          /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/H2D, /*Bytes=*/sizeof(a),
+                          /*Timeframe=*/{10, 100000})
+
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_KERNEL)
+
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/D2H)
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/DELETE)
+  OMPT_ASSERT_SET_GROUPED("R1", BufferRecord, /*Type=*/CB_TARGET,
+                          /*Kind=*/TARGET, /*Endpoint=*/END)
+
+  OMPT_ASSERT_SET_GROUPED("R1", TargetEmi, /*Kind=*/TARGET,
+                          /*Endpoint=*/END)
+
+  /* Actual testcase code. */
+
+  for (int i = 0; i < N; i++)
+    a[i] = 0;
+
+  for (int i = 0; i < N; i++)
+    b[i] = i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
+  }
+
+  // Ensure there are no remaining expected events
+  OMPT_ASSERT_SYNC_POINT("C1")
+
+  OMPT_ASSERT_SEQUENCE_GROUPED_ONLY("R2", TargetEmi, /*Kind=*/TARGET,
+                                    /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SEQUENCE_GROUPED_ONLY("R2", TargetEmi, /*Kind=*/TARGET,
+                                    /*Endpoint=*/END)
+
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_TARGET,
+                          /*Kind=*/TARGET,
+                          /*Endpoint=*/BEGIN)
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/ALLOC, /*Bytes=*/sizeof(a),
+                          /*MinimumTimeDelta=*/10)
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/H2D, /*Bytes=*/sizeof(a),
+                          /*Timeframe=*/{10, 100000})
+
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_KERNEL)
+
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/D2H)
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_DATAOP,
+                          /*OpType=*/DELETE)
+  OMPT_ASSERT_SET_GROUPED("R2", BufferRecord, /*Type=*/CB_TARGET,
+                          /*Kind=*/TARGET, /*Endpoint=*/END)
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
+  }
+
+  OMPT_ASSERT_SYNC_POINT("C2")
+
+  int rc = 0;
+  for (int i = 0; i < N; i++)
+    if (a[i] != b[i]) {
+      rc++;
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+}
+
+// Leave this suite down here so it gets discovered last and executed first.
+TEST(InitialTestSuite, uut_device_init_load) {
+  /* The Test Body */
+  int N = 128;
+  int a[N];
+
+  OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/0)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
+#ifndef LIBOFFLOAD_LIBOMPTEST_USE_GOOGLETEST
+int main(int argc, char **argv) {
+  Runner R;
+  R.run();
+
+  return 0;
+}
+#endif


### PR DESCRIPTION
Testsuite to showcase the current capabilities of the ompTest library.
 * Support for device tracing buffer records
 * Handling of event groups
 * Support for interleaved TestCase / Code
 * Support for Markers
   * Ensure that at a given moment all events have been processed
 * Deactivation of TestCases