### PR TITLE
Honor AOMP_TEST_DIR when running nekbone, ovo, sollve, etc

### DIFF
--- a/bin/clone_test.sh
+++ b/bin/clone_test.sh
@@ -166,8 +166,8 @@ fi
 tmpfile=/tmp/mlines$$
 cat $manifest_file | grep project > $tmpfile
 
-if [ ! -d ~/git/aomp-test ]; then
-  mkdir -p ~/git/aomp-test
+if [ ! -d ${AOMP_REPOS_TEST} ]; then
+  mkdir -p ${AOMP_REPOS_TEST}
 fi
 
 while read line ; do 

--- a/bin/rocm-test/scripts/parse_OvO.sh
+++ b/bin/rocm-test/scripts/parse_OvO.sh
@@ -19,7 +19,8 @@ runtime_regex='>>> runtime error'
 wrong_value_regex='>>> wrong value'
 success_regex='>>> success'
 
-cd "$HOME/git/aomp-test/OvO"
+AOMP_TEST_DIR=${AOMP_TEST_DIR:-"$HOME/git/aomp-test"}
+cd "${AOMP_TEST_DIR}/OvO"
 infile=`ls | grep "ovo.run.log"`
 
 # Clean up before parsing

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -31,14 +31,15 @@ setaompgpu
 cd $AOMP_REPOS_TEST/Nekbone
 cd test/nek_gpu1
 rm -f make-fail.txt failing-tests.txt passing-tests.txt
-make -f makefile.aomp clean
+make_overrides="CASEDIR:=${AOMP_TEST_DIR}/Nekbone/test/nek_gpu1 S:=${AOMP_TEST_DIR}/Nekbone/src"
+make -f makefile.aomp clean ${make_overrides}
 ret=$?
 if [ $ret -ne 0 ]; then
   echo "nekbone" >> make-fail.txt
   exit 1
 fi
 ulimit -s unlimited
-PATH=$AOMP/bin/:$PATH make F77=$FLANG -f makefile.aomp
+PATH=$AOMP/bin/:$PATH make F77=$FLANG -f makefile.aomp  ${make_overrides}
 VERBOSE=${VERBOSE:-"1"}
 if [ $VERBOSE -eq 0 ]; then
   ./nekbone 2>&1 | tee nek.log > /dev/null

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -747,19 +747,19 @@ function sollve(){
   checkrc $?
 
   # 4.5 Results
-  cd "$HOME"/git/aomp-test/sollve_vv/results_report45
+  cd "$AOMP_TEST_DIR"/sollve_vv/results_report45
   copyresults sollve45
 
   # 5.0 Results
-  cd "$HOME"/git/aomp-test/sollve_vv/results_report50
+  cd "$AOMP_TEST_DIR"/sollve_vv/results_report50
   copyresults sollve50
 
   # 5.1 Results
-  cd "$HOME"/git/aomp-test/sollve_vv/results_report51
+  cd "$AOMP_TEST_DIR"/sollve_vv/results_report51
   copyresults sollve51
 
   # 5.2 Results
-  cd "$HOME"/git/aomp-test/sollve_vv/results_report52
+  cd "$AOMP_TEST_DIR"/sollve_vv/results_report52
   copyresults sollve52
 }
 
@@ -801,7 +801,7 @@ function LLNL(){
 function ovo(){
   mkdir -p "$resultsdir"/ovo
   cd "$aompdir"/bin
-  ./run_ovo.sh log "$HOME"/git/aomp-test/OvO
+  ./run_ovo.sh log "$AOMP_TEST_DIR"/OvO
   "$scriptsdir"/parse_OvO.sh
   cd "$AOMP_TEST_DIR"/OvO
   copyresults ovo


### PR DESCRIPTION
Replace use of `$HOME/git/aomp-test` or `~/git/aomp-test` with `${AOMP_TEST_DIR}` or `${AOMP_REPOS_TEST}`.