### PR TITLE
Added new smoke-dev test to cover new envar in OpenMP runtime

### DIFF
--- a/test/smoke-dev/occupancy-based-opt/Makefile
+++ b/test/smoke-dev/occupancy-based-opt/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = occupancy_based_opt
+TESTSRC_MAIN = occupancy_based_opt.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+RUNENV 		+= OMPX_SPMD_OCCUPANCY_BASED_OPT=1
+CFLAGS      += -fno-openmp-target-big-jump-loop
+
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/occupancy-based-opt/occupancy_based_opt.c
+++ b/test/smoke-dev/occupancy-based-opt/occupancy_based_opt.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target teams distribute parallel for 
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong varlue: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: Achieved Occupancy: 100%


### PR DESCRIPTION
This test is to cover the new environment variable introduced for occupancy based optimization.

P.S please do not merge until the offload patch was landed.