### PR TITLE
Fix clang-362823 make step

### DIFF
--- a/test/smoke-fails/clang-362823/Makefile
+++ b/test/smoke-fails/clang-362823/Makefile
@@ -3,10 +3,6 @@ include ../../Makefile.defs
 TESTNAME        = vectoradd_hip
 TESTSRC_MAIN    = vectoradd_hip.o
 TESTSRC_AUX     = vectoradd_hip2.o
-
-$(TESTRC_MAIN)  : vectoradd_hip.cpp
-$(TESTSRC_AUX)  : vectoradd_hip2.cpp
-
 TESTSRC_ALL     = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 CLANG           = hipcc
@@ -20,3 +16,6 @@ OMP_BIN         = $(HIPCC)
 CC              = $(COMPILE_ENV) $(OMP_BIN)
 
 include ../Makefile.rules
+
+$(TESTRC_MAIN)  : vectoradd_hip.cpp
+$(TESTSRC_AUX)  : vectoradd_hip2.cpp


### PR DESCRIPTION
During execution via `check_smoke_fails` only 1/3 compile steps was attempted, this was due to an ordering issue.

Note, this test still (expectedly) fails:
`lld: error: duplicate symbol`