### PR TITLE
Move compiler-rt to LLVM_ENABLE_RUNTIMES

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -72,9 +72,9 @@ AOMP_SKIP_FLANG=${AOMP_SKIP_FLANG:-0}
 AOMP_SKIP_FLANG_NEW=${AOMP_SKIP_FLANG_NEW:-0}
 
 if [ "$AOMP_SKIP_FLANG" == 1 ] || [ "$AOMP_SKIP_FLANG_NEW" == 1 ] ; then
-   AOMP_PROJECTS_LIST=${AOMP_PROJECTS_LIST:-"clang;lld;compiler-rt;clang-tools-extra"}
+   AOMP_PROJECTS_LIST=${AOMP_PROJECTS_LIST:-"clang;lld;clang-tools-extra"}
 else
-   AOMP_PROJECTS_LIST=${AOMP_PROJECTS_LIST:-"clang;lld;compiler-rt;clang-tools-extra;flang"}
+   AOMP_PROJECTS_LIST=${AOMP_PROJECTS_LIST:-"clang;lld;clang-tools-extra;flang"}
 fi
 AOMP_COMPONENT_LIST=${AOMP_COMPONENT_LIST:-"prereq project"}
 

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -70,9 +70,9 @@ else
 fi
 
 if [ "$AOMP_LEGACY_OPENMP" != 0 ]; then
-  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind"
+  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt"
 else
-  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;openmp;offload"
+  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;openmp;offload;compiler-rt"
 fi
 
 rocmdevicelib_loc_new=lib/llvm/lib/clang/$AOMP_MAJOR_VERSION/lib/amdgcn


### PR DESCRIPTION
Looks like some trunk patches came in and broke the project build of compiler-rt.