### PR TITLE
Support separate cmake-only stage for build scripts

### DIFF
--- a/bin/build_amdsmi.sh
+++ b/bin/build_amdsmi.sh
@@ -97,7 +97,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
 fi
 
 cd $BUILD_DIR/build/amdsmi

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -110,7 +110,7 @@ if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
   if [ "$_hostarch" == "x86_64" ] ; then
     # These components build on x86_64, so add them to components list
     if [ "$AOMP_SKIP_FLANG" == 0 ] ; then
-      components="$components flang-legacy pgmath flang flang_runtime"
+      components="$components llvm-legacy flang-legacy pgmath flang flang_runtime"
     fi
     #components="$components hipfort"
     components="$components hipcc hipamd "
@@ -139,7 +139,7 @@ else
   if [ "$SANITIZER" == 1 ] && [ -f $AOMP/bin/flang-legacy ] ; then
     components="$components pgmath flang flang_runtime"
   else
-    components="$components flang-legacy pgmath flang flang_runtime"
+    components="$components llvm-legacy flang-legacy pgmath flang flang_runtime"
   fi
 fi
 echo "COMPONENTS:$components"

--- a/bin/build_bolt.sh
+++ b/bin/build_bolt.sh
@@ -110,7 +110,10 @@ $AOMP_ORIGIN_RPATH \
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
 fi
 
 cd $BUILD_DIR/build/bolt

--- a/bin/build_comgr.sh
+++ b/bin/build_comgr.sh
@@ -103,6 +103,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
+fi
+
 cd $BUILD_AOMP/build/comgr
 echo
 echo " -----Running make for comgr ---- " 

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -119,7 +119,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
 fi
 
 cd $BUILD_DIR/build/extras

--- a/bin/build_flang.sh
+++ b/bin/build_flang.sh
@@ -139,6 +139,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 echo
 if [ "$SANITIZER" != 1 ]; then
    echo " ----- Running make ---- "

--- a/bin/build_flang_runtime.sh
+++ b/bin/build_flang_runtime.sh
@@ -173,6 +173,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 echo
 if [ "$SANITIZER" != 1 ]; then
    echo " -----Running make ---- "

--- a/bin/build_hipamd.sh
+++ b/bin/build_hipamd.sh
@@ -150,6 +150,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   fi
 fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
+fi
+
 cd $BUILD_DIR/build/hipamd
 
 echo

--- a/bin/build_hipcc.sh
+++ b/bin/build_hipcc.sh
@@ -95,7 +95,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
 fi
 
 cd $BUILD_DIR/build/hipcc

--- a/bin/build_hipfort.sh
+++ b/bin/build_hipfort.sh
@@ -101,7 +101,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+  exit 0
 fi
 
 cd $BUILD_DIR/build/hipfort

--- a/bin/build_libdevice.sh
+++ b/bin/build_libdevice.sh
@@ -37,7 +37,7 @@ export PATH=$LLVM_BUILD/bin:$PATH
 
 patchrepo $REPO_DIR
 
-if [ "$1" != "install" ] ; then 
+if [ "$1" != "install" && "$1" != "nocmake" ]; then
     
       builddir_libdevice=$BUILD_DIR/build/libdevice
       if [ -d $builddir_libdevice ] ; then 
@@ -60,6 +60,14 @@ if [ "$1" != "install" ] ; then
          echo "      ${AOMP_CMAKE} $MYCMAKEOPTS -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $BUILD_DIR/$AOMP_LIBDEVICE_REPO_NAME"
          exit 1
       fi
+fi
+
+if [ "$1" = "cmake" ]; then
+   removepatch $REPO_DIR
+   exit 0
+fi
+
+if [ "$1" != "install" ]; then
       echo "make -j $AOMP_JOB_THREADS"
       make -j $AOMP_JOB_THREADS 
       if [ $? != 0 ] ; then 

--- a/bin/build_llvm-legacy.sh
+++ b/bin/build_llvm-legacy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# 
-#  build_flang-legacy.sh:  Script to build the legacy flang binary driver
-#         This driver will never call flang -fc1, it only calls binaries 
-#             clang, flang1, flang2, build elsewhere
+#
+#  build_llvm-legacy.sh:  Script to build the legacy LLVM used by flang-legacy. binary driver
+#         This driver will never call flang -fc1, it only calls binaries
+#             clang, flang1, flang2, built elsewhere
 #  Instead of downloading the ROCm 5.5 llvm package we have to
 #  compile the 11vm/clang libs from source to support various
 #  operating systems and spack. This will be the llvm-legacy build step.
