### PR TITLE
[offload][OMPT] Changed signature of set_trace_ompt for various tests

### DIFF
--- a/test/smoke-fails/aomp-issue374/callbacks.h
+++ b/test/smoke-fails/aomp-issue374/callbacks.h
@@ -114,12 +114,12 @@ static void on_ompt_callback_buffer_complete (
   if (buffer_owned) delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt) return ompt_set_error;
 
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 
   return ompt_set_always;
 }
@@ -178,7 +178,7 @@ static void on_ompt_callback_device_initialize
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke-fails/veccopy-shared-ompt-ctor-1/callbacks.h
+++ b/test/smoke-fails/veccopy-shared-ompt-ctor-1/callbacks.h
@@ -118,22 +118,22 @@ static void on_ompt_callback_buffer_complete (
   if (buffer_owned) delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt) return ompt_set_error;
 
-#if EMI  
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
+#if EMI
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit_emi);
 #else
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 #endif
   
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
   if (!ompt_start_trace) return 0;
 
@@ -187,8 +187,8 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
-  set_trace_ompt();
+
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke-limbo/aomp-issue531/callbacks.h
+++ b/test/smoke-limbo/aomp-issue531/callbacks.h
@@ -118,12 +118,12 @@ static void on_ompt_callback_buffer_complete (
   if (buffer_owned) delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt) return ompt_set_error;
 
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 
   return ompt_set_always;
 }
@@ -187,7 +187,7 @@ static void on_ompt_callback_device_initialize
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke-limbo/veccopy-ompt-ctor-1/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-ctor-1/callbacks.h
@@ -118,22 +118,22 @@ static void on_ompt_callback_buffer_complete (
   if (buffer_owned) delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt) return ompt_set_error;
 
-#if EMI  
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
+#if EMI
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit_emi);
 #else
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 #endif
   
   return ompt_set_always;
 }
-  
+
 static int start_trace(int device_num, ompt_device_t *Device) {
   if (!ompt_start_trace) return 0;
 
@@ -187,8 +187,8 @@ static void on_ompt_callback_device_initialize
     DeviceMapPtr = std::make_unique<DeviceMap_t>();
     IsDeviceMapInitialized = true;
   }
-  
-  set_trace_ompt();
+
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-data-tracing-emi/callbacks.h
@@ -123,18 +123,18 @@ static void on_ompt_callback_buffer_complete(
     delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt)
     return ompt_set_error;
 
 #if EMI
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit_emi);
 #else
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 #endif
 
   return ompt_set_always;
@@ -194,7 +194,7 @@ static void on_ompt_callback_device_initialize(int device_num, const char *type,
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke-limbo/veccopy-ompt-target-tracing/callbacks.h
+++ b/test/smoke-limbo/veccopy-ompt-target-tracing/callbacks.h
@@ -129,13 +129,13 @@ static void on_ompt_callback_buffer_complete(
     delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt)
     return ompt_set_error;
 
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 
   return ompt_set_always;
 }
@@ -201,7 +201,7 @@ static void on_ompt_callback_device_initialize(int device_num, const char *type,
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke/aomp-issue376/callbacks.h
+++ b/test/smoke/aomp-issue376/callbacks.h
@@ -118,12 +118,12 @@ static void on_ompt_callback_buffer_complete (
   if (buffer_owned) delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt) return ompt_set_error;
 
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 
   return ompt_set_always;
 }
@@ -187,7 +187,7 @@ static void on_ompt_callback_device_initialize
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this

--- a/test/smoke/veccopy-ompt-target-emi-tracing/callbacks.h
+++ b/test/smoke/veccopy-ompt-target-emi-tracing/callbacks.h
@@ -123,18 +123,18 @@ static void on_ompt_callback_buffer_complete(
     delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt)
     return ompt_set_error;
 
 #if EMI
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit_emi);
 #else
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 #endif
 
   return ompt_set_always;
@@ -194,7 +194,7 @@ static void on_ompt_callback_device_initialize(int device_num, const char *type,
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this


### PR DESCRIPTION
This change enables device specific tracing of events.
Until now the device was always passed as nullptr.