### PR TITLE
[smoke-fort-fails] Add test case flang-464660-2

### DIFF
--- a/test/smoke-fort-fails/Makefile
+++ b/test/smoke-fort-fails/Makefile
@@ -17,6 +17,7 @@ TESTS_DIR = \
     flang-464541 \
     flang-464660 \
     flang-464660-1 \
+    flang-464660-2 \
     flang-469194 \
     flang-479382 \
     flang-479382-1 \

--- a/test/smoke-fort-fails/flang-464660-2/Makefile
+++ b/test/smoke-fort-fails/flang-464660-2/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-464660
+TESTSRC_MAIN = flang-464660.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS   += -lFortranRuntimeHostDevice -gpulibc
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-464660-2/flang-464660.f90
+++ b/test/smoke-fort-fails/flang-464660-2/flang-464660.f90
@@ -1,0 +1,26 @@
+program testFortranRuntime
+use, intrinsic :: iso_fortran_env
+implicit none
+    integer, parameter :: n = 1024
+    integer(int32) :: x(n), y(n)
+    integer :: i
+    x = 1
+    y = 0
+    y = test_offload(x)
+    do i = 1,n
+      if ( x(i) .ne. y(i)) then
+        stop 1
+      endif
+    enddo
+    print *, "Test passed"
+
+    contains
+        function test_offload(xin) result(xout)
+            integer(int32), intent(in) :: xin(1024)
+            integer(int32) :: xout(1024)
+            xout = 0.0
+!$omp target map(to:xin) map(from: xout)
+                xout = xin
+!$omp end target
+        end function test_offload
+end program testFortranRuntime


### PR DESCRIPTION
    - Exercises -lFortranRuntimeDeviceHost -gpulibc for _FortranAAssign
    - Removing -gpulibc will cause unresolved libc symbols:
        strlen, memcpy, memset, memmove