### PR TITLE
Fix aomp directory typo

### DIFF
--- a/docs/RELEASESOURCEINSTALL.md
+++ b/docs/RELEASESOURCEINSTALL.md
@@ -16,7 +16,7 @@ To build and install aomp from the release source tarball run these commands:
 ```
    wget https://github.com/ROCm-Developer-Tools/aomp/releases/download/rel_20.0-0/aomp-20.0-0.tar.gz
    tar -xzf aomp-20.0-0.tar.gz
-   cd aomp19.0
+   cd aomp20.0
    nohup make &
 ```
 Depending on your system, the last command could take a very long time.  So it is recommended to use nohup and background the process.  The simple Makefile that make will use runs build script "build_aomp.sh" and sets some flags to avoid git checks and applying ROCm patches. Here is that Makefile:


### PR DESCRIPTION
Extracted directory from the tarball is now aomp20.0, not aomp19.0.