### PR TITLE
[build_supp] - Update cmake version to 3.25.2

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -403,7 +403,7 @@ function buildfftw(){
 
 function buildcmake(){
   _cname="cmake"
-  _version=3.22.1
+  _version=3.25.2
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname 


### PR DESCRIPTION
This is mainly for the upcoming build of Ubuntu 24.04. CMake 3.22 is not aware of the newer python3 version that is the default on 24.04 and fails to find the python
headers/libraries.