### PR TITLE
[offload][OMPT] Fix ompTest-based tests after device tracing

### DIFF
--- a/test/smoke-fails/omptest-testsuite-emi/Makefile
+++ b/test/smoke-fails/omptest-testsuite-emi/Makefile
@@ -11,7 +11,5 @@ RUNENV       += OMPTEST_USE_OMPT_EMI=1
 RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 RUNCMD       = ./$(TESTNAME)
 CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
-#-ccc-print-phases
-#"-\#\#\#"
 
 include ../Makefile.rules

--- a/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
+++ b/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
@@ -210,142 +210,142 @@ TEST(SequenceSuite, veccopy_ompt_target) {
 
   /* First Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetEmi, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetEmi, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetSubmitEmi, /*RequestedNumTeams=*/1,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetSubmitEmi, /*RequestedNumTeams=*/1,
                                /*Endpoint=*/BEGIN)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetSubmitEmi, /*RequestedNumTeams=*/1,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetSubmitEmi, /*RequestedNumTeams=*/1,
                                /*Endpoint=*/END)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/BEGIN, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/END, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/BEGIN, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/END, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetEmi, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetEmi, /*Kind=*/TARGET,
                                /*Endpoint=*/END, /*DeviceNum=*/0)
 
   /* Second Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetEmi, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetEmi, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/ALLOC,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int))
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/H2D,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetSubmitEmi, /*RequestedNumTeams=*/0,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetSubmitEmi, /*RequestedNumTeams=*/0,
                                /*Endpoint=*/BEGIN)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetSubmitEmi, /*RequestedNumTeams=*/0,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetSubmitEmi, /*RequestedNumTeams=*/0,
                                /*Endpoint=*/END)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/BEGIN, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/D2H,
                                /*Endpoint=*/END, /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/BEGIN, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/END, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/BEGIN, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOpEmi, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOpEmi, /*OpType=*/DELETE,
                                /*Endpoint=*/END, /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetEmi, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetEmi, /*Kind=*/TARGET,
                                /*Endpoint=*/END, /*DeviceNum=*/0)
 
   /* Actual testcase code. */

--- a/test/smoke-fails/omptest-testsuite/Makefile
+++ b/test/smoke-fails/omptest-testsuite/Makefile
@@ -9,7 +9,5 @@ CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
-#-ccc-print-phases
-#"-\#\#\#"
 
 include ../Makefile.rules

--- a/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
+++ b/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
@@ -119,70 +119,70 @@ TEST(SequenceSuite, veccopy_ompt_target) {
 
   /* First Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", Target, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", Target, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetSubmit, /*RequestedNumTeams=*/1)
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetSubmit, /*RequestedNumTeams=*/1)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
                                /*DeviceNum=*/0)
 
   /* Second Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", Target, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", Target, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetSubmit, /*RequestedNumTeams=*/0)
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetSubmit, /*RequestedNumTeams=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
                                /*DeviceNum=*/0)
 
   /* Actual testcase code. */

--- a/test/smoke-fails/omptest-unittest/Makefile
+++ b/test/smoke-fails/omptest-unittest/Makefile
@@ -9,7 +9,5 @@ CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
 CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
-#-ccc-print-phases
-#"-\#\#\#"
 
 include ../Makefile.rules

--- a/test/smoke-fails/omptest-unittest/omptest.cpp
+++ b/test/smoke-fails/omptest-unittest/omptest.cpp
@@ -5,34 +5,49 @@
 TEST(ManualSuite, ParallelFor) {
   /* The Test Body */
   int arr[10] = {0};
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
+      "User Parallel Begin", "Group", omptest::ObserveState::always,
       /*NumThreads=*/2));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ThreadBegin(
-      "User Thread Begin", "Group", omptest::ObserveState::always, ompt_thread_initial));
-  SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ThreadBegin(
+      "User Thread Begin", "Group", omptest::ObserveState::always,
+      ompt_thread_initial));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
+      "User Parallel End", "Group", omptest::ObserveState::always));
 
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelEnd("User Parallel End 2", "Group", omptest::ObserveState::always));
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelBegin);
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelEnd);
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ThreadBegin);
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ThreadEnd);
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
+
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ParallelBegin);
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ParallelEnd);
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ThreadBegin);
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ThreadEnd);
 }
 
 TEST(ManualSuite, ParallelForActivation) {
   /* The Test Body */
   int arr[10] = {0};
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
+      "User Parallel Begin", "Group", omptest::ObserveState::always,
       /*NumThreads=*/2));
