### PR TITLE
[smoke] - Additional dynamic memory detection

### DIFF
--- a/test/smoke/clang-337336/Makefile
+++ b/test/smoke/clang-337336/Makefile
@@ -1,3 +1,4 @@
+OVERFLOW_GUARD =1
 include ../../Makefile.defs
 
 TESTNAME     = clang-337336

--- a/test/smoke/clang-337336/clang-337336.cpp
+++ b/test/smoke/clang-337336/clang-337336.cpp
@@ -8,18 +8,32 @@
 const size_t SIZE = 3 * 1024L * 1024L;
 const unsigned int NUM_TEAMS = 3;
 
-int main()
+int main(int argc, char * argv[])
 {
+    unsigned int NKERNELS = 10;
+    if (argc > 1){
+      float memSize = atof(argv[1]);
+      float sizeGiB;
+      float reservedMemPercent = 10;
+      for (int i = NKERNELS; i > 0; i--) {
+        sizeGiB = (i * (double)SIZE * sizeof(double) / GB);
+        printf("sizeGiB: %f, memSize: %f, reservedMemPercent: %f\n", sizeGiB, memSize, reservedMemPercent);
+        if (sizeGiB < (memSize * (1 - reservedMemPercent/100))) {
+          NKERNELS = i;
+          break;
+       }
+    }
+      printf("NKERNELS reduced to: %d\n", NKERNELS);
+    }
     int dummy = 0;
 
-    printf("TOtal Memory = %.6lf GB\n\n", (double)SIZE * sizeof(double) / GB);
+    printf("Total Memory = %.6lf GB\n\n", NKERNELS * (double)SIZE * sizeof(double) / GB);
 
 #pragma omp target
     {
         dummy += 1;
     }
     {
-        unsigned int const NKERNELS = 10;
         double *p[NKERNELS];
         unsigned const check = 9;
 

--- a/test/smoke/clang_udel_saxpy/Makefile
+++ b/test/smoke/clang_udel_saxpy/Makefile
@@ -1,3 +1,4 @@
+OVERFLOW_GUARD=1
 include ../../Makefile.defs
 
 TESTNAME     = clang_udel_saxpy

--- a/test/smoke/clang_udel_saxpy/clang_udel_saxpy.cc
+++ b/test/smoke/clang_udel_saxpy/clang_udel_saxpy.cc
@@ -69,6 +69,23 @@ string to_string(nanoseconds ns) {
 
 int main(int argc, char **argv) {
   int n = 500000000;
+  int numArrays = 2;
+  if (argc > 1){
+    float memSize = atof(argv[1]);
+    float sizeGiB;
+    float GiB = 1 << 30;
+    float reservedMemPercent = 5;
+    for (int i = n; i > 0; i -= n/10) {
+      sizeGiB = (i * numArrays * sizeof(double) / GiB);
+      printf("sizeGiB: %f, memSize: %f, reservedMemPercent: %f\n", sizeGiB, memSize, reservedMemPercent);
+      if (sizeGiB < (memSize * (1 - reservedMemPercent/100))) {
+        n = i;
+        break;
+      }
+    }
+      printf("n reduced to: %d\n", n);
+    }
+
   double a = 3.;
   vector<double> x(n, 1.), y(n, 2.);
   vector<double> xcpu(x), xgpu(x), xloop(x);


### PR DESCRIPTION
Add OVERFLOW_GUARD support for clang-337336
and clang_udel_saxpy. Testing with a gfx1200
8GB showed failures.