### PR TITLE
[smoke-fort] Adjust envs of some tests

### DIFF
--- a/test/smoke-fort/fdefault-sizeof/Makefile
+++ b/test/smoke-fort/fdefault-sizeof/Makefile
@@ -11,6 +11,7 @@ CC           = AOMP=${AOMP} AOMP_GPU=${AOMP_GPU} FLANG=${FLANG} ./buildit.sh
 #-ccc-print-phases
 #"-\#\#\#"
 
+RUNENV       = AOMP=${AOMP}
 RUNCMD       = ./doit.sh > ${TESTNAME}.out 2>&1 && ./chkit.sh ${TESTNAME}.out
 
 include ../Makefile.rules

--- a/test/smoke-fort/flang-440121/Makefile
+++ b/test/smoke-fort/flang-440121/Makefile
@@ -10,7 +10,7 @@ OMP_BIN      = $(AOMP)/bin/$(FLANG)
 WRONG_LIB    = `pwd`/lib
 CC           = LIBRARY_PATH=$(WRONG_LIB):$(AOMP)/lib $(OMP_BIN) $(VERBOSE)
 OMP_FLAGS   += -fopenmp
-RUNENV       = LD_LIBRARY_PATH=$(WRONG_LIB):$(AOMP)/lib
+RUNENV       = LD_LIBRARY_PATH=$(WRONG_LIB):$(AOMP)/lib:$(AOMP)/lib/x86_64-unknown-linux-gnu
 
 #-ccc-print-phases
 #"-\#\#\#"


### PR DESCRIPTION
Extends the envs of 2 tests to make sure all the available paths are set.