### PR TITLE
Added a warning that shows up if someone wants to build AOMP for the untested targets aarch64 or ppc64le

### DIFF
--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -38,8 +38,8 @@ patchrepo $REPO_DIR
 
 # End check-openmp prep
 if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
-   echo "WARNING: You are about to build AOMP for the *untested* target $AOMP_PROC. Press enter to continue."
-   read
+   echo "WARNING: You are about to build AOMP for the *untested* target $AOMP_PROC."
+   sleep 6
 fi
 
 if [ "$AOMP_PROC" == "ppc64le" ] ; then

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -37,6 +37,10 @@ REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
 patchrepo $REPO_DIR
 
 # End check-openmp prep
+if [ "$AOMP_PROC" == "ppc64le" ] || [ "$AOMP_PROC" == "aarch64" ] ; then
+   echo "WARNING: You are about to build AOMP for the *untested* target $AOMP_PROC. Press enter to continue."
+   read
+fi
 
 if [ "$AOMP_PROC" == "ppc64le" ] ; then
    COMPILERS="-DCMAKE_C_COMPILER=/usr/bin/gcc-7 -DCMAKE_CXX_COMPILER=/usr/bin/g++-7"


### PR DESCRIPTION
Since the targets are completely untested, I added a warning instead of a comment. The complete logic for these targets may be removed from the scripts in the long run.