### PR TITLE
Add tests for program termination from GPU kernels

### DIFF
--- a/test/smoke-fort-fails/Makefile
+++ b/test/smoke-fort-fails/Makefile
@@ -29,6 +29,10 @@ TESTS_DIR = \
     olcf-tf-7-loop-combined \
     rocm-issue-842 \
     tgt-printf-c \
+    flang-gpu-stop-integer \
+    flang-gpu-stop-string \
+    flang-gpu-exit \
+    flang-gpu-abort
 
 all:
 	@for test_dir in $(TESTS_DIR); do \

--- a/test/smoke-fort-fails/flang-gpu-abort/Makefile
+++ b/test/smoke-fort-fails/flang-gpu-abort/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-gpu-abort
+TESTSRC_MAIN = flang-gpu-abort.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+RUNCMD       =  ./runit.sh > ${TESTNAME}.out 2>&1 && exit 1 || ./chkit.sh ${TESTNAME}.out
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-gpu-abort/chkit.sh
+++ b/test/smoke-fort-fails/flang-gpu-abort/chkit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ $(wc -l $1 | awk '{print $1}') != 1 ]]; then
+    exit 1
+fi
+grep -q 'Aborted' $1

--- a/test/smoke-fort-fails/flang-gpu-abort/flang-gpu-abort.f90
+++ b/test/smoke-fort-fails/flang-gpu-abort/flang-gpu-abort.f90
@@ -1,0 +1,18 @@
+module gpu_abort_impl
+    implicit none
+contains
+    subroutine abort_it()
+        implicit none
+        print '(A)', 'Launching kernel'
+        !$omp target
+            call abort()
+        !$omp end target
+        print '(A)', 'This should not be printed!'
+    end subroutine abort_it
+end module gpu_abort_impl
+
+program gpu_stop
+    use gpu_abort_impl
+    implicit none
+    call abort_it()
+end program gpu_stop

--- a/test/smoke-fort-fails/flang-gpu-abort/runit.sh
+++ b/test/smoke-fort-fails/flang-gpu-abort/runit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+{
+    ./flang-gpu-abort
+} 2>&1
+if [[ $? != 0 ]]; then
+    # turn whatever error code into error code 1
+    exit 1
+fi

--- a/test/smoke-fort-fails/flang-gpu-exit/Makefile
+++ b/test/smoke-fort-fails/flang-gpu-exit/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-gpu-exit
+TESTSRC_MAIN = flang-gpu-exit.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+RUNCMD       = ./flang-gpu-exit > ${TESTNAME}.out 2>&1 && exit 1 || ./chkit.sh ${TESTNAME}.out
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-gpu-exit/chkit.sh
+++ b/test/smoke-fort-fails/flang-gpu-exit/chkit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ $(wc -l $1 | awk '{print $1}') != 1 ]]; then
+    exit 1
+fi
+grep -q 'Launching kernel' $1

--- a/test/smoke-fort-fails/flang-gpu-exit/flang-gpu-exit.f90
+++ b/test/smoke-fort-fails/flang-gpu-exit/flang-gpu-exit.f90
@@ -1,0 +1,18 @@
+module gpu_exit_impl
+    implicit none
+contains
+    subroutine exit_with_integer()
+        implicit none
+        print '(A)', 'Launching kernel'
+        !$omp target
+            call exit(1)
+        !$omp end target
+        print '(A)', 'This should not be printed!'
+    end subroutine exit_with_integer
+end module gpu_exit_impl
+
+program gpu_stop
+    use gpu_exit_impl
+    implicit none
+    call exit_with_integer()
+end program gpu_stop

--- a/test/smoke-fort-fails/flang-gpu-stop-integer/Makefile
+++ b/test/smoke-fort-fails/flang-gpu-stop-integer/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-gpu-stop-integer
+TESTSRC_MAIN = flang-gpu-stop-integer.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+RUNCMD       = ./flang-gpu-stop-integer > ${TESTNAME}.out 2>&1 || ./chkit.sh ${TESTNAME}.out
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-gpu-stop-integer/chkit.sh
+++ b/test/smoke-fort-fails/flang-gpu-stop-integer/chkit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ $(wc -l $1 | awk '{print $1}') != 3 ]]; then
+    exit 1
+fi
+grep -q 'Fortran STOP: code 1' $1

--- a/test/smoke-fort-fails/flang-gpu-stop-integer/flang-gpu-stop-integer.f90
+++ b/test/smoke-fort-fails/flang-gpu-stop-integer/flang-gpu-stop-integer.f90
@@ -1,0 +1,18 @@
+module gpu_stop_impl
+    implicit none
+contains
+    subroutine stop_with_integer()
+        implicit none
+        print '(A)', 'Launching kernel'
+        !$omp target
+            stop 1
+        !$omp end target
+        print '(A)', 'This should not be printed!'
+    end subroutine stop_with_integer
+end module gpu_stop_impl
+
+program gpu_stop
+    use gpu_stop_impl
+    implicit none
+    call stop_with_integer()
+end program gpu_stop

--- a/test/smoke-fort-fails/flang-gpu-stop-string/Makefile
+++ b/test/smoke-fort-fails/flang-gpu-stop-string/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-gpu-stop-string
+TESTSRC_MAIN = flang-gpu-stop-string.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+RUNCMD       = ./flang-gpu-stop-string > ${TESTNAME}.out 2>&1 || ./chkit.sh ${TESTNAME}.out
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-gpu-stop-string/chkit.sh
+++ b/test/smoke-fort-fails/flang-gpu-stop-string/chkit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ $(wc -l $1 | awk '{print $1}') != 3 ]]; then
+    exit 1
+fi
+grep -q 'Fortran STOP: Error message' $1

--- a/test/smoke-fort-fails/flang-gpu-stop-string/flang-gpu-stop-string.f90
+++ b/test/smoke-fort-fails/flang-gpu-stop-string/flang-gpu-stop-string.f90
@@ -1,0 +1,18 @@
+module gpu_stop_impl
+    implicit none
+contains
+    subroutine stop_with_string()
+        implicit none
+        print '(A)', 'Launching kernel'
+        !$omp target
+            stop 'Error message'
+        !$omp end target
+        print '(A)', 'This should not be printed!'
+    end subroutine stop_with_string
+end module gpu_stop_impl
+
+program gpu_stop
+    use gpu_stop_impl
+    implicit none
+    call stop_with_string()
+end program gpu_stop


### PR DESCRIPTION
Add tests for Fortran instrinsic STOP *int* and STOP *message* as well as Fortran extenstions EXIT(*int*) and ABORT()