### PR TITLE
Add run_hpc2021.sh and run_accel2023.sh scripts

### DIFF
--- a/bin/run_accel2023.sh
+++ b/bin/run_accel2023.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+# ACCEL2023_SOURCE_DIR           where to clone sources to. Default: AOMP_REPOS_TEST
+# ACCEL2023_BUILD_NUM_THREADS    Number of parallel compile processes. Default: 32
+# export ACC_INPUT=ref   if you wantto run reference isntead of test
+
+export ACC_INPUT=${ACC_INPUT:-test}
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
+export AOMP_USE_CCACHE=0
+
+. $thisdir/aomp_common_vars
+
+: ${ACCEL2023_SOURCE_DIR:=$AOMP_REPOS_TEST/accel2023-2.0.18}
+: ${ACCEL2023_BUILD_NUM_THREADS:=32}
+
+rm -rf ${ACCEL2023_SOURCE_DIR}
+mkdir -p ${ACCEL2023_SOURCE_DIR}
+
+cd ${ACCEL2023_SOURCE_DIR} || exit 1
+wget http://roclogin.amd.com/SPEC/accel2023-2.0.18.tar.xz
+wget http://roclogin.amd.com/SPEC/Accel23-scripts.tar
+tar xf accel2023-2.0.18.tar.xz
+./install.sh -f
+tar xvf Accel23-scripts.tar
+sed -i s/ref/${ACC_INPUT}/g ./runOne
+./runOne
+grep ratio= result/*.log

--- a/bin/run_accel2023.sh
+++ b/bin/run_accel2023.sh
@@ -4,7 +4,7 @@
 # ACCEL2023_BUILD_NUM_THREADS    Number of parallel compile processes. Default: 32
 # export ACC_INPUT=ref   if you wantto run reference isntead of test
 
-export ACC_INPUT=${ACC_INPUT:-test}
+export HPG_INPUT=${HPG_INPUT:-test}
 realpath=`realpath $0`
 thisdir=`dirname $realpath`
 export AOMP_USE_CCACHE=0
@@ -14,15 +14,18 @@ export AOMP_USE_CCACHE=0
 : ${ACCEL2023_SOURCE_DIR:=$AOMP_REPOS_TEST/accel2023-2.0.18}
 : ${ACCEL2023_BUILD_NUM_THREADS:=32}
 
-rm -rf ${ACCEL2023_SOURCE_DIR}
-mkdir -p ${ACCEL2023_SOURCE_DIR}
+if [ "$1" == "-clean" ]; then
+  rm -rf ${ACCEL2023_SOURCE_DIR}
+  mkdir -p ${ACCEL2023_SOURCE_DIR}
+  cd ${ACCEL2023_SOURCE_DIR} || exit 1
+  wget http://roclogin.amd.com/SPEC/accel2023-2.0.18.tar.xz
+  wget http://roclogin.amd.com/SPEC/Accel23-scripts.tar
+  tar xf accel2023-2.0.18.tar.xz
+  ./install.sh -f
+  tar xvf Accel23-scripts.tar
+else
+  cd ${ACCEL2023_SOURCE_DIR} || exit 1
+fi
 
-cd ${ACCEL2023_SOURCE_DIR} || exit 1
-wget http://roclogin.amd.com/SPEC/accel2023-2.0.18.tar.xz
-wget http://roclogin.amd.com/SPEC/Accel23-scripts.tar
-tar xf accel2023-2.0.18.tar.xz
-./install.sh -f
-tar xvf Accel23-scripts.tar
-sed -i s/ref/${ACC_INPUT}/g ./runOne
 ./runOne
 grep ratio= result/*.log

--- a/bin/run_hpc2021.sh
+++ b/bin/run_hpc2021.sh
@@ -4,7 +4,7 @@
 # HPC2021_BUILD_NUM_THREADS    Number of parallel compile processes. Default: 32
 # export HPC_INPUT=ref   if you wantto run reference isntead of test
 
-export HPC_INPUT=${HPC_INPUT:-test}
+export HPG_INPUT=${HPG_INPUT:-test}
 realpath=`realpath $0`
 thisdir=`dirname $realpath`
 export AOMP_USE_CCACHE=0
@@ -14,15 +14,17 @@ export AOMP_USE_CCACHE=0
 : ${HPC2021_SOURCE_DIR:=$AOMP_REPOS_TEST/hpc2021-1.1.9}
 : ${HPC2021_BUILD_NUM_THREADS:=32}
 
-rm -rf ${HPC2021_SOURCE_DIR}
-mkdir -p ${HPC2021_SOURCE_DIR}
-
-cd ${HPC2021_SOURCE_DIR} || exit 1
-wget http://roclogin.amd.com/SPEC/hpc2021-1.1.9.tar.xz
-wget http://roclogin.amd.com/SPEC/Hpc21-scripts.tar
-tar xf hpc2021-1.1.9.tar.xz
-./install.sh -f
-tar xvf Hpc21-scripts.tar
-sed -i s/ref/${HPC_INPUT}/g ./runOne
+if [ "$1" == "-clean" ]; then
+  rm -rf ${HPC2021_SOURCE_DIR}
+  mkdir -p ${HPC2021_SOURCE_DIR}
+  cd ${HPC2021_SOURCE_DIR} || exit 1
+  wget http://roclogin.amd.com/SPEC/hpc2021-1.1.9.tar.xz
+  wget http://roclogin.amd.com/SPEC/Hpc21-scripts.tar
+  tar xf hpc2021-1.1.9.tar.xz
+  ./install.sh -f
+  tar xvf Hpc21-scripts.tar
+else
+  cd ${HPC2021_SOURCE_DIR} || exit 1
+fi
 ./runOne
 grep ratio= result/*.log

--- a/bin/run_hpc2021.sh
+++ b/bin/run_hpc2021.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+
+# HPC2021_SOURCE_DIR           where to clone sources to. Default: AOMP_REPOS_TEST
+# HPC2021_BUILD_NUM_THREADS    Number of parallel compile processes. Default: 32
+# export HPC_INPUT=ref   if you wantto run reference isntead of test
+
+export HPC_INPUT=${HPC_INPUT:-test}
+realpath=`realpath $0`
+thisdir=`dirname $realpath`
+export AOMP_USE_CCACHE=0
+
+. $thisdir/aomp_common_vars
+
+: ${HPC2021_SOURCE_DIR:=$AOMP_REPOS_TEST/hpc2021-1.1.9}
+: ${HPC2021_BUILD_NUM_THREADS:=32}
+
+rm -rf ${HPC2021_SOURCE_DIR}
+mkdir -p ${HPC2021_SOURCE_DIR}
+
+cd ${HPC2021_SOURCE_DIR} || exit 1
+wget http://roclogin.amd.com/SPEC/hpc2021-1.1.9.tar.xz
+wget http://roclogin.amd.com/SPEC/Hpc21-scripts.tar
+tar xf hpc2021-1.1.9.tar.xz
+./install.sh -f
+tar xvf Hpc21-scripts.tar
+sed -i s/ref/${HPC_INPUT}/g ./runOne
+./runOne
+grep ratio= result/*.log

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -844,6 +844,24 @@ function ovo(){
   copyresults ovo
 }
 
+function accel2023(){
+  mkdir -p "$resultsdir"/accel2023
+  cd "$aompdir"/bin
+  ./run_accel2023.sh log "$AOMP_TEST_DIR"/accel2023
+  echo need to run "$scriptsdir"/parse_accel2023.sh
+  cd "$AOMP_TEST_DIR"/accel2023
+  copyresults accel2023
+}
+
+function hpc2021(){
+  mkdir -p "$resultsdir"/hpc2021
+  cd "$aompdir"/bin
+  ./run_hpc2021.sh log "$AOMP_TEST_DIR"/hpc2021
+  echo need to run "$scriptsdir"/parse_hpc2021.sh
+  cd "$AOMP_TEST_DIR"/hpc2021
+  copyresults hpc2021
+}
+
 # Clean Results
 cd "$aompdir"/bin
 rm -rf $resultsdir

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -847,7 +847,7 @@ function ovo(){
 function accel2023(){
   mkdir -p "$resultsdir"/accel2023
   cd "$aompdir"/bin
-  ./run_accel2023.sh log "$AOMP_TEST_DIR"/accel2023
+  ./run_accel2023.sh -clean
   echo need to run "$scriptsdir"/parse_accel2023.sh
   cd "$AOMP_TEST_DIR"/accel2023
   copyresults accel2023
@@ -856,7 +856,7 @@ function accel2023(){
 function hpc2021(){
   mkdir -p "$resultsdir"/hpc2021
   cd "$aompdir"/bin
-  ./run_hpc2021.sh log "$AOMP_TEST_DIR"/hpc2021
+  ./run_hpc2021.sh -clean
   echo need to run "$scriptsdir"/parse_hpc2021.sh
   cd "$AOMP_TEST_DIR"/hpc2021
   copyresults hpc2021


### PR DESCRIPTION
export ACC_INPUT=ref   if you wan tto run reference isntead of test for accel2023
export HPC_INPUT=ref   if you want to run reference isntead of test for hpc2021

for now, to run with run_rocm_test.sh
   AOMP=... SUITE_LIST="hpc20201 accel2023" ./run_rocm_test.sh

adds about 7 minutes total time to run both