### PR TITLE
[Test] Add test to cover the new envar

### DIFF
--- a/test/smoke-dev/rt-tuning-envar/Makefile
+++ b/test/smoke-dev/rt-tuning-envar/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = rt_tuning_envar
+TESTSRC_MAIN = rt_tuning_envar.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV       += OMPX_ENABLE_RUNTIME_AUTOTUNING=1
+RUNENV       += LIBOMPTARGET_AMDGPU_ENABLE_QUEUE_PROFILING=1
+
+RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/rt-tuning-envar/rt_tuning_envar.c
+++ b/test/smoke-dev/rt-tuning-envar/rt_tuning_envar.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i=0; i<N; i++)
+    a[i]=0;
+
+  for (i=0; i<N; i++)
+    b[i]=i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j< N; j++)
+      a[j]=b[j];
+  }
+
+  int rc = 0;
+  for (i=0; i<N; i++)
+    if (a[i] != b[i] ) {
+      rc++;
+      printf ("Wrong varlue: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: Kernel Duration: {{[0-9]+}} ns


### PR DESCRIPTION
This test is to cover OMPX_ENABLE_RUNTIME_AUTOTUNING envar. 