### PR TITLE
Apply ATD_ASO_full.patch when AOMP_APPLY_ATD_AMD_STAGING_PATCH==1

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -111,6 +111,9 @@ AOMP_SUPP_INSTALL=${AOMP_SUPP_INSTALL:-$AOMP_SUPP/install}
 # To build aomp from the release source taball, set these values to 0
 AOMP_APPLY_ROCM_PATCHES=${AOMP_APPLY_ROCM_PATCHES:-1}
 
+#  This applies ATD_ASO_full.patch to llvm-project
+AOMP_APPLY_ATD_AMD_STAGING_PATCH=${AOMP_APPLY_ATD_AMD_STAGING_PATCH:-0}
+
 CUDA=${CUDA:-/usr/local/cuda}
 CUDAT=${CUDAT:-$CUDA/targets}
 CUDAINCLUDE=${CUDAINCLUDE:-$CUDA/include}

--- a/bin/build_offload.sh
+++ b/bin/build_offload.sh
@@ -109,6 +109,14 @@ export HSA_RUNTIME_PATH=$ROCM_DIR
 #breaks build as it cant find rocm-path
 #export HIP_DEVICE_LIB_PATH=$ROCM_DIR/lib
 
+# Patch llvm-project with ATD patch customized for amd-staging.
+# WARNING: This patch (ATD_ASO_full.patch) rarely applies cleanly
+#          because of its size and constant trunk merges to amd-staging.
+#          This is why default is 0 (OFF).
+if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+   patchrepo $REPO_DIR
+fi
+
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo " "
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/offload."
@@ -421,4 +429,9 @@ if [ "$1" == "install" ] ; then
       echo cp -rp $_from_dir_plugins $_ompd_src_dir/offload
       $SUDO cp -rp $_from_dir_plugins $_ompd_src_dir/offload
    fi # end of AOMP_BUILD_DEBUG install block
+
+   if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+      removepatch $REPO_DIR
+   fi
+
 fi # end of install block

--- a/bin/build_openmp.sh
+++ b/bin/build_openmp.sh
@@ -118,6 +118,14 @@ export HSA_RUNTIME_PATH=$ROCM_DIR
 #breaks build as it cant find rocm-path
 #export HIP_DEVICE_LIB_PATH=$ROCM_DIR/lib
 
+# Patch llvm-project with ATD patch customized for amd-staging.
+# WARNING: This patch (ATD_ASO_full.patch) rarely applies cleanly
+#          because of its size and constant trunk merges to amd-staging.
+#          This is why default is 0 (OFF).
+if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+   patchrepo $REPO_DIR
+fi
+
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo " "
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_DIR/openmp."
@@ -457,4 +465,9 @@ if [ "$1" == "install" ] ; then
         $SUDO cp -rp $LLVM_PROJECT_ROOT/openmp/libompd/src $_ompd_src_dir/openmp/libompd
       fi
    fi
+
+   if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+      removepatch $REPO_DIR
+   fi
+
 fi

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -23,12 +23,17 @@ WEBSITE="http\:\/\/github.com\/ROCm-Developer-Tools\/aomp"
 
 # Check-openmp prep
 # Patch rocr
-REPO_DIR=$AOMP_REPOS/$AOMP_ROCR_REPO_NAME
-patchrepo $REPO_DIR
+ROCR_REPO_DIR=$AOMP_REPOS/$AOMP_ROCR_REPO_NAME
+patchrepo $ROCR_REPO_DIR
 
-# Patch rocm-device-libs
+# Patch llvm-project with ATD patch customized for amd-staging.
+# WARNING: This patch (ATD_ASO_full.patch) rarely applies cleanly
+#          because of its size and constant trunk merges to amd-staging.
+#          This is why default is 0 (OFF).
 REPO_DIR=$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME
-patchrepo $REPO_DIR
+if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+   patchrepo $REPO_DIR
+fi
 
 # End check-openmp prep
 
@@ -277,9 +282,10 @@ if [ "$1" == "install" ] ; then
    echo
    echo "SUCCESSFUL INSTALL to $INSTALL_PROJECT with link to $AOMP"
    echo
-   removepatch $REPO_DIR
-   REPO_DIR=$AOMP_REPOS/$AOMP_ROCR_REPO_NAME
-   removepatch $REPO_DIR
+   if [ "$AOMP_APPLY_ATD_AMD_STAGING_PATCH"  == 1 ] ; then
+      removepatch $REPO_DIR
+   fi
+   removepatch $ROCR_REPO_DIR
    amd_compiler_symlinks=("amdclang" "amdclang++" "amdclang-cl" "amdclang-cpp" "amdflang" "amdlld")
    if [ "$AOMP_SKIP_FLANG_NEW" == 1 ]; then
      amd_compiler_cfg=("clang" "clang++" "clang-cpp" "clang-${AOMP_MAJOR_VERSION}" "clang-cl" "flang")

--- a/bin/patches/patch-control-file_20.0.txt
+++ b/bin/patches/patch-control-file_20.0.txt
@@ -9,4 +9,5 @@ bolt: bolt.patch
 rocr-runtime: rocr-runtime-combined-numa-check-openmp-support.patch
 rocprofiler: rocprofiler-no-aql-ok.patch
 babelstream: babelstream-usm.patch
+llvm-project: ATD_ASO_full.patch
 UMT: umt.patch


### PR DESCRIPTION
Use with caution!  The ATD_ASO_full.patch is very large and often does not apply if trunk code is merged into amd-staging without updating the patch.  

The default is 0 till the size of ATD patch is significantly reduced.

This is safe to merge now.   However, I would like the updates to support lib-debug, lib-perf, and asan merged first.  I suspect this PR will have minor conflicts with the more complex change to support source level runtime debugging.  