### PR TITLE
Add missing HIP_CLANG_PATH to hipcc-based smoke-fails tests

### DIFF
--- a/test/smoke-fails/clang-323972-hipcc/Makefile
+++ b/test/smoke-fails/clang-323972-hipcc/Makefile
@@ -1,15 +1,18 @@
 include ../../Makefile.defs
 
-TESTNAME     = clang-323972
-TESTSRC_MAIN = clang-323972.cpp
-TESTSRC_AUX  =
-TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+TESTNAME        = clang-323972
+TESTSRC_MAIN    = clang-323972.cpp
+TESTSRC_AUX     =
+TESTSRC_ALL     = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-OMP_FLAGS = -fopenmp -O2
-CLANG        = hipcc
-OMP_BIN      = $(AOMP)/bin/$(CLANG)
-CC           = $(OMP_BIN) $(VERBOSE)
-#-ccc-print-phases
-#"-\#\#\#"
+CLANG           = hipcc
+AOMPHIP        ?= $(AOMP)
+HIP_CLANG_PATH ?= $(AOMPHIP)/bin
+HIPCC          ?= $(HIP_CLANG_PATH)/$(CLANG)
+COMPILE_ENV     = HIP_CLANG_PATH=$(HIP_CLANG_PATH)
+
+OMP_FLAGS       = -fopenmp -O2
+OMP_BIN         = $(HIPCC)
+CC              = $(COMPILE_ENV) $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules

--- a/test/smoke-fails/clang-362823/Makefile
+++ b/test/smoke-fails/clang-362823/Makefile
@@ -1,17 +1,22 @@
 include ../../Makefile.defs
 
-TESTNAME  = vectoradd_hip
-TESTSRC_MAIN = vectoradd_hip.o
-TESTSRC_AUX	= vectoradd_hip2.o
+TESTNAME        = vectoradd_hip
+TESTSRC_MAIN    = vectoradd_hip.o
+TESTSRC_AUX     = vectoradd_hip2.o
 
-$(TESTRC_MAIN)	: vectoradd_hip.cpp
-$(TESTSRC_AUX)	: vectoradd_hip2.cpp
+$(TESTRC_MAIN)  : vectoradd_hip.cpp
+$(TESTSRC_AUX)  : vectoradd_hip2.cpp
 
-TESTSRC_ALL	= $(TESTSRC_MAIN) $(TESTSRC_AUX)
+TESTSRC_ALL     = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-OMP_FLAGS	= -fgpu-rdc
-CLANG	= hipcc
-OMP_BIN	= $(AOMP)/bin/$(CLANG)
-CC	= $(OMP_BIN)
+CLANG           = hipcc
+AOMPHIP        ?= $(AOMP)
+HIP_CLANG_PATH ?= $(AOMPHIP)/bin
+HIPCC          ?= $(HIP_CLANG_PATH)/$(CLANG)
+COMPILE_ENV     = HIP_CLANG_PATH=$(HIP_CLANG_PATH)
+
+OMP_FLAGS       = -fgpu-rdc
+OMP_BIN         = $(HIPCC)
+CC              = $(COMPILE_ENV) $(OMP_BIN)
 
 include ../Makefile.rules

--- a/test/smoke-fails/flang-305553/Makefile
+++ b/test/smoke-fails/flang-305553/Makefile
@@ -1,22 +1,25 @@
 include ../../Makefile.defs
 
-TESTNAME     = flang-305553
-TESTSRC_MAIN = flang-305553.f90
-TESTSRC_AUX  = fortran_callable_init.o
-TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
-AOMPHIP ?= $(AOMP)
-HIPCC ?= $(AOMPHIP)/bin/hipcc
+TESTNAME        = flang-305553
+TESTSRC_MAIN    = flang-305553.f90
+TESTSRC_AUX     = fortran_callable_init.o
+TESTSRC_ALL     = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CFLAGS = -O3
-FLANG        = flang
-OMP_BIN      = $(AOMP)/bin/$(FLANG)
-CC           = $(OMP_BIN) $(VERBOSE)
-EXTRA_CFLAGS = -L$(AOMPHIP)/lib -lamdhip64 -Wl,-rpath,$(AOMPHIP)/lib
-#-ccc-print-phases
-#"-\#\#\#"
+CLANG           = hipcc
+AOMPHIP        ?= $(AOMP)
+HIP_CLANG_PATH ?= $(AOMPHIP)/bin
+HIPCC          ?= $(HIP_CLANG_PATH)/$(CLANG)
+COMPILE_ENV     = HIP_CLANG_PATH=$(HIP_CLANG_PATH)
+
+CFLAGS          = -O3
+FLANG           = flang
+OMP_BIN         = $(AOMP)/bin/$(FLANG)
+CC              = $(OMP_BIN) $(VERBOSE)
+EXTRA_CFLAGS    = -L$(AOMPHIP)/lib -lamdhip64 -Wl,-rpath,$(AOMPHIP)/lib
 
 include ../Makefile.rules
+
 all: $(TESTNAME)
 
 fortran_callable_init.o : fortran_callable_init.cpp
-	$(HIPCC) -c --offload-arch=$(AOMP_GPU) $^ -o $@
+	$(COMPILE_ENV) $(HIPCC) -c --offload-arch=$(AOMP_GPU) $^ -o $@


### PR DESCRIPTION
Add setup and variable forwarding to 'CC' for:
 * clang-323972-hipcc
 * flang-305553
 * clang-362823