### PR TITLE
[smoke] - if 'make check' returns a non-zero log it as a failure

### DIFF
--- a/test/smoke/flang-339906/Makefile
+++ b/test/smoke/flang-339906/Makefile
@@ -3,15 +3,17 @@ include ../../Makefile.defs
 TESTNAME     = flang-339906
 TESTSRC_MAIN = main.f90
 TESTSRC_AUX  = matrix.f90
-TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+#TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+AOMP_NO_PREREQ = 1
 
 # Skip Makefile.defs, because test needs aux object generated before main binary
 TESTSRC_AUX_OBJ  = matrix.o
-all: $(TESTNAME)
+
+include ../Makefile.rules
 
 $(TESTSRC_AUX_OBJ) : $(TESTSRC_AUX)
 	$(SETENV) $(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) $(OMP_FLAGS) $^  -o $@
@@ -19,11 +21,3 @@ $(TESTSRC_AUX_OBJ) : $(TESTSRC_AUX)
 $(TESTNAME) : $(TESTSRC_MAIN) $(TESTSRC_AUX_OBJ)
 	$(SETENV) $(CC) $(CFLAGS) $(EXTRA_CFLAGS) $(OMP_FLAGS) $^ -o $@
 
-run: $(TESTNAME)
-	$(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
-
-clean:
-	rm -f $(TESTNAME) $(TESTSRC_AUX_OBJ) *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.log *.mod verify_output *.stb *.ilm *.cmod *.cmdx $(TESTNAME)_og11
-
-clean_log:
-	rm -f *.log

--- a/test/smoke/teams512-info/Makefile
+++ b/test/smoke/teams512-info/Makefile
@@ -23,25 +23,11 @@ ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))
 endif
 
 CFLAGS += $(EXTRA_CFLAGS)
+AOMP_NO_PREREQ = 1
+
+include ../Makefile.rules
 
 # ----- Demo compile and link in one step, no object code saved
 $(TESTNAME): $(TESTSRC)
 	$(CCENV) $(CC) $(CFLAGS) -DGPUINFO $(LFLAGS) $^ -o $@ -mllvm -amdgpu-dump-hsa-metadata 2>&1 | egrep '.vgpr_count|.max_flat_workgroup_size'
 	$(CCENV) $(CC) $(CFLAGS) -DGPUINFO $(LFLAGS) $^ -o $@
-
-run: $(TESTNAME)
-	$(RUNENV) ./$(TESTNAME)
-
-#  ----   Demo compile and link in two steps, object saved
-$(TESTNAME).o: $(TESTSRC)
-	$(CCENV) $(CC) -c $(CFLAGS) $^ -o $@
-
-obin:	$(TESTNAME).o
-	$(CCENV) $(CC) $(CFLAGS) $(LFLAGS) $^ -o $@
-
-run_obin: obin
-	$(RUNENV) ./obin
-
-# Cleanup anything this makefile can create
-clean:
-	rm -f $(TESTNAME) obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin


### PR DESCRIPTION
Some of the smoke tests did not include Makefile.rules and therefore did not have the 'make check' target. In the future, these tests will be logged as failures to avoid slipping through undetected.

flang-33906 and teams512-info have been fixed.