### PR TITLE
[OMPT] Adapt set_trace_ompt signature to internal handling

### DIFF
--- a/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/callbacks.h
+++ b/test/smoke-dev/veccopy-ompt-target-emi-tracing-dag/callbacks.h
@@ -124,18 +124,18 @@ static void on_ompt_callback_buffer_complete(
     delete_buffer_ompt(buffer);
 }
 
-static ompt_set_result_t set_trace_ompt() {
+static ompt_set_result_t set_trace_ompt(ompt_device_t *Device) {
   if (!ompt_set_trace_ompt)
     return ompt_set_error;
 
 #if EMI
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op_emi);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op_emi);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit_emi);
 #else
-  ompt_set_trace_ompt(0, 1, ompt_callback_target);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_data_op);
-  ompt_set_trace_ompt(0, 1, ompt_callback_target_submit);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_data_op);
+  ompt_set_trace_ompt(Device, 1, ompt_callback_target_submit);
 #endif
 
   return ompt_set_always;
@@ -195,7 +195,7 @@ static void on_ompt_callback_device_initialize(int device_num, const char *type,
     IsDeviceMapInitialized = true;
   }
 
-  set_trace_ompt();
+  set_trace_ompt(device);
 
   // In many scenarios, this will be a good place to start the
   // trace. If start_trace is called from the main program before this


### PR DESCRIPTION
Fix test-specific set_trace_ompt to set the traced device correctly.