### PR TITLE
Add patch file for GenASiS

### DIFF
--- a/bin/patches/genasis.patch
+++ b/bin/patches/genasis.patch
@@ -1,915 +1,281 @@
-diff -Naur -x .git GenASiS.orig/Build/Machines/Makefile_ROCm GenASiS.NOBUILD/Build/Machines/Makefile_ROCm
---- GenASiS.orig/Build/Machines/Makefile_ROCm	1969-12-31 18:00:00.000000000 -0600
-+++ GenASiS.NOBUILD/Build/Machines/Makefile_ROCm	2022-02-17 16:04:59.203999780 -0600
-@@ -0,0 +1,67 @@
-+# Makefile for GENASIS_MACHNE=ROCm
-+
-+AOMP                ?= /opt/rocm/llvm
-+FORTRAN_COMPILE      = $(AOMP)/bin/flang -c -D_use_includes=1 -I/opt/openmpi-4.0.3/include
-+
-+FORTRAN_FIXEDFORM    = -ffixed
-+FORTRAN_BOUND_CHECK  = #-R bcp #-- FIXME: bound checking may cause issue with OpenMP
-+FORTRAN_DEBUG        = -O2
-+FORTRAN_OPTIMIZE     = #-Oipa2 #-- Default optimization (O2) but with lower ipa
-+FORTRAN_PROFILE      = 
-+
-+CC_COMPILE           = $(AOMP)/bin/clang -c
-+CC_DEBUG             = -g
-+CC_OPTIMIZE          = $(FORTRAN_OPTIMIZE)
-+
-+LINK = $(AOMP)/bin/clang
-+
-+# Define default switches for this compiler. These can be overwritten at
-+# build time with, e.g., 'make ENABLE_OMP_OFFLOAD=0 <target>'
-+ENABLE_OMP          ?= 1
-+ENABLE_OMP_OFFLOAD  ?= 1
-+USE_ISO_10646       ?= 0
-+
-+ifneq ($(ENABLE_OMP), 0)
-+  FORTRAN_COMPILE += -I$(AOMP)/include -fopenmp
-+  CC_COMPILE += -I$(AOMP)/include -fopenmp
-+endif
-+
-+ifneq ($(ENABLE_OMP_OFFLOAD), 0)
-+  DEFINES         += -DENABLE_OMP_OFFLOAD
-+  GPU              = $(shell $(AOMP)/bin/offload-arch)
-+  TRIPLE           = $(shell $(AOMP)/bin/offload-arch -t | awk '{print $$2}')
-+  ifeq (sm_,$(findstring sm_,$(GPU)))
-+    DEVICE_CUDA    = 1
-+  endif
-+  FORTRAN_COMPILE += -fopenmp-targets=$(TRIPLE) -Xopenmp-target=$(TRIPLE) -march=$(GPU)
-+endif
-+
-+#-- Silo library may be  automatically included & linked by 
-+#-- "module load silo" if provided, otherwise, manually put include and 
-+#-- link line flag &  location below
-+SILO_DIR ?= /usr/local/silo/silo-4.10.2
-+INCLUDE_SILO = -I${SILO_DIR}/include
-+LIBRARY_SILO = -L${SILO_DIR}/lib -lsilo
-+
-+#-- HDF5 library may be  automatically included & linked by 
-+#-- "module load hdf5" if provided, otherwise, manually put include and 
-+#-- link line flag &  location below
-+HDF5_DIR ?= /usr/include/hdf5/serial
-+INCLUDE_HDF5 = -I$(HDF5_DIR)
-+LIBRARY_HDF5 = -L /usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_fortran -lhdf5
-+
-+#-- if empty, don't link to HDF5
-+ifeq ($(strip $(HDF5_DIR)),)  
-+  INCLUDE_HDF5 = 
-+  LIBRARY_HDF5 = 
-+endif
-+
-+INCLUDE_PREPROCESSOR = -I$(PATH_GENASIS)/Build
-+
-+DEVICE_HIP     = 1
-+DEVICE_COMPILE = $(AOMP)/bin/hipcc -c -D__HIP_PLATFORM_HCC__
-+INCLUDE_DEVICE = -I$(AOMP)/include
-+LIBRARY_DEVICE = -L$(AOMP)}/lib -lamdhip64
-+DEFINES       += -D__HIP_PLATFORM_HCC__
-+
-+DEFINES += -D$(GENASIS_MACHINE)
-diff -Naur -x .git GenASiS.orig/Modules/Basics/Display/Show_Command.f90 GenASiS.NOBUILD/Modules/Basics/Display/Show_Command.f90
---- GenASiS.orig/Modules/Basics/Display/Show_Command.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/Display/Show_Command.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -15,7 +15,7 @@
-     ShowCharacter_KBCH
+diff --git a/Build/Preprocessor b/Build/Preprocessor
+index 5a66aa14..0a11c950 100644
+--- a/Build/Preprocessor
++++ b/Build/Preprocessor
+@@ -1,3 +1,4 @@
++#define ENABLE_OMP_OFFLOAD 1
+ #ifdef ENABLE_OMP_OFFLOAD
+ #define OMP_TARGET_DIRECTIVE target teams distribute
+ #define OMP_SCHEDULE_TARGET static, 1
+diff --git a/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90 b/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90
+index eba18541..6d430130 100644
+--- a/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90
++++ b/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90
+@@ -49,9 +49,9 @@ contains
+     integer ( KDI ), dimension ( : ), intent ( out ) :: &
+       A
  
