### PR TITLE
Smoke test updates for VM  based systems (#1067) mainline cherry-pick

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -33,13 +33,20 @@ ISVIRT=0
 echo $lspci_loc
 $lspci_loc 2>&1 | grep -q VMware
 if [ $? -eq 0 ] ; then
-  ISVIRT=1
+  export ISVIRT=1
 fi
+
 lscpu 2>&1 | grep -q Hyperv
 if [ $? -eq 0 ] ; then
-  ISVIRT=1
+  export ISVIRT=1
 fi
 if [ $ISVIRT -eq 1 ] ; then
+
+$lspci_loc 2>&1 | grep -qi Virtio
+if [ $? -eq 0 ] ; then
+  export ISVIRT=1
+fi
+
 SKIP_USM=1
 export SKIP_USM=1
 export HSA_XNACK=${HSA_XNACK:-0}

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -356,3 +356,8 @@ endif
 # Header include path + linker flag for libomptest based OMPT tests
 OMPTEST = -I$(AOMP)/lib/omptest/include -lomptest
 
+ifeq ($(ISVIRT),1)
+GPU_MEM_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
+GPU_MEM_SIZE_GIB := $(shell bc -l <<< "$(GPU_MEM_SIZE)/1024 ^ 3")
+ISVIRT_UNSUPPORTED = ISVIRT_COMPILE ISVIRT_RUNTIME
+endif

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -10,6 +10,9 @@ SKIP_COMPILE_SUPPORTED   = Skipped compiling $(TESTNAME) for $(GPU_W_FEATURES) (
 SKIP_COMPILE_UNSUPPORTED = Skipped compiling $(TESTNAME): not supported on $(UNSUPPORTED)
 SKIP_RUN_SUPPORTED       = Skipped running $(TESTNAME) on $(GPU_W_FEATURES) (supported only on $(SUPPORTED))
 SKIP_RUN_UNSUPPORTED     = Skipped running $(TESTNAME): not supported on $(UNSUPPORTED)
+SKIP_ISVIRT_COMPILE_UNSUPPORTED = Skipped compiling $(TESTNAME): not supported on virtual environment
+SKIP_ISVIRT_RUN_UNSUPPORTED = Skipped running $(TESTNAME): not supported on virtual environment
+POSTRUN ?= echo > /dev/null
 
 all: $(TESTNAME)
 
@@ -43,6 +46,7 @@ $(TESTNAME): prerequisites $(TESTSRC_ALL)
 else
 $(TESTNAME): $(TESTSRC_ALL)
 endif
+ifeq (,$(findstring $(word 1,$(ISVIRT_UNSUPPORTED)),$(UNSUPPORTED)))
 ifneq (,$(findstring $(GPU_W_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 ifdef nvidia_targets
@@ -64,8 +68,12 @@ endif
 else
 	@echo "  $(SKIP_COMPILE_SUPPORTED)"
 endif
+else
+	@echo "  ${SKIP_ISVIRT_COMPILE_UNSUPPORTED}"
+endif
 
 run: $(TESTNAME)
+ifeq (,$(findstring $(word 2,$(ISVIRT_UNSUPPORTED)),$(UNSUPPORTED)))
 ifneq (,$(findstring $(GPU_W_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 	$(RUNENV) $(RUNPROF) $(RUNPROF_FLAGS) $(CHECK_COMMAND) 2>&1 | tee $@.log
@@ -74,6 +82,9 @@ else
 endif
 else
 	@echo "  $(SKIP_RUN_SUPPORTED)" 2>&1 | tee $@.log
+endif
+else
+	@echo "$(SKIP_ISVIRT_RUN_UNSUPPORTED)"
 endif
 
 $(TESTNAME)_og11: $(TESTSRC_ALL)
@@ -104,6 +115,7 @@ verify-log: run
 	)9>../lockfile;
 
 check: $(TESTNAME)
+ifeq (,$(findstring $(word 2,$(ISVIRT_UNSUPPORTED)),$(UNSUPPORTED)))
 ifneq (,$(findstring $(GPU_W_FEATURES),$(SUPPORTED)))
 ifeq (,$(findstring $(GPU_W_FEATURES),$(UNSUPPORTED)))
 	path=`pwd`; \
@@ -123,6 +135,9 @@ else
 endif
 else
 	@echo "  $(SKIP_RUN_SUPPORTED)"
+endif
+else
+	@echo "$(SKIP_ISVIRT_RUN_UNSUPPORTED)"
 endif
 
 check-asan: $(TESTNAME)

--- a/test/smoke/c-heatx/Makefile
+++ b/test/smoke/c-heatx/Makefile
@@ -11,4 +11,6 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
+export TIMEOUT = 180s
+
 include ../Makefile.rules

--- a/test/smoke/exp-303973/Makefile
+++ b/test/smoke/exp-303973/Makefile
@@ -11,5 +11,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
+export TIMEOUT = 180s
+
 include ../Makefile.rules
 

--- a/test/smoke/flang-321277/Makefile
+++ b/test/smoke/flang-321277/Makefile
@@ -9,4 +9,6 @@ FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
+UNSUPPORTED = ISVIRT_RUNTIME
+
 include ../Makefile.rules

--- a/test/smoke/many_arrays/Makefile
+++ b/test/smoke/many_arrays/Makefile
@@ -11,9 +11,15 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
+
+
+ifeq ($(ISVIRT),1)
+ARGS = $(GPU_MEM_SIZE_GIB)
+endif
+
+RUNENV = LIBOMPTARGET_KERNEL_TRACE=2
+
 export TIMEOUT = 120s
 
 include ../Makefile.rules
 
-run: $(TESTNAME)
-	LIBOMPTARGET_KERNEL_TRACE=2 $(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log

--- a/test/smoke/many_arrays/many_arrays.cpp
+++ b/test/smoke/many_arrays/many_arrays.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <cmath>
 #include <omp.h>
+#include <stdlib.h>
 
 // Timing infrastructure
 using namespace std;
@@ -185,14 +186,46 @@ int vecadd(long size, std::string label) {
   return rc;
 }
 
-int main()
+int checkSize(long arraySize , float memSize, int initialExponent){
+  int exponent = 0;
+  float GiB =  pow(1024,3);
+  float sizeGiB;
+  int numArrays = 20;
+
+  for (int i = initialExponent; i > 0; i--){
+    sizeGiB = (arraySize * numArrays * i) / GiB;
+    if (sizeGiB < memSize){
+      exponent = i;
+      return exponent;
+   }
+  }
+  return initialExponent;
+}
+
+int main(int argc, char * argv[])
 {
+  int largeExponent = 8;
+  int adjustedExponent = 0;
   long smallSize = pow(10,3);
+  long largeSize = pow(10,largeExponent);
+
+  // Expects size of GPU memory in GiB (Bytes/1024^3)
+  if (argc > 1){
+    float memSize = atof(argv[1]);
+    adjustedExponent = checkSize(largeSize, memSize, largeExponent);
+    largeSize =  pow(10,adjustedExponent);
+    largeExponent = adjustedExponent;
+    printf("largeExponent: %d\n", adjustedExponent);
+  }
+
   int rc = vecadd(smallSize, "small (10^3)");
   if (rc) return rc;
+  std::string largeString = "large (10^";
+  largeString = largeString + std::to_string(largeExponent) + ")";
+  rc = vecadd(largeSize, largeString);
 
-  long largeSize = pow(10,8);
-  rc = vecadd(largeSize, "large (10^8)");
+  if (adjustedExponent != 0)
+    printf("Warning: Large exponent was adjusted due to insufficient GPU memory. largeSize: %s\n", largeString.c_str());
 
   return rc;
 }

--- a/test/smoke/xteamr_extended/Makefile
+++ b/test/smoke/xteamr_extended/Makefile
@@ -16,4 +16,8 @@ endif
 #-ccc-print-phases
 #"-\#\#\#"
 
+ifeq ($(ISVIRT),1)
+ARGS = $(GPU_MEM_SIZE_GIB)
+endif
+
 include ../Makefile.rules


### PR DESCRIPTION
* [smoke] - many_arrays/xteamr_extended dynamic memory check

* [smoke] - Updates for virtual environment testing

* [smoke] - Increase timeouts for c-heatx/exp-303973 in virtual env

Add new ISVIRT detection.
Add UNSUPPORTED detection for ISVIRT in 'make check'.

* [smoke] - Remove extra print statement in many_arrays