### PR TITLE
[Smoke] Large memory allocation tests should only use available memory

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -370,8 +370,10 @@ endif
 # Header include path + linker flag for libomptest based OMPT tests
 OMPTEST = -I$(AOMP)/lib/omptest/include -lomptest
 
+GPU_MEM_TOTAL_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
+GPU_MEM_USED_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Used Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
+GPU_MEM_SIZE_GIB := $(shell echo "scale=2; ( ($(GPU_MEM_TOTAL_SIZE) - $(GPU_MEM_USED_SIZE)) / (1024 * 1024 * 1024) )" | bc)
+
 ifeq ($(ISVIRT),1)
-GPU_MEM_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
-GPU_MEM_SIZE_GIB := $(shell bc -l <<< "$(GPU_MEM_SIZE)/1024 ^ 3")
 ISVIRT_UNSUPPORTED = ISVIRT_COMPILE ISVIRT_RUNTIME
 endif

--- a/test/smoke/many_arrays/Makefile
+++ b/test/smoke/many_arrays/Makefile
@@ -11,11 +11,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
 
-
-
-ifeq ($(ISVIRT),1)
 ARGS = $(GPU_MEM_SIZE_GIB)
-endif
 
 RUNENV = LIBOMPTARGET_KERNEL_TRACE=2
 

--- a/test/smoke/many_arrays/many_arrays.cpp
+++ b/test/smoke/many_arrays/many_arrays.cpp
@@ -186,37 +186,37 @@ int vecadd(long size, std::string label) {
   return rc;
 }
 
-int checkSize(long arraySize , float memSize, int initialExponent){
-  int exponent = 0;
-  float GiB =  pow(1024,3);
-  float sizeGiB;
+int checkSize(float memSize, int initialExponent, long smallSize, float reservedMemPercent) {
+  float GiB =  1 << 30;
   int numArrays = 20;
+  float sizeGiB;
 
-  for (int i = initialExponent; i > 0; i--){
-    sizeGiB = (arraySize * numArrays * i) / GiB;
-    if (sizeGiB < memSize){
-      exponent = i;
-      return exponent;
+  for (int i = initialExponent; i > 0; i--) {
+    sizeGiB = ((pow(10, i) + smallSize) * numArrays * sizeof(double)) / GiB;
+    printf("sizeGiB: %f, memSize: %f, reservedMemPercent: %f\n", sizeGiB, memSize, reservedMemPercent);
+    if (sizeGiB < (memSize * (1 - reservedMemPercent/100))) {
+      return i;
    }
   }
   return initialExponent;
 }
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char * argv[]) {
   int largeExponent = 8;
+  long smallSize = 1000;
+  float reservedMemPercent = 5;
   int adjustedExponent = 0;
-  long smallSize = pow(10,3);
-  long largeSize = pow(10,largeExponent);
+  long largeSize;
 
   // Expects size of GPU memory in GiB (Bytes/1024^3)
   if (argc > 1){
     float memSize = atof(argv[1]);
-    adjustedExponent = checkSize(largeSize, memSize, largeExponent);
-    largeSize =  pow(10,adjustedExponent);
+    adjustedExponent = checkSize(memSize, largeExponent, smallSize, reservedMemPercent);
     largeExponent = adjustedExponent;
-    printf("largeExponent: %d\n", adjustedExponent);
+    printf("adjustedExponent: %d\n", adjustedExponent);
   }
+
+  largeSize = pow(10, largeExponent);
 
   int rc = vecadd(smallSize, "small (10^3)");
   if (rc) return rc;


### PR DESCRIPTION
Use rocm-smi to query available memory on the GPU and pass it to the tests which require a large size of memory.