-   interface Show
--    module procedure ShowInteger
-+    module procedure ShowInteger_0D
-     module procedure ShowInteger_1D
-     module procedure ShowInteger_2D
-     module procedure ShowBigInteger
-@@ -36,7 +36,7 @@
-     module procedure ShowComplex_3D
-     module procedure ShowLogical
-     module procedure ShowLogical_1D
--    module procedure ShowCharacter
-+    module procedure ShowCharacter_0D
- !    module procedure ShowCharacter_KBCH
-     module procedure ShowCharacterNoDescription
-     module procedure ShowCharacter_1D
-@@ -55,7 +55,7 @@
- contains
+-    !$OMP parallel workshare
++!    !$OMP parallel workshare
+     A = 0_KDI
+-    !$OMP end parallel workshare
++!    !$OMP end parallel workshare
  
+   end subroutine ClearInteger_1D
  
--  subroutine ShowInteger &
-+  subroutine ShowInteger_0D  &
-                ( Integer, Description, IgnorabilityOption, &
-                  DisplayRankOption, nLeadingLinesOption, &
-                  nTrailingLinesOption )
-@@ -86,7 +86,7 @@
+@@ -61,9 +61,9 @@ contains
+     integer ( KDI ), dimension ( :, : ), intent ( out ) :: &
+       A
  
-     call EndShow ( nTrailingLinesOption )
+-    !$OMP parallel workshare
++!    !$OMP parallel workshare
+     A = 0_KDI
+-    !$OMP end parallel workshare
++!    !$OMP end parallel workshare
  
--  end subroutine ShowInteger
-+  end subroutine ShowInteger_0D
+   end subroutine ClearInteger_2D
  
+@@ -73,9 +73,9 @@ contains
+     integer ( KDI ), dimension ( :, :, : ), intent ( out ) :: &
+       A
  
-   subroutine ShowInteger_1D &
-@@ -954,7 +954,7 @@
-   end subroutine ShowLogical_1D
+-    !$OMP parallel workshare
++!    !$OMP parallel workshare
+     A = 0_KDI
+-    !$OMP end parallel workshare
++!    !$OMP end parallel workshare
  
+   end subroutine ClearInteger_3D
  
--  subroutine ShowCharacter &
-+  subroutine ShowCharacter_0D &
-                ( Character, Description, IgnorabilityOption, &
-                  DisplayRankOption, nLeadingLinesOption, &
-                  nTrailingLinesOption )
-@@ -981,7 +981,7 @@
+diff --git a/Modules/Basics/DataManagement/ArrayOperations/Copy_Command.f90 b/Modules/Basics/DataManagement/ArrayOperations/Copy_Command.f90
+index e2f7ae74..0ea9ace6 100644
+--- a/Modules/Basics/DataManagement/ArrayOperations/Copy_Command.f90
++++ b/Modules/Basics/DataManagement/ArrayOperations/Copy_Command.f90
+@@ -63,9 +63,9 @@ contains
+     integer ( KDI ), dimension ( : ), intent ( out ) :: &
+       B
  
