### PR TITLE
[ASan] Fix LD_LIBRARY_PATH initialization for ASan.

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -21,7 +21,7 @@ export CLEANUP=0
 # Enable AMDGPU Sanitizer Testing
 if [ "$1" == "-a" ]; then
   export AOMP_SANITIZER=1
-  export LD_LIBRARY_PATH=$ROCM_INSTALL_PATH/llvm/lib/asan:$ROCM_INSTALL_PATH/lib/asan:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=$AOMP/lib/asan:$AOMPROCM/lib/asan:$LD_LIBRARY_PATH
 fi
 
 if [ -e /usr/sbin/lspci ]; then


### PR DESCRIPTION
'ROCM_INSTALL_PATH' variable is unsed in aomp_common_vars. Only aomp variables are visible to run_rocm_test.sh script.

* The equivalent path for /opt/rocm/llvm/lib/asan is '$AOMP/lib/asan'
* The equivalent path for /opt/rocm/lib/asan is '$AOMPROCM/lib/asan'