### PR TITLE
Add new smoke test to cover new envar in OpenMP runtime

### DIFF
--- a/test/smoke-dev/occupancy-based-opt-big-jump-loop/Makefile
+++ b/test/smoke-dev/occupancy-based-opt-big-jump-loop/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = occupancy_based_opt_big_jump_loop
+TESTSRC_MAIN = occupancy_based_opt_big_jump_loop.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+RUNENV 		+= OMPX_BIGJUMPLOOP_OCCUPANCY_BASED_OPT=1
+
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/occupancy-based-opt-big-jump-loop/occupancy_based_opt_big_jump_loop.c
+++ b/test/smoke-dev/occupancy-based-opt-big-jump-loop/occupancy_based_opt_big_jump_loop.c
@@ -1,0 +1,37 @@
+#include <omp.h>
+#include <stdio.h>
+
+int main() {
+  int N = 10;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i = 0; i < N; i++)
+    a[i] = 0;
+
+  for (i = 0; i < N; i++)
+    b[i] = i;
+
+#pragma omp target teams distribute parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
+  }
+
+  int rc = 0;
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
+      rc++;
+      printf("Wrong varlue: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: Achieved Occupancy: 100%


### PR DESCRIPTION
This test is to cover the new environment variable introduced for occupancy based optimization on big jump loop kernels.

P.S please merge this after the offload patch was landed.