### PR TITLE
Set HSA_XNACK for sollve/OpenMP_VV for more GPUs

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -595,6 +595,52 @@ function setaompgpu (){
   fi
 }
 
+# GPUs which need HSA_XNACK=1 to be set for USM to work.  The canonical place
+# this info is stored in these scripts is in test/Makefile.defs (SUPPORTS_USM).
+# We use a tiny custom makefile to extract the info.
+# Usage:
+# if gpu_needs_xnack_for_usm "$GPU"; then ...; fi
+
+function gpu_needs_xnack_for_usm(){
+  local needs_usm
+  needs_usm=$(make -s -C "$thisdir"/../test -f USM_check.make GPU="$1")
+  case "$needs_usm" in
+    true)
+      return 0
+      ;;
+    false)
+      return 1
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+}
+
+# Return success (0) if ROCR_VISIBLE_DEVICES (or the first GPU if it is unset)
+# refers to an APU, as indicated by rocminfo returning
+# "Coherent Host Access: TRUE" for the device, else return failure (1).
+
+function is_apu(){
+  local device_num=${ROCR_VISIBLE_DEVICES:-0}
+  local cha
+  cha=$(ROCR_VISIBLE_DEVICES="$device_num" rocminfo | grep -m 1 -F "Coherent Host Access:")
+  if [[ "$cha" =~ Coherent\ Host\ Access:[[:blank:]]+(TRUE|FALSE) ]]; then
+    case "${BASH_REMATCH[1]}" in
+      TRUE)
+        return 0
+        ;;
+      FALSE)
+        return 1
+        ;;
+     esac
+  else
+    # If we don't see the above pattern in rocminfo output, it's probably not
+    # an APU.
+    return 1
+  fi
+}
+
 function help_build_aomp(){
    /bin/cat 2>&1 <<"EOF"
 

--- a/bin/run_OpenMP_VV.sh
+++ b/bin/run_OpenMP_VV.sh
@@ -155,7 +155,7 @@ fi
 
 if [ "$SKIP_SOLLVE50" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."
@@ -176,7 +176,7 @@ fi
 
 if [ "$SKIP_SOLLVE51" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."
@@ -202,7 +202,7 @@ fi
 
 if [ "$SKIP_SOLLVE52" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."

--- a/bin/run_sollve.sh
+++ b/bin/run_sollve.sh
@@ -153,7 +153,7 @@ fi
 
 if [ "$SKIP_SOLLVE50" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."
@@ -174,7 +174,7 @@ fi
 
 if [ "$SKIP_SOLLVE51" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."
@@ -200,7 +200,7 @@ fi
 
 if [ "$SKIP_SOLLVE52" != 1 ]; then
   enable_xnack=0
-  if [ "$AOMP_GPU" == gfx90a ] && [ "$HSA_XNACK" == "" ]; then
+  if gpu_needs_xnack_for_usm "$AOMP_GPU" && ! is_apu && [ "$HSA_XNACK" == "" ]; then
     export HSA_XNACK=1
     enable_xnack=1
     echo "Turning on HSA_XNACK=1 for 5.0 to allow USM tests to pass."

--- a/test/USM_check.make
+++ b/test/USM_check.make
@@ -1,0 +1,10 @@
+	include Makefile.defs
+
+.SILENT:
+.PHONY: all
+
+SOUGHT_GPU := $(findstring $(GPU), $(SUPPORTS_USM))
+
+all::
+	if [ "$(SOUGHT_GPU)" ]; then echo "true"; else echo "false"; fi
+


### PR DESCRIPTION
At present, several SOLLVE_VV/OpenMP_VV tests for unified shared memory (USM) require the HSA_XNACK=1 setting to work correctly on GPUs that support the feature, but which are running in "xnack-" mode.

The run_sollve.sh/run_OpenMP_VV.sh scripts currently set the environment variable for gfx90a devices only.  This patch lets the USM tests run on additional GPU types also, via querying the list of GPUs that support USM in the test/Makefile.defs fragment.

The situation on APUs is a bit more complicated: if we enable HSA_XNACK on those then the USM tests pass, but several SOLLVE_VV/OpenMP_VV tests that are written to rely on a distinct address space for target regions (with in/out copies) regress because we then get "zero-copy" behaviour (i.e. target regions unexpectedly affect the "host versions" of data).

So, for now, we do *not* set HSA_XNACK on APU devices, perhaps until the above tests are adjusted to allow for "zero-copy" mode.