@@ -45,10 +45,16 @@ else
   _cxx_flag=""
 fi
 
-# We need a version of ROCM llvm that supports legacy flang 
-# via the link from flang to clang.  rocm 5.5 would be best. 
-# This will enable removal of legacy flang driver support 
-# from clang to make way for flang-new.  
+# Legacy Flang dosen't support building of compiler-rt so it
+# utilizes the clang runtime libraries build/install using build_project.sh.
+# The LLVM_VERSION_MAJOR of legacy flang driver has to match with the clang
+# binaries generated from build_project.sh.
+LLVM_VERSION_MAJOR=$(${LLVM_INSTALL_LOC}/bin/clang --version | grep -oP '(?<=clang version )[0-9]+')
+
+# We need a version of ROCM llvm that supports legacy flang
+# via the link from flang to clang.  rocm 5.5 would be best.
+# This will enable removal of legacy flang driver support
+# from clang to make way for flang-new.
 
 # Options for llvm-legacy cmake.
 TARGETS_TO_BUILD="AMDGPU;X86"
@@ -63,30 +69,31 @@ AOMP_LFL_DIR=${AOMP_LFL_DIR:-"17.0-4"}
 # comment out above line and uncomment next line for new LFL
 #AOMP_LFL_DIR=${AOMP_LFL_DIR:-17.0-4}
 
-MYCMAKEOPTS="\
--DCMAKE_BUILD_TYPE=$BUILD_TYPE \
--DCMAKE_C_COMPILER=$LLVM_INSTALL_LOC/bin/clang \
--DCMAKE_CXX_COMPILER=$LLVM_INSTALL_LOC/bin/clang++ \
+LLVMCMAKEOPTS="\
+-DLLVM_ENABLE_PROJECTS=clang \
+-DCMAKE_BUILD_TYPE=Release \
+-DLLVM_ENABLE_ASSERTIONS=ON \
+-DLLVM_TARGETS_TO_BUILD=$TARGETS_TO_BUILD \
+-DCLANG_DEFAULT_LINKER=lld \
+-DLLVM_VERSION_MAJOR="$LLVM_VERSION_MAJOR" \
+-DLLVM_INCLUDE_BENCHMARKS=0 \
+-DLLVM_INCLUDE_RUNTIMES=0 \
+-DLLVM_INCLUDE_EXAMPLES=0 \
+-DLLVM_INCLUDE_TESTS=0 \
+-DLLVM_INCLUDE_DOCS=0 \
+-DLLVM_INCLUDE_UTILS=0 \
+-DCLANG_DEFAULT_PIE_ON_LINUX=0 \
+-DLLVM_ENABLE_ZSTD=OFF \
 $_cxx_flag \
--DCMAKE_CXX_STANDARD=17 \
--DCMAKE_INSTALL_PREFIX=$LLVM_INSTALL_LOC \
-$AOMP_SET_NINJA_GEN \
-"
+$AOMP_SET_NINJA_GEN"
 
-if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
-  MYCMAKEOPTS="$MYCMAKEOPTS -DBUILD_SHARED_LIBS=ON $AOMP_ORIGIN_RPATH"
-else
-  MYCMAKEOPTS="$MYCMAKEOPTS -DBUILD_SHARED_LIBS=OFF $OPENMP_EXTRAS_ORIGIN_RPATH"
-fi
-
-
-if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
+if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
-if [ $AOMP_STANDALONE_BUILD == 1 ] ; then 
-   if [ ! -L $AOMP ] ; then 
-     if [ -d $AOMP ] ; then 
+if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
+   if [ ! -L $AOMP ] ; then
+     if [ -d $AOMP ] ; then
         echo "ERROR: Directory $AOMP is a physical directory."
         echo "       It must be a symbolic link or not exist"
         exit 1
@@ -95,31 +102,23 @@ if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
 fi
 
 # Make sure we can update the install directory
-if [ "$1" == "install" ] ; then 
+if [ "$1" == "install" ] ; then
    $SUDO mkdir -p $AOMP_INSTALL_DIR
    $SUDO touch $AOMP_INSTALL_DIR/testfile
-   if [ $? != 0 ] ; then 
+   if [ $? != 0 ] ; then
       echo "ERROR: No update access to $AOMP_INSTALL_DIR"
       exit 1
    fi
    $SUDO rm $AOMP_INSTALL_DIR/testfile
 fi
 
