### PR TITLE
[RAJAPerf] updated build/run script

### DIFF
--- a/bin/run_rajaperf.sh
+++ b/bin/run_rajaperf.sh
@@ -48,7 +48,7 @@ build_targets="hip openmp"
 if [ "$2" == "build" ]; then
   # Begin configuration
   pushd $AOMP_REPOS_TEST/RAJAPerf
-  git reset --hard 73f73cfa1979bc9944d9f34ee0059873fb38d79d
+  git reset --hard abb07792a899f7417e77ea40015e7e1dfd52716e
   git submodule update --recursive
   
   rm -rf build_${BUILD_SUFFIX}


### PR DESCRIPTION
Updated the script to build the latest version of RAJAPerf. It contains a bug fix for the build error we are currently observing. Another bug ticket is still open (https://github.com/LLNL/RAJAPerf/issues/493).

!!! Requires cmake version 3.23  !!!!