-     call EndShow ( nTrailingLinesOption )
+-    !$OMP parallel workshare
++!    !$OMP parallel workshare
+     B = A
+-    !$OMP end parallel workshare
++!    !$OMP end parallel workshare
  
--  end subroutine ShowCharacter
-+  end subroutine ShowCharacter_0D
+   end subroutine CopyInteger_1D
    
+@@ -183,9 +183,9 @@ contains
+     integer ( KBI ), dimension ( : ), intent ( out ) :: &
+       B
+ 
+-    !$OMP parallel workshare
++!    !$OMP parallel workshare
+     B = A
+-    !$OMP end parallel workshare
++!    !$OMP end parallel workshare
+ 
+   end subroutine CopyBigInteger_1D
    
-   subroutine ShowCharacter_KBCH &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_BI__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -1,14 +1,19 @@
- module CollectiveOperation_BI__Form
+diff --git a/Modules/Basics/Devices/DeviceAddress_Function.f90 b/Modules/Basics/Devices/DeviceAddress_Function.f90
+index 5ceafe62..a4c7d39f 100644
+--- a/Modules/Basics/Devices/DeviceAddress_Function.f90
++++ b/Modules/Basics/Devices/DeviceAddress_Function.f90
+@@ -27,7 +27,6 @@ contains
  
--  use MPI
-   use Specifiers
-   use DataManagement
-   use Display
-   use MessagePassingBasics
-   use PointToPoint
-   use CollectiveOperation_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
+     type ( c_ptr ) :: &
+       DA
+-      
+     if ( OnDevice ( Value ) ) then
+ #ifdef ENABLE_OMP_OFFLOAD
+       !$OMP target data use_device_ptr ( Value )
+diff --git a/Modules/Basics/Devices/Device_C_OMP.f90 b/Modules/Basics/Devices/Device_C_OMP.f90
+index 3e3fa4fb..57a2a8b9 100644
+--- a/Modules/Basics/Devices/Device_C_OMP.f90
++++ b/Modules/Basics/Devices/Device_C_OMP.f90
+@@ -25,7 +25,7 @@ module Device_C
+   interface 
+     
+     integer ( c_int ) function SetDevice ( iDevice ) &
+-                                 bind ( c, name = 'SetDevice' )
++                                 bind ( c, name = 'SetDevice_OMP' )
+       use iso_c_binding
+       implicit none
+       integer ( c_int ), value :: &
+@@ -34,7 +34,7 @@ module Device_C
+     
+ 
+     integer ( c_int ) function GetDevice ( iDevice ) &
+-                                 bind ( c, name = 'GetDevice' )
++                                 bind ( c, name = 'GetDevice_OMP' )
+       use iso_c_binding
+       implicit none
+       integer ( c_int ) :: &
+@@ -119,7 +119,7 @@ module Device_C
+     
+     
+     type ( c_ptr ) function AllocateHostDouble ( nValues ) &
+-                              bind ( c, name = 'AllocateHostDouble_Device' )
++                              bind ( c, name = 'AllocateHostDouble_Device_OMP' )
+       use iso_c_binding
+       implicit none
+       integer ( c_int ), value :: &
+@@ -127,7 +127,7 @@ module Device_C
+     end function AllocateHostDouble
+     
+     
+-    subroutine FreeHost ( Host ) bind ( c, name = 'FreeHost_Device' )
++    subroutine FreeHost ( Host ) bind ( c, name = 'FreeHost_Device_OMP' )
+       use iso_c_binding
+       implicit none
+       type ( c_ptr ), value :: &
+@@ -176,7 +176,7 @@ module Device_C
+     
+     
+     integer ( c_int ) function DeviceMemGetInfo ( Free, Total ) &
+-                        bind ( c, name = 'DeviceMemGetInfo_Device' )
++                        bind ( c, name = 'DeviceMemGetInfo_Device_OMP' )
+       use iso_c_binding
+       implicit none
+       integer ( c_size_t ) :: &
+diff --git a/Modules/Basics/Devices/Device_OMP.c b/Modules/Basics/Devices/Device_OMP.c
+index abccbb8d..810753de 100644
+--- a/Modules/Basics/Devices/Device_OMP.c
++++ b/Modules/Basics/Devices/Device_OMP.c
+@@ -3,6 +3,13 @@
+ #include <stdbool.h>
+ #include <omp.h>
+ 
++#ifdef USE_LLVM_RUNTIME
++void llvm_omp_target_free_host(void *DevicePtr, int DeviceNum);
++void llvm_omp_target_free_device(void *DevicePtr, int DeviceNum);
++void *llvm_omp_target_alloc_host(size_t Size, int DeviceNum);
++void *llvm_omp_target_alloc_device(size_t Size, int DeviceNum);
 +#endif
 +