-# Allow extglobs -- seems like this must be set before bash starts parsing
-# the 'if' block below.
-shopt -s extglob
-
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR"
    echo "Use ""$0 nocmake"" or ""$0 install"" to avoid FRESH START."
-   if [ -d "$BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR" ]; then
-     # This needs extglob enabled, as set above.
-     rm -rf "$BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR"/!("llvm-legacy")
-   else
-     echo "ERROR: Build llvm-legacy before flang-legacy."
-     exit 1
-   fi
+   rm -rf $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy
+   mkdir -p $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR
+   mkdir -p $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy
 else
    if [ ! -d $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR ] ; then
       echo "ERROR: The build directory $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR does not exist"
@@ -128,60 +127,33 @@ else
    fi
 fi
 
-echo
-# Cmake flang-legacy.
+# Cmake for llvm legacy (ROCm 5.5).
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
-   cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR
-   echo " -----Running cmake ---- " 
-   echo ${AOMP_CMAKE} $MYCMAKEOPTS  $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/flang-legacy/$AOMP_LFL_DIR
-   ${AOMP_CMAKE} $MYCMAKEOPTS  $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/flang-legacy/$AOMP_LFL_DIR 2>&1
-   if [ $? != 0 ] ; then 
+   cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy
+   echo " -----Running cmake ---- "
+   echo ${AOMP_CMAKE} $LLVMCMAKEOPTS  $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/flang-legacy/$AOMP_LFL_DIR/llvm-legacy/llvm
+   ${AOMP_CMAKE} $LLVMCMAKEOPTS  $AOMP_REPOS/$AOMP_FLANG_REPO_NAME/flang-legacy/$AOMP_LFL_DIR/llvm-legacy/llvm 2>&1
+   if [ $? != 0 ] ; then
       echo "ERROR cmake failed. Cmake flags"
-      echo "      $MYCMAKEOPTS"
+      echo "      $LLVMCMAKEOPTS"
       exit 1
    fi
+   echo
 fi
 
 if [ "$1" = "cmake" ]; then
    exit 0
 fi
 
-echo
-
-# Build flang-legacy.
-echo " ---  Running $AOMP_NINJA_BIN for $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR ---- "
-cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR
+# Build llvm legacy.
+echo " ---  Running $AOMP_NINJA_BIN for $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy ---- "
+cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy
 $AOMP_NINJA_BIN -j $AOMP_JOB_THREADS
 if [ $? != 0 ] ; then
       echo " "
       echo "ERROR: $AOMP_NINJA_BIN -j $AOMP_JOB_THREADS  FAILED"
       echo "To restart:"
-      echo "  cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR"
+      echo "  cd $BUILD_DIR/build/flang-legacy/$AOMP_LFL_DIR/llvm-legacy"
       echo "  $AOMP_NINJA_BIN"
       exit 1
