### PR TITLE
[smoke-fort] Remove constants from map clauses

### DIFF
--- a/test/smoke-fort/flang-476122/hlfir_test.f90
+++ b/test/smoke-fort/flang-476122/hlfir_test.f90
@@ -33,9 +33,9 @@ program main
   allocate(U(dimsB(1):dimsE(1),dimsB(2):dimsE(2)))
   U(:,:) = 1.0
 
-  !$OMP TARGET ENTER DATA MAP(to: U, dimsB, dimsE)
+  !$OMP TARGET ENTER DATA MAP(to: U)
   call test_omp(dimsB, dimsE, U)
-  !$OMP TARGET EXIT DATA MAP(from: U) MAP(release: dimsB, dimsE)
+  !$OMP TARGET EXIT DATA MAP(from: U)
 
   if (abs(sum(U) - 50.0d0) < TOL) then
     print*,"OMP offload test passed."

--- a/test/smoke-fort/flang-476122a/hlfir_test_working.f90
+++ b/test/smoke-fort/flang-476122a/hlfir_test_working.f90
@@ -10,14 +10,14 @@ program main
   allocate(U(dimsB(1):dimsE(1),dimsB(2):dimsE(2)))
   U(:,:) = 1.0
 
-  !$OMP TARGET ENTER DATA MAP(to: U, dimsB, dimsE)
+  !$OMP TARGET ENTER DATA MAP(to: U)
   !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO SIMD COLLAPSE(2)
   do idim1 = dimsB(1), dimsE(1)
     do idim2 = dimsB(2), dimsE(2)
       U(idim1, idim2) = U(idim1, idim2) + 1.0
     END DO
   END DO
-  !$OMP TARGET EXIT DATA MAP(from: U) MAP(release: dimsB, dimsE)
+  !$OMP TARGET EXIT DATA MAP(from: U)
 
   if (abs(sum(U) - 50.0d0) < TOL) then
     print*,"OMP offload test passed."


### PR DESCRIPTION
This change prevents semantics errors from being emitted, and the flang-476122 test starts passing. However, I'm observing a segfault for the flang-476122a test after the change.