### PR TITLE
Fix run command of clang-293471 as the expected file was not created

### DIFF
--- a/test/smoke-fails/clang-aa-293471/Makefile
+++ b/test/smoke-fails/clang-aa-293471/Makefile
@@ -5,13 +5,11 @@ TESTSRC_MAIN = clang-293471.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-OMP_FLAGS = -fnt-store=aggressive -O3 -march=znver2 -S
+OMP_FLAGS    = -fnt-store=aggressive -O3 -march=znver2 -S
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-#-ccc-print-phases
-#"-\#\#\#"
+
+RUNCMD       = cat clang-293471
 
 include ../Makefile.rules
-run:
-	cat clang-293471.s

--- a/test/smoke-fails/clang-aa-293471/clang-293471.c
+++ b/test/smoke-fails/clang-aa-293471/clang-293471.c
@@ -1,8 +1,6 @@
-int fun(int *src, int N)
-{
+int fun(int *src, int N) {
+  for (int i = 0; i < N; i++)
+    src[i] = 1234.0;
 
-for (int i = 0; i < N; i++)
-            src[i] = 1234.0;
+  return 0;
 }
-
-


### PR DESCRIPTION
Expected file 'clang-293471.s' was never created but without .s extension
Replaced run recipe by RUNCMD definition