-fi
-
-if [ "$1" == "install" ] ; then
-   echo " -----Installing to $AOMP_INSTALL_DIR ---- "
-   $SUDO ${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS --target install
-   if [ $? != 0 ] ; then
-      echo "ERROR make install failed "
-      exit 1
-   fi
-   if [ $AOMP_BUILD_FLANG_LEGACY == 1 ] ; then
-      echo "------ Linking flang-legacy to flang -------"
-      if [ -L $AOMP_INSTALL_DIR/bin/flang ] ; then
-         $SUDO rm $AOMP_INSTALL_DIR/bin/flang
-      fi
-      cd $LLVM_INSTALL_LOC/bin
-      $SUDO ln -sf flang-legacy flang
-   fi
-   echo
-   echo "SUCCESSFUL INSTALL to $AOMP_INSTALL_DIR"
-   echo
-else 
-   echo 
-   echo "SUCCESSFUL BUILD, please run:  $0 install"
-   echo "  to install into $AOMP"
-   echo 
 fi

--- a/bin/build_offload.sh
+++ b/bin/build_offload.sh
@@ -257,6 +257,11 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       fi
    fi
 fi
+
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 if [ "$1" != "install" ] ; then
 if [ "$AOMP_LEGACY_OPENMP" == "1" ] && [ "$SANITIZER" != 1 ] ; then
   cd $BUILD_DIR/build/offload

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -265,6 +265,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 if [ "$1" != "install" ] ; then
 if [ "$AOMP_LEGACY_OPENMP" == "1" ] && [ "$SANITIZER" != 1 ] ; then
   cd $BUILD_DIR/build/openmp

--- a/bin/build_pgmath.sh
+++ b/bin/build_pgmath.sh
@@ -132,6 +132,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 if [ "$SANITIZER" != 1 ]; then
    echo
    cd $BUILD_DIR/build/pgmath

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -219,6 +219,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 echo
 echo " -----Running make ---- " 
 

--- a/bin/build_qmcpack.sh
+++ b/bin/build_qmcpack.sh
@@ -176,6 +176,10 @@ $custom_opts \
 ..
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 echo
 echo make -j$AOMP_JOB_THREADS
 make -j$AOMP_JOB_THREADS

--- a/bin/build_rocdbgapi.sh
+++ b/bin/build_rocdbgapi.sh
@@ -86,6 +86,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 cd $BUILD_AOMP/build/rocdbgapi
 echo
 echo " -----Running make for rocdbgapi ---- " 

--- a/bin/build_rocgdb.sh
+++ b/bin/build_rocgdb.sh
@@ -84,6 +84,10 @@ if [ "$1" != "noconfigure" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "configure" ]; then
+   exit 0
+fi
+
 cd $BUILD_AOMP/build/rocgdb
 echo
 echo " -----Running make for gdb ---- " 

--- a/bin/build_rocm-cmake.sh
+++ b/bin/build_rocm-cmake.sh
@@ -86,8 +86,12 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
-
 fi
+
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 cd $BUILD_DIR/build/rocm-cmake
 
 #  ----------- no make for this component

--- a/bin/build_rocm_smi_lib.sh
+++ b/bin/build_rocm_smi_lib.sh
@@ -97,7 +97,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
 fi
 
 cd $BUILD_DIR/build/rocm_smi_lib

--- a/bin/build_rocminfo.sh
+++ b/bin/build_rocminfo.sh
@@ -100,7 +100,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
   fi
+fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
 fi
 
 cd $BUILD_DIR/build/rocminfo

--- a/bin/build_rocprofiler-register.sh
+++ b/bin/build_rocprofiler-register.sh
@@ -71,6 +71,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 cd $BUILD_AOMP/build/$AOMP_PROF_REGISTER_REPO_NAME
 echo
 echo " -----Running make for $AOMP_PROF_REGISTER_REPO_NAME ---- " 

--- a/bin/build_rocprofiler.sh
+++ b/bin/build_rocprofiler.sh
@@ -88,6 +88,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 cd $BUILD_AOMP/build/rocprofiler
 echo
 echo " -----Running make for rocprofiler ---- " 

--- a/bin/build_rocr.sh
+++ b/bin/build_rocr.sh
@@ -92,7 +92,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
          exit 1
       fi
    fi
+fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
 fi
 
 cd $BUILD_AOMP/build/rocr

--- a/bin/build_roct.sh
+++ b/bin/build_roct.sh
@@ -87,6 +87,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    fi
 fi
 
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
 cd $BUILD_AOMP/build/roct
 echo
 echo " -----Running make for roct ---- " 

--- a/bin/build_roctracer.sh
+++ b/bin/build_roctracer.sh
@@ -72,7 +72,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
          fi
       fi
    fi
-   BUILD_TYPE="release"
+   BUILD_TYPE="Release"
    export CMAKE_BUILD_TYPE=$BUILD_TYPE
    CMAKE_PREFIX_PATH="$ROCM_DIR/include/hsa;$ROCM_DIR/include;$ROCM_DIR/lib;$ROCM_DIR;$LLVM_INSTALL_LOC"
    export CMAKE_PREFIX_PATH
@@ -88,6 +88,10 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
       echo "      $MYCMAKEOPTS"
       exit 1
    fi
+fi
+
+if [ "$1" = "cmake" ]; then
+   exit 0
 fi
 
 cd $BUILD_AOMP/build/roctracer


### PR DESCRIPTION
As part of an experimental project to wrap, isolate and adjust the UI for these scripts, it's helpful to be able to separate out the running of the 'cmake' (or 'configure') step from the build and install steps.

This is mostly quite straightforward: we just add a command 'cmake' (or 'configure') for each script to fit alongside the existing 'nocmake' and 'install' commands.  One slight difficulty is handling the flang-legacy script, because it actually builds two components in succession (llvm-legacy then flang-legacy).  Incremental rebuilds are more easily handled (in the above-mentioned project) by splitting the component into two scripts, so that's what this patch does.

A normal build still completes successfully with the patch.

OK?