### PR TITLE
Update multi-image3 to catch failures in multi-image generation

### DIFF
--- a/test/smoke/multi-image3/Makefile
+++ b/test/smoke/multi-image3/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = multi-image.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES) --offload-arch=gfx803$(AOMP_TARGET_FEATURES) --offload-arch=gfx1031$(AOMP_TARGET_FEATURES)
+OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES),gfx90a:xnack+,gfx90a:xnack-
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
@@ -15,4 +15,4 @@ CC           = $(OMP_BIN) $(VERBOSE)
 include ../Makefile.rules
 run: $(TESTNAME)
 	./$(TESTNAME)
-	strings $(TESTNAME) |grep -i gfx
+	strings $(TESTNAME) | grep $(AOMP_GPU)$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx90a:xnack+ && strings $(TESTNAME) | grep gfx90a:xnack-

--- a/test/smoke/multi-image3/Makefile
+++ b/test/smoke/multi-image3/Makefile
@@ -5,9 +5,9 @@ TESTSRC_MAIN = multi-image.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-RUNCMD	     = ./$(TESTNAME) && strings $(TESTNAME) | grep $(AOMP_GPU)$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx90a:xnack+ && strings $(TESTNAME) | grep gfx90a:xnack-
+RUNCMD	     = ./$(TESTNAME) && strings $(TESTNAME) | grep $(AOMP_GPU)$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx908$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx942$(AOMP_TARGET_FEATURES)
 
-OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES),gfx90a:xnack+,gfx90a:xnack-
+OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES),gfx908$(AOMP_TARGET_FEATURES),gfx942$(AOMP_TARGET_FEATURES)
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke/multi-image3/Makefile
+++ b/test/smoke/multi-image3/Makefile
@@ -5,6 +5,8 @@ TESTSRC_MAIN = multi-image.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+RUNCMD	     = ./$(TESTNAME) && strings $(TESTNAME) | grep $(AOMP_GPU)$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx90a:xnack+ && strings $(TESTNAME) | grep gfx90a:xnack-
+
 OMP_FLAGS    = -fopenmp --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES),gfx90a:xnack+,gfx90a:xnack-
 CLANG        = clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
@@ -13,6 +15,3 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #"-\#\#\#"
 
 include ../Makefile.rules
-run: $(TESTNAME)
-	./$(TESTNAME)
-	strings $(TESTNAME) | grep $(AOMP_GPU)$(AOMP_TARGET_FEATURES) && strings $(TESTNAME) | grep gfx90a:xnack+ && strings $(TESTNAME) | grep gfx90a:xnack-


### PR DESCRIPTION
Update multi-image testing to catch if all images were actually created. Also explicitly checks for target features xnack+ and xnack-.