### PR TITLE
[smoke] - Add hip-fopenmp test

### DIFF
--- a/test/smoke/hip-fopenmp/Makefile
+++ b/test/smoke/hip-fopenmp/Makefile
@@ -1,0 +1,23 @@
+include ../../Makefile.defs
+
+TESTNAME     = hip-fopenmp
+TESTSRC_MAIN = hip-fopenmp.cpp
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+VERS = $(shell $(AOMP)/bin/clang --version | grep -oP '(?<=clang version )[0-9.]+')
+ifeq ($(shell expr $(VERS) \>= 12.0), 1)
+ifeq ($(AOMP_SANITIZER),1)
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib/asan
+  LLIB = -L$(AOMPHIP)/lib/asan
+else
+  RPTH = -Wl,-rpath,$(AOMPHIP)/lib
+  LLIB = -L$(AOMPHIP)/lib
+endif
+endif
+CLANG        ?= clang++ -x hip -D__HIP_PLATFORM_AMD__=1 $(LLIB) -lamdhip64 $(RPTH) -I$(AOMPHIP)/include
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke/hip-fopenmp/hip-fopenmp.cpp
+++ b/test/smoke/hip-fopenmp/hip-fopenmp.cpp
@@ -1,0 +1,24 @@
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+
+// Testing hip compilation (-x hip) with -fopenmp. This should not pick up the openmp_wrappers/hip_host_overlay.h header. If it does then there will be an error:
+// ld.lld: error: undefined symbol: omp_register_coarse_grain_mem
+int main() {
+  constexpr int num_objects = 2;
+  void** buffers{nullptr};
+  hipError_t mallocResult = hipHostMalloc(&buffers, num_objects * sizeof(void*));
+  hipError_t freeResult = hipHostFree(buffers);
+  if (mallocResult != hipSuccess || freeResult != hipSuccess){
+    printf("Test failed in hipHostMalloc or hipHostFree \n");
+    return 1;
+  }
+
+  mallocResult = hipMalloc(&buffers, num_objects * sizeof(void*));
+  freeResult = hipFree(buffers);
+  if (mallocResult != hipSuccess || freeResult != hipSuccess){
+    printf("Test failed in hipMalloc or hipFree! \n");
+    return 1;
+  }
+  printf("Passed\n");
+  return 0;
+}


### PR DESCRIPTION
This is a simple hip program with -fopenmp. There was an unresolved symbol issue when using hip_host_overlay.h. Only programs with hip runtime calls, like hipMalloc, combined with openmp target regions should use this header. Hip programs with host openmp should not.