### PR TITLE
[Smoke test] Add a new smoke test to cover the new envar in OpenMP runtime

### DIFF
--- a/test/smoke-dev/occupancy-based-opt-xteam-reduction/Makefile
+++ b/test/smoke-dev/occupancy-based-opt-xteam-reduction/Makefile
@@ -1,0 +1,19 @@
+include ../../Makefile.defs
+
+TESTNAME     = occupancy_based_opt_xteam_reduction
+TESTSRC_MAIN = occupancy_based_opt_xteam_reduction.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+RUNENV      += OMPX_XTEAMREDUCTION_OCCUPANCY_BASED_OPT=1
+CFLAGS      += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
+
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/occupancy-based-opt-xteam-reduction/Makefile
+++ b/test/smoke-dev/occupancy-based-opt-xteam-reduction/Makefile
@@ -6,7 +6,6 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
 RUNENV      += OMPX_XTEAMREDUCTION_OCCUPANCY_BASED_OPT=1
-CFLAGS      += -fopenmp-target-ignore-env-vars -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state
 
 RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 

--- a/test/smoke-dev/occupancy-based-opt-xteam-reduction/occupancy_based_opt_xteam_reduction.c
+++ b/test/smoke-dev/occupancy-based-opt-xteam-reduction/occupancy_based_opt_xteam_reduction.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 1000000;
+
+  double a[N];
+
+  for (int i=0; i<N; i++)
+    a[i]=i;
+
+  double sum1, sum2, sum3, sum4;
+  sum1 = sum2 = sum3 = sum4 = 0;
+  
+#pragma omp target teams distribute parallel for map(tofrom:sum1) reduction(+:sum1)
+  for (int j = 0; j< N; j=j+1)
+    sum1 += a[j];
+
+#pragma omp target teams distribute parallel for map(tofrom:sum2) reduction(+:sum2)
+  for (int j = 0; j< N; j=j+2)
+    sum2 += a[j];
+
+#pragma omp target teams distribute parallel for map(tofrom:sum3,sum4) reduction(+:sum3,sum4)
+  for (int j = 0; j< N; j=j+1) {
+    sum3 += a[j];
+    sum4 += a[j];
+  }
+  
+  printf("%f %f %f %f\n", sum1, sum2, sum3, sum4);
+  
+  int rc =
+    (sum1 != 499999500000) ||
+    (sum2 != 249999500000) ||
+    (sum3 != 499999500000) ||
+    (sum4 != 499999500000);
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: Achieved Occupancy: 100%
+

--- a/test/smoke-dev/occupancy-based-opt-xteam-reduction/occupancy_based_opt_xteam_reduction.c
+++ b/test/smoke-dev/occupancy-based-opt-xteam-reduction/occupancy_based_opt_xteam_reduction.c
@@ -42,4 +42,6 @@ int main()
 }
 
 /// CHECK: Achieved Occupancy: 100%
+/// CHECK: Achieved Occupancy: 100%
+/// CHECK: Achieved Occupancy: 100%
 


### PR DESCRIPTION
This test is to cover the new environment variable for occupancy based optimization on cross-team reduction kernels.

Please merge after the runtime changes.