-   private
- 
-   type, public, extends ( CollectiveOperationTemplate ) :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_C__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,15 +4,20 @@
- 
- module CollectiveOperation_C__Form
- 
--  use MPI
-   use Specifiers
-   use DataManagement
-   use Display
-   use MessagePassingBasics
-   use PointToPoint
-   use CollectiveOperation_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( CollectiveOperationTemplate ) :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_I__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,15 +4,20 @@
- 
- module CollectiveOperation_I__Form
- 
--  use MPI
-   use Specifiers
-   use DataManagement
-   use Display
-   use MessagePassingBasics
-   use PointToPoint
-   use CollectiveOperation_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( CollectiveOperationTemplate ) :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_R__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_R__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,7 +4,6 @@
- 
- module CollectiveOperation_R__Form
- 
--  use MPI
-   use iso_c_binding
-   use Specifiers
-   use DataManagement
-@@ -12,8 +11,14 @@
-   use MessagePassingBasics
-   use PointToPoint
-   use CollectiveOperation_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( CollectiveOperationTemplate ) :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_Template.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_Template.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/CollectiveOperation_Template.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/CollectiveOperation_Template.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,11 +4,16 @@
- 
- module CollectiveOperation_Template
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   integer ( KDI ), public, parameter :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/Collective/REDUCTION_Singleton.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/REDUCTION_Singleton.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/Collective/REDUCTION_Singleton.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/Collective/REDUCTION_Singleton.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,10 +3,15 @@
- 
- module REDUCTION_Singleton
- 
--  use MPI
-   use Specifiers
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
-   
-   type, public :: ReductionSingleton
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/MessagePassingBasics/Communicator_Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/MessagePassingBasics/Communicator_Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/MessagePassingBasics/Communicator_Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/MessagePassingBasics/Communicator_Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module Communicator_Form
-   
--  use MPI
-   use Specifiers
-   use Display
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public :: CommunicatorForm
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_1D__Template.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_1D__Template.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_1D__Template.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_1D__Template.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,12 +4,17 @@
- 
- module Message_1D__Template
- 
--  use MPI
-   use Specifiers
-   use Devices
-   use Message_Template
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, abstract :: Message_1D_Template
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_BI__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,12 +3,17 @@
- 
- module Message_BI__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( MessageTemplate ) :: Message_BI_Form 
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_C__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,12 +3,17 @@
- 
- module Message_C__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( MessageTemplate ) :: Message_C_Form 
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_I__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,12 +3,17 @@
- 
- module Message_I__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( MessageTemplate ) :: Message_I_Form 
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_BI__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageIncoming_1D_BI__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageIncoming_BI__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageIncoming_1D_BI_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_C__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageIncoming_1D_C__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageIncoming_C__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageIncoming_1D_C_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_I__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageIncoming_1D_I__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageIncoming_I__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageIncoming_1D_I_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_R__Form.f90	2022-02-17 15:23:33.627999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_1D_R__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageIncoming_1D_R__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageIncoming_R__Form
-   use Message_1D__Template 
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageIncoming_1D_R_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_BI__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageIncoming_BI__Form
- 
--  use MPI
-   use Specifiers
-   use Message_BI__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_BI_Form ) :: MessageIncoming_BI_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_C__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageIncoming_C__Form
- 
--  use MPI
-   use Specifiers
-   use Message_C__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_C_Form ) :: MessageIncoming_C_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_I__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageIncoming_I__Form
- 
--  use MPI
-   use Specifiers
-   use Message_I__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_I_Form ) :: MessageIncoming_I_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_R__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageIncoming_R__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,11 +4,16 @@
- module MessageIncoming_R__Form
- 
-   use iso_c_binding
--  use MPI
-   use Specifiers
-   use Message_R__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_R_Form ) :: MessageIncoming_R_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_BI__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageOutgoing_1D_BI__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageOutgoing_BI__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageOutgoing_1D_BI_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_C__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageOutgoing_1D_C__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageOutgoing_C__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_I__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageOutgoing_1D_I__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageOutgoing_I__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageOutgoing_1D_I_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_R__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_1D_R__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,14 +4,19 @@
- 
- module MessageOutgoing_1D_R__Form
- 
--  use MPI
-   use Specifiers
-   use MessagePassingBasics
-   use Message_Template
-   use MessageOutgoing_R__Form
-   use Message_1D__Template 
-- 
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+ 
-   private
- 
-   type, public, extends ( Message_1D_Template ) :: MessageOutgoing_1D_R_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_BI__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_BI__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_BI__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_BI__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageOutgoing_BI__Form
- 
--  use MPI
-   use Specifiers
-   use Message_BI__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_BI_Form ) :: MessageOutgoing_BI_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_C__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_C__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_C__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_C__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageOutgoing_C__Form
- 
--  use MPI
-   use Specifiers
-   use Message_C__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_C_Form ) :: MessageOutgoing_C_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_I__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_I__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_I__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_I__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -3,11 +3,16 @@
- 
- module MessageOutgoing_I__Form
- 
--  use MPI
-   use Specifiers
-   use Message_I__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_I_Form ) :: MessageOutgoing_I_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_R__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/MessageOutgoing_R__Form.f90	2022-02-17 15:30:33.967999465 -0600
-@@ -4,11 +4,16 @@
- module MessageOutgoing_R__Form
- 
-   use iso_c_binding
--  use MPI
-   use Specifiers
-   use Message_R__Form
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( Message_R_Form ) :: MessageOutgoing_R_Form
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_R__Form.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_R__Form.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_R__Form.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_R__Form.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -4,13 +4,18 @@
- module Message_R__Form
- 
-   use iso_c_binding
--  use MPI
-   use Specifiers
-   use Devices
-   use MessagePassingBasics
-   use Message_Template
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, extends ( MessageTemplate ) :: Message_R_Form 
-diff -Naur -x .git GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_Template.f90 GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_Template.f90
---- GenASiS.orig/Modules/Basics/MessagePassing/PointToPoint/Message_Template.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/MessagePassing/PointToPoint/Message_Template.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -4,12 +4,17 @@
- module Message_Template
- 
-   use iso_c_binding
--  use MPI
-   use Specifiers
-   use Devices
-   use MessagePassingBasics
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
- 
-   type, public, abstract :: MessageTemplate
-diff -Naur -x .git GenASiS.orig/Modules/Basics/Runtime/GetMemoryUsage_Command.f90 GenASiS.NOBUILD/Modules/Basics/Runtime/GetMemoryUsage_Command.f90
---- GenASiS.orig/Modules/Basics/Runtime/GetMemoryUsage_Command.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/Runtime/GetMemoryUsage_Command.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -3,13 +3,18 @@
- 
- module GetMemoryUsage_Command
-   
--  use MPI
-   use Specifiers
-   use DataManagement
-   use Display
-   use MessagePassing
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
-   
-   public :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/Runtime/WallTime_Function.f90 GenASiS.NOBUILD/Modules/Basics/Runtime/WallTime_Function.f90
---- GenASiS.orig/Modules/Basics/Runtime/WallTime_Function.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/Runtime/WallTime_Function.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -3,10 +3,15 @@
- 
- module WallTime_Function
-   
--  use MPI
-   use Specifiers
--
-+#ifdef _use_includes
-   implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-+  implicit none
-+#endif
-+
-   private
-   
-   public :: &
-diff -Naur -x .git GenASiS.orig/Modules/Basics/Specifiers/UNIT_Singleton.f90 GenASiS.NOBUILD/Modules/Basics/Specifiers/UNIT_Singleton.f90
---- GenASiS.orig/Modules/Basics/Specifiers/UNIT_Singleton.f90	2022-02-17 15:23:33.631999551 -0600
-+++ GenASiS.NOBUILD/Modules/Basics/Specifiers/UNIT_Singleton.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -99,8 +99,7 @@
-       MeV_Minus_1 = 'MeV^-1'
-     character ( 5, KBCH ) :: &
-       MeV_Minus_1_KBCH &
--        = KBCH_'MeV' // char ( KB % SUPERSCRIPT_MINUS, KBCH ) &
--                     // char ( KB % SUPERSCRIPT_1, KBCH )
-+        = KBCH_'MeV' // '?' // '?'
- 
- contains
- 
-diff -Naur -x .git GenASiS.orig/Programs/Examples/Basics/GPU_MPI_Direct/GPU_AllToAll.f90 GenASiS.NOBUILD/Programs/Examples/Basics/GPU_MPI_Direct/GPU_AllToAll.f90
---- GenASiS.orig/Programs/Examples/Basics/GPU_MPI_Direct/GPU_AllToAll.f90	2022-02-17 15:23:33.647999551 -0600
-+++ GenASiS.NOBUILD/Programs/Examples/Basics/GPU_MPI_Direct/GPU_AllToAll.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -4,10 +4,14 @@
-   !   FIXME: Only works with CCE so far
-   !   RUNNING: export MPICH_RDMA_ENABLED_CUDA=1, use 1 MPI per device (node)
- 
--  use MPI
-   use Basics
+ int OnTarget_OMP ( void * Host )
+   {
+   int iDevice;
+@@ -28,9 +35,13 @@ void * AllocateTargetInteger_OMP ( int nValues )
+   /*
+   printf("nValues Alloc: %d\n", nValues );
+   printf("iDevice: %d\n", iDevice );
+-  */ 
++  */
++  #ifdef USE_LLVM_RUNTIME
++  D_Pointer = llvm_omp_target_alloc_device ( sizeof ( int ) * nValues, iDevice );
++  #else
+   D_Pointer = omp_target_alloc ( sizeof ( int ) * nValues, iDevice );
 -  
-+#ifdef _use_includes
-+  implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-   implicit none
-+#endif
++  #endif
++
+   // printf("D_Pointer : %p\n", D_Pointer);
+   #endif 
    
-   integer ( KDI ) :: &
-     iV
-diff -Naur -x .git GenASiS.orig/Programs/UnitTests/Basics/MessagePassing/PointToPoint/MessageIncomingOutgoing_Forms_Test.f90 GenASiS.NOBUILD/Programs/UnitTests/Basics/MessagePassing/PointToPoint/MessageIncomingOutgoing_Forms_Test.f90
---- GenASiS.orig/Programs/UnitTests/Basics/MessagePassing/PointToPoint/MessageIncomingOutgoing_Forms_Test.f90	2022-02-17 15:23:33.663999551 -0600
-+++ GenASiS.NOBUILD/Programs/UnitTests/Basics/MessagePassing/PointToPoint/MessageIncomingOutgoing_Forms_Test.f90	2022-02-17 15:30:33.971999465 -0600
-@@ -1,6 +1,5 @@
- program MessageIncomingOutgoing_Forms_Test
+@@ -53,8 +64,12 @@ void * AllocateTargetDouble_OMP ( int nValues )
+   printf("nValues Alloc: %d\n", nValues );
+   printf("pre iDevice: %d\n", iDevice );
+   */ 
++  #ifdef USE_LLVM_RUNTIME
++  D_Pointer = llvm_omp_target_alloc_device ( sizeof ( double ) * nValues, iDevice );
++  #else
+   D_Pointer = omp_target_alloc ( sizeof ( double ) * nValues, iDevice );
+-  
++  #endif
++
+   //printf("D_Pointer : %p\n", D_Pointer);
+   
+   //omp_set_default_device(iDevice);
+@@ -141,7 +156,11 @@ void FreeTarget_OMP ( void * D_Pointer )
+   
+   #ifdef ENABLE_OMP_OFFLOAD
+   iDevice = omp_get_default_device();
++  #ifdef USE_LLVM_RUNTIME
++  llvm_omp_target_free_device ( D_Pointer, iDevice );
++  #else
+   omp_target_free ( D_Pointer, iDevice );
++  #endif
+   #endif 
+   
+   }
+@@ -220,3 +239,60 @@ bool OffloadEnabled ( )
+   return false;
+   #endif
+   }
++
++int SetDevice_OMP ( int iDevice )
++  {
++  #ifdef ENABLE_OMP_OFFLOAD
++  omp_set_default_device(iDevice);
++  return 0;
++  #else
++  return -1;
++  #endif
++  }
++
++
++int GetDevice_OMP ( int * iDevice )
++  {
++  #ifdef ENABLE_OMP_OFFLOAD
++  *iDevice = omp_get_default_device();
++  return 0;
++  #else
++  return -1;
++  #endif
++  }
++
++void * AllocateHostDouble_Device_OMP ( int nValues )
++  {
++  void * Host;
++
++  #ifdef ENABLE_OMP_OFFLOAD
++  #ifdef USE_LLVM_RUNTIME
++  Host = llvm_omp_target_alloc_host(sizeof ( double ) * nValues, omp_get_initial_device());
++  #else
++  Host = omp_target_alloc( sizeof ( double ) * nValues, omp_get_initial_device());
++  #endif
++  #else
++  Host = malloc ( sizeof ( double ) * nValues );
++  #endif
++  return Host;
++  }
++
++void FreeHost_Device_OMP ( void * Host )
++  {
++  #ifdef ENABLE_OMP_OFFLOAD
++  #ifdef USE_LLVM_RUNTIME
++  llvm_omp_target_free_host(Host, omp_get_initial_device());
++  #else
++  omp_target_free(Host, omp_get_initial_device());
++  #endif
++  #else
++  free ( Host );
++  #endif
++  }
++
++int DeviceMemGetInfo_Device_OMP ( size_t * Free, size_t * Total )
++  {
++  Free  = 0;
++  Total = 0;
++  return -1;
++  }
+diff --git a/Modules/Basics/Display/CONSOLE_Singleton.f90 b/Modules/Basics/Display/CONSOLE_Singleton.f90
+index 2f8cd18a..aa5b4ac0 100644
+--- a/Modules/Basics/Display/CONSOLE_Singleton.f90
++++ b/Modules/Basics/Display/CONSOLE_Singleton.f90
+@@ -18,7 +18,7 @@ module CONSOLE_Singleton
+     logical ( KDL ) :: &
+       Muted = .false.
+     procedure ( AbortInterface ), nopass, pointer :: &
+-      Abort => null ( )
++      Abort
+   contains
+     procedure, public, nopass :: &
+       Initialize
+@@ -180,7 +180,7 @@ contains
+   end subroutine Unmute
+   
  
