### PR TITLE
[smoke] - add hipmalloc-omptarget-multifile

### DIFF
--- a/test/smoke/hipmalloc-omptarget-multifile/Makefile
+++ b/test/smoke/hipmalloc-omptarget-multifile/Makefile
@@ -1,0 +1,31 @@
+include ../../Makefile.defs
+
+TESTNAME     = main
+TESTSRC_MAIN = main.cpp
+TESTSRC_AUX  = support.o hipMallocOmpTarget1.o hipMallocOmpTarget2.o
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+VERS = $(shell $(AOMP)/bin/clang --version | grep -oP '(?<=clang version )[0-9.]+')
+ifeq ($(shell expr $(VERS) \>= 12.0), 1)
+ifeq ($(AOMP_SANITIZER),1)
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib/asan
+  LLIB = -L$(AOMPHIP)/lib/asan
+else
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib
+  LLIB = -L$(AOMPHIP)/lib
+endif
+endif
+CLANG        ?= clang++ -D__HIP_PLATFORM_AMD__=1 -I$(AOMPHIP)/include -fopenmp
+LINK_FLAGS   = $(LLIB) -lamdhip64 $(RPTH)
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules
+
+support.o: support.cpp
+	$(CC) -c $^ -o $@
+hipMallocOmpTarget1.o: hipMallocOmpTarget1.cpp
+	$(CC) $(TARGET) -c $^ -o $@
+hipMallocOmpTarget2.o: hipMallocOmpTarget2.cpp
+	$(CC) $(TARGET) -c $^ -o $@

--- a/test/smoke/hipmalloc-omptarget-multifile/hipMallocOmpTarget1.cpp
+++ b/test/smoke/hipmalloc-omptarget-multifile/hipMallocOmpTarget1.cpp
@@ -1,0 +1,32 @@
+#include <cstdio>
+#include "hip/hip_runtime.h"
+#include "support.h"
+
+#define SIZE 4
+
+int hipMallocOmpTarget1() {
+    int *array = NULL;
+    int finalArray[SIZE];
+
+    hipCallSuccessful(hipMalloc((void **)&array, SIZE *sizeof(int)));
+    int error = 0;
+
+    printf("\nOutput from hipMallocOmpTarget1:\n");
+    #pragma omp target is_device_ptr(array) map(from: finalArray)
+      for (int i = 0; i < SIZE; ++i) {
+        array[i] = i;
+	finalArray[i] = i;
+        printf("hipMalloc memory in omp target region: array[%i] = %i\n", i, array[i]);
+      }
+
+    hipCallSuccessful(hipFree(array));
+
+    for (int i = 0; i < SIZE; ++i) {
+      printf("Final Host Array: finalArray[%i] = %i\n",  i, finalArray[i]);
+      if (finalArray[i] != i){
+        printf("Error at finalArray[%i]: %i != %i\n", i, finalArray[i], i);
+	return 1;
+      }
+    }
+    return 0;
+}

--- a/test/smoke/hipmalloc-omptarget-multifile/hipMallocOmpTarget2.cpp
+++ b/test/smoke/hipmalloc-omptarget-multifile/hipMallocOmpTarget2.cpp
@@ -1,0 +1,32 @@
+#include <cstdio>
+#include "hip/hip_runtime.h"
+#include "support.h"
+
+#define SIZE 4
+
+int hipMallocOmpTarget2() {
+    int *array = NULL;
+    int finalArray[SIZE];
+
+    hipCallSuccessful(hipMalloc((void **)&array, SIZE *sizeof(int)));
+    int error = 0;
+
+    printf("\nOutput from hipMallocOmpTarget2:\n");
+    #pragma omp target is_device_ptr(array) map(from: finalArray)
+      for (int i = 0; i < SIZE; ++i) {
+        array[i] = i;
+	finalArray[i] = i;
+        printf("hipMalloc memory in omp target region: array[%i] = %i\n", i, array[i]);
+      }
+
+    hipCallSuccessful(hipFree(array));
+
+    for (int i = 0; i < SIZE; ++i) {
+      printf("Final Host Array: finalArray[%i] = %i\n",  i, finalArray[i]);
+      if (finalArray[i] != i){
+        printf("Error at finalArray[%i]: %i != %i\n", i, finalArray[i], i);
+	return 1;
+      }
+    }
+    return 0;
+}

--- a/test/smoke/hipmalloc-omptarget-multifile/main.cpp
+++ b/test/smoke/hipmalloc-omptarget-multifile/main.cpp
@@ -1,0 +1,21 @@
+#include <cstdio>
+
+extern int hipMallocOmpTarget1();
+extern int hipMallocOmpTarget2();
+
+int main() {
+  int rc = 0;
+  rc = hipMallocOmpTarget1();
+  if (rc !=0){
+    printf("\nTest hipMallocOmpTarget1 failed\n");
+    return rc;
+  }
+  hipMallocOmpTarget2();
+  if (rc !=0){
+    printf("\nTest hipMallocOmpTarget2 failed\n");
+    return rc;
+  }
+  printf("Passed \n");
+  return 0;
+}
+

--- a/test/smoke/hipmalloc-omptarget-multifile/support.cpp
+++ b/test/smoke/hipmalloc-omptarget-multifile/support.cpp
@@ -1,0 +1,14 @@
+#include "hip/hip_runtime.h"
+#include "support.h"
+
+void printHipError(hipError_t error) {
+  fprintf(stderr,"Hip Error: %s\n", hipGetErrorString(error));
+}
+
+bool hipCallSuccessful(hipError_t error) {
+  if (error != hipSuccess){
+    printHipError(error);
+    exit(1);
+  }
+  return error == hipSuccess;
+}

--- a/test/smoke/hipmalloc-omptarget-multifile/support.h
+++ b/test/smoke/hipmalloc-omptarget-multifile/support.h
@@ -1,0 +1,2 @@
+void printHipError(hipError_t error);
+bool hipCallSuccessful(hipError_t error);


### PR DESCRIPTION
This tests the usage of the hip_host_overlay.h header in multiple files. There was an issue linking object files together causing duplicate symbols to clash when using hipMalloc + openmp target regions.