### PR TITLE
[Smoke] Compute available memory only for tests which require it

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -370,9 +370,15 @@ endif
 # Header include path + linker flag for libomptest based OMPT tests
 OMPTEST = -I$(AOMP)/lib/omptest/include -lomptest
 
-GPU_MEM_TOTAL_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
-GPU_MEM_USED_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Used Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
-GPU_MEM_SIZE_GIB := $(shell echo "scale=2; ( ($(GPU_MEM_TOTAL_SIZE) - $(GPU_MEM_USED_SIZE)) / (1024 * 1024 * 1024) )" | bc)
+# Individual tests need to set OVERFLOW_GUARD=1 to enable available memory
+# computation at the runtime and passing it to the test as the first argument.
+ifeq ($(OVERFLOW_GUARD),1)
+  GPU_MEM_TOTAL_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
+  GPU_MEM_USED_SIZE = $(shell $(AOMPHIP)/bin/rocm-smi --showmeminfo vram | grep -E "VRAM Total Used Memory"  | grep -m1 -Eo " [0-9]+" | tr -d ' ')
+  GPU_MEM_SIZE_GIB := $(shell echo "scale=2; ( ($(GPU_MEM_TOTAL_SIZE) - $(GPU_MEM_USED_SIZE)) / (1024 * 1024 * 1024) )" | bc)
+  # prepend ARGS with GPU_MEM_SIZE_GIB value
+  ARGS := $(GPU_MEM_SIZE_GIB) $(ARGS)
+endif
 
 ifeq ($(ISVIRT),1)
 ISVIRT_UNSUPPORTED = ISVIRT_COMPILE ISVIRT_RUNTIME

--- a/test/smoke/many_arrays/Makefile
+++ b/test/smoke/many_arrays/Makefile
@@ -1,3 +1,9 @@
+# OVERFLOW_GUARD=1 needs to be set before including Makefile.defs.
+# It will ensure that the first argument to the make run command is
+# the available GPU memory in GiB. No need to set ARGS variable
+# explicitly.
+OVERFLOW_GUARD=1
+
 include ../../Makefile.defs
 
 TESTNAME     = many_arrays
@@ -10,8 +16,6 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases
 #"-\#\#\#"
-
-ARGS = $(GPU_MEM_SIZE_GIB)
 
 RUNENV = LIBOMPTARGET_KERNEL_TRACE=2
 

--- a/test/smoke/xteamr_extended/Makefile
+++ b/test/smoke/xteamr_extended/Makefile
@@ -1,3 +1,9 @@
+# OVERFLOW_GUARD=1 needs to be set before including Makefile.defs.
+# It will ensure that the first argument to the make run command is
+# the available GPU memory in GiB. No need to set ARGS variable
+# explicitly.
+OVERFLOW_GUARD=1
+
 include ../../Makefile.defs
 
 TESTNAME     = test_xteamr
@@ -15,11 +21,6 @@ ifneq ("$(wildcard $(AOMP)/lib/libmlir_float16_utils.so)","")
 endif
 #-ccc-print-phases
 #"-\#\#\#"
-
-
-ifeq ($(ISVIRT),1)
-ARGS = $(GPU_MEM_SIZE_GIB)
-endif
 
 UNSUPPORTED = ASAN_COMPILE
 


### PR DESCRIPTION
Only few tests require large amount of free memory, thus it is
not required to compute the available GPU memory for every
test. Any test requiring it, needs to set OVERFLOW_GUARD=1
before including Makefile.defs.