### PR TITLE
[GenASiS] Force update of host/target values

### DIFF
--- a/bin/patches/genasis.patch
+++ b/bin/patches/genasis.patch
@@ -279,3 +279,19 @@ index 2f8cd18a..aa5b4ac0 100644
  
      type ( ConsoleSingleton ), intent ( inout ) :: &
        C
+diff --git a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90 b/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
+index a2d813c..335e77b 100644
+--- a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
++++ b/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
+@@ -102,9 +102,11 @@ contains
+     VZ = K ( 3 ) / ( dot_product ( K, K ) * Period )
+
+     end associate !-- K
+
++    call PF % UpdateDevice ( )
+     call PF % ComputeAuxiliary ( PF % Value )
+     call PF % ComputeConserved ( PF % Value )
++    call PF % UpdateHost ( )
+
+     !-- FIXME: Implicit do-loop array needed to workaround Cray compiler
+     !          crashes for elemental function argument of array and scalar

--- a/bin/patches/genasis_basics.patch
+++ b/bin/patches/genasis_basics.patch
@@ -11,3 +11,19 @@ index 5fc7364..4ae10ae 100644
  #define OMP_SCHEDULE_TARGET auto
  #define OMP_SCHEDULE_HOST runtime
  #define OMP_TARGET_DISTRIBUTE_SCHEDULE dist_schedule ( auto )
+diff --git a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90 b/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
+index a2d813c..335e77b 100644
+--- a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
++++ b/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
+@@ -102,9 +102,11 @@ contains
+     VZ = K ( 3 ) / ( dot_product ( K, K ) * Period )
+
+     end associate !-- K
+
++    call PF % UpdateDevice ( )
+     call PF % ComputeAuxiliary ( PF % Value )
+     call PF % ComputeConserved ( PF % Value )
++    call PF % UpdateHost ( )
+
+     !-- FIXME: Implicit do-loop array needed to workaround Cray compiler
+     !          crashes for elemental function argument of array and scalar


### PR DESCRIPTION
GenASiS and GenASiS_Basics do not use standard OpenMP mapping mechanism to synchronize host and device values. They allocate and link memory device/host C pointers by explicitly calling C OpenMP runtime functions. C function `omp_target_associate_ptr` is called to create link between host and device memory pointers. Once the link is created, OpenMP runtime can skip meory tranfer to/from the device at the launch/end of `omp target` region.

Lack of synchronization between host and device memory leads to indefinite loop for `SineWaveAdvection nCells=128,128,128` sample command.

Code analysis is performed for GenASiS-Basics (v4.0 tag) and SineVaweAdvection application:

1) Initialization of data:
File: Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
  subroutine Initialize_PWA (line: 38)

In `Initialize_PWA` we initialize PWA % ConservedFields object. The type of this object is PressurelessFluidForm:

Code:
line 60:
     allocate ( PressurelessFluidForm :: PWA % ConservedFields )
     select type ( PF => PWA % ConservedFields )
     type is ( PressurelessFluidForm )

Then we initialize device memory for this object:
line 65:
     call PF % AllocateDevice ( )

PF is type `PressurelessFluidForm`. `PressurelessFluidForm` extends `ConservedFieldsTemplate` . `ConservedFieldsTemplate` extends `StorageForm` which contains definition of `AllocateDevice` function:

File Modules/Basics/DataManagement/Storages/Storage_Form.f90: line 62 defines `AllocateDevice`:
     procedure, public, pass :: &
      AllocateDevice => AllocateDevice_S

Function `AllocateDevice_S` is defined in line 304. It firstly allocates memory on the device in line 320:
     call AllocateDevice ( S % nValues * S % nVariables, S % D_Value )
and then it creates the link between host and device memory pointers in line 325:
       call S % AssociateHost_S ( AssociateVariables )

Subroutine AssociateHost_S is defined in line 675 and it calls function AssociateHost in line 703:
        call AssociateHost ( S % D_Selected ( iV ), Variable

AssociateHost is an interface defined in file:
Modules/Basics/Devices/AssociateHost_Command.f90 . It contains wrappers for different data types. For OpenMP the C wrappers are defined in file
Modules/Basics/Devices/Device_C_OMP.f90. This file contains OpenMP C wrappers which calls `omp_target_associate_ptr` to associate device and host pointers.

In consequence, at the end of
Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90 line 65:
     call PF % AllocateDevice ( )
we allocated memory for the device. This memory is associated with host memory which is not initialized. The initialization of host memory is done in lines 69-104. We setup VX, VY and VZ host values. They should be used for setup corresponding device values in lines 106-107:
    call PF % ComputeAuxiliary ( PF % Value )
    call PF % ComputeConserved ( PF % Value )
but they are not used. OpenMP runtime detects that there is established link between host and device memory pointers. That's why it doesn't use the updated host values. It computes device auxilary items on the basis of uninitialized device values.

2) Consequences of uses of wrong data
Wrong device values cause that the time step is wrongly calculated (-Inf) in subroutine Evolve (
file: Programs/Examples/Basics/FluidDynamics/ConservationLawEvolution_Template.f90). The loop in line 205 becomes infinite loop because of wrong calculation of time step if FinishCycle param is not set.

3) Proposed fix

That's why if we force update the host and device
values in Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90 then we can properly calculate time step in Evolve procedure.