--  use MPI
-   use Specifiers
-   use Display
-   use Devices
-@@ -13,8 +12,13 @@
-   use MessageOutgoing_BI__Form
-   use MessageOutgoing_R__Form
-   use MessageOutgoing_C__Form
--
-+#ifdef _use_includes
-+  implicit none
-+  include "mpif.h"
-+#else
-+  use MPI
-   implicit none
-+#endif
+-  elemental subroutine Finalize ( C )
++  impure elemental subroutine Finalize ( C )
  
-   integer ( KDI ), parameter :: &
-     nReceive = 8, &
+     type ( ConsoleSingleton ), intent ( inout ) :: &
+       C

--- a/bin/run_genasis_flang_new.sh
+++ b/bin/run_genasis_flang_new.sh
@@ -33,6 +33,8 @@ fi
 # Copy Makefile_ROCm to GenASis repository
 cp Makefile_ROCmFlangNew $REPO_DIR/Build/Machines/
 
+patchrepo $AOMP_REPOS_TEST/GenASis
+
 cd $REPO_DIR
 
 AOMP_SUPP=${AOMP_SUPP:-$HOME/local}


### PR DESCRIPTION
Patch GenASiS benchmark so that it can be compiled by flang-new.

Scope of the patch:

1. Fix for procedure pointer component default initialization (missed language feature) (file: Modules/Basics/Display/CONSOLE_Singleton.f90)
2.  Fix for omp parallel workshare pragma (files: Modules/Basics/DataManagement/ArrayOperations/Copy_Command.f90 and Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90 )
3. Fix for preprocessor issue - add #define ENABLE_OMP_OFFLOAD 1 (file: Build/Preprocessor)
4.  Fix for OpenMP device memory allocation (files: Modules/Basics/Devices/Device_C_OMP.f90 and Modules/Basics/Devices/Device_OMP.c )