-  SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
+      "User Parallel End", "Group", omptest::ObserveState::always));
 
   // The last sequence we want to observe does not contain
   // another thread begin.
-  SequenceAsserter.insert(omptest::OmptAssertEvent::ParallelBegin("User Parallel Begin", "Group", omptest::ObserveState::always,
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
+      "User Parallel Begin", "Group", omptest::ObserveState::always,
       /*NumThreads=*/2));
-  SequenceAsserter.insert(
-      omptest::OmptAssertEvent::ParallelEnd("User Parallel End", "Group", omptest::ObserveState::always));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
+      "User Parallel End", "Group", omptest::ObserveState::always));
+
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelBegin);
+  SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelEnd);
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
@@ -49,6 +64,9 @@ TEST(ManualSuite, ParallelForActivation) {
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
+
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ParallelBegin);
+  SequenceAsserter->suppressEvent(omptest::internal::EventTy::ParallelEnd);
 }
 
 TEST(ManualSuite, AnotherTest) {
@@ -68,10 +86,10 @@ TEST(ManualSuite, ParallelForToString) {
 
   OMPT_REPORT_EVENT_DISABLE();
 
-  EventReporter.permitEvent(omptest::internal::EventTy::ParallelBegin);
-  EventReporter.permitEvent(omptest::internal::EventTy::ParallelEnd);
-  EventReporter.permitEvent(omptest::internal::EventTy::ThreadBegin);
-  EventReporter.permitEvent(omptest::internal::EventTy::ThreadEnd);
+  EventReporter->permitEvent(omptest::internal::EventTy::ParallelBegin);
+  EventReporter->permitEvent(omptest::internal::EventTy::ParallelEnd);
+  EventReporter->permitEvent(omptest::internal::EventTy::ThreadBegin);
+  EventReporter->permitEvent(omptest::internal::EventTy::ThreadEnd);
 
 #pragma omp parallel for num_threads(2)
   for (int i = 0; i < 10; ++i)
@@ -91,10 +109,10 @@ TEST(ManualSuite, ParallelForToString) {
   for (int i = 0; i < 10; ++i)
     arr[i] = i;
 
-  EventReporter.suppressEvent(omptest::internal::EventTy::ParallelBegin);
-  EventReporter.suppressEvent(omptest::internal::EventTy::ParallelEnd);
-  EventReporter.suppressEvent(omptest::internal::EventTy::ThreadBegin);
-  EventReporter.suppressEvent(omptest::internal::EventTy::ThreadEnd);
+  EventReporter->suppressEvent(omptest::internal::EventTy::ParallelBegin);
+  EventReporter->suppressEvent(omptest::internal::EventTy::ParallelEnd);
+  EventReporter->suppressEvent(omptest::internal::EventTy::ThreadBegin);
+  EventReporter->suppressEvent(omptest::internal::EventTy::ThreadEnd);
 
   OMPT_ASSERT_SEQUENCE_ENABLE();
 }

--- a/test/smoke-fails/veccopy-ompTest/Makefile
+++ b/test/smoke-fails/veccopy-ompTest/Makefile
@@ -1,14 +1,13 @@
 include ../../Makefile.defs
 
-TESTNAME     = veccopy
+TESTNAME     = veccopy-ompTest
 TESTSRC_MAIN = veccopy.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
-CC           = $(OMP_BIN) $(VERBOSE) -I$(AOMP_REPOS)/llvm-project/openmp/libomptarget/test/ompTest/include -L$(AOMP_REPOS)/build/openmp/libomptarget -lomptest
-#-ccc-print-phases
-#"-\#\#\#"
+RUNENV       += OMPTEST_RUN_AS_TESTSUITE=1
+CC           = $(OMP_BIN) $(VERBOSE) $(OMPTEST)
 
 include ../Makefile.rules

--- a/test/smoke-fails/veccopy-ompTest/veccopy.cpp
+++ b/test/smoke-fails/veccopy-ompTest/veccopy.cpp
@@ -2,7 +2,7 @@
 
 #include "OmptTester.h"
 
-OMPTTESTCASE(InitialSuite, veccopy) {
+TEST(InitialSuite, veccopy) {
   int N = 10;
 
   int a[N];
@@ -16,16 +16,47 @@ OMPTTESTCASE(InitialSuite, veccopy) {
   for (i=0; i<N; i++)
     b[i]=i;
 
-  
-  SequenceAsserter.insert(omptest::OmptAssertEvent::Target("User Target"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetSubmit("User Target Submit"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
-  SequenceAsserter.insert(omptest::OmptAssertEvent::TargetDataOp("User Target DataOp"));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::DeviceLoad(
+      "User DeviceLoad", "Group", omptest::ObserveState::always,
+      /*DeviceNum=*/0));
 
+  SequenceAsserter->insert(omptest::OmptAssertEvent::Target(
+      "User Target", "Group", omptest::ObserveState::always, /*Kind=*/TARGET,
+      /*Endpoint=*/BEGIN));
+
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/ALLOC, /*Bytes=*/sizeof(a)));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/H2D, /*Bytes=*/sizeof(a)));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/ALLOC, /*Bytes=*/sizeof(a)));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/H2D, /*Bytes=*/sizeof(a)));
+
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetSubmit(
+      "User Target Submit", "Group", omptest::ObserveState::always,
+      /*RequestedNumTeams=*/1));
+
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/D2H, /*Bytes=*/sizeof(a)));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/D2H, /*Bytes=*/sizeof(a)));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/DELETE));
+  SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
+      "User Target DataOp", "Group", omptest::ObserveState::always,
+      /*OpType=*/DELETE));
+
+  SequenceAsserter->insert(omptest::OmptAssertEvent::Target(
+      "User Target", "Group", omptest::ObserveState::always, /*Kind=*/TARGET,
+      /*Endpoint=*/END));
 
 #pragma omp target parallel for
   {
@@ -37,12 +68,11 @@ OMPTTESTCASE(InitialSuite, veccopy) {
   for (i=0; i<N; i++)
     if (a[i] != b[i] ) {
       rc++;
-      printf ("Wrong varlue: a[%d]=%d\n", i, a[i]);
+      printf("Wrong value: a[%d]=%d\n", i, a[i]);
     }
 
   if (!rc)
     printf("Success\n");
-
 }
 
 int main(int argc, char **argv) {

--- a/test/smoke-limbo/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
@@ -119,70 +119,70 @@ TEST(SequenceSuite, veccopy_ompt_target) {
 
   /* First Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", Target, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", Target, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetSubmit, /*RequestedNumTeams=*/1)
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetSubmit, /*RequestedNumTeams=*/1)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R1", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R1", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
                                /*DeviceNum=*/0)
 
   /* Second Target Region */
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", Target, /*Kind=*/TARGET,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", Target, /*Kind=*/TARGET,
                                /*Endpoint=*/BEGIN, /*DeviceNum=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/ALLOC,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/ALLOC,
                                /*Size=*/N * sizeof(int))
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/H2D,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/H2D,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/&b)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetSubmit, /*RequestedNumTeams=*/0)
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetSubmit, /*RequestedNumTeams=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&b)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/D2H,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/D2H,
                                /*Size=*/N * sizeof(int),
                                /*SrcAddr=*/nullptr, /*DstAddr=*/&a)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", TargetDataOp, /*OpType=*/DELETE,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", TargetDataOp, /*OpType=*/DELETE,
                                /*Size=*/0)
 
-  OMPT_ASSERT_GROUPED_SEQUENCE("R2", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
+  OMPT_ASSERT_SEQUENCE_GROUPED("R2", Target, /*Kind=*/TARGET, /*Endpoint=*/END,
                                /*DeviceNum=*/0)
 
   /* Actual testcase code. */


### PR DESCRIPTION
Due to macro renaming and/or signature changes some tests would fail.