### PR TITLE
[GenASiS] Fix host version of GenASiS

### DIFF
--- a/bin/patches/genasis.patch
+++ b/bin/patches/genasis.patch
@@ -1,12 +1,3 @@
-diff --git a/Build/Preprocessor b/Build/Preprocessor
-index 5a66aa14..0a11c950 100644
---- a/Build/Preprocessor
-+++ b/Build/Preprocessor
-@@ -1,3 +1,4 @@
-+#define ENABLE_OMP_OFFLOAD 1
- #ifdef ENABLE_OMP_OFFLOAD
- #define OMP_TARGET_DIRECTIVE target teams distribute
- #define OMP_SCHEDULE_TARGET static, 1
 diff --git a/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90 b/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90
 index eba18541..6d430130 100644
 --- a/Modules/Basics/DataManagement/ArrayOperations/Clear_Command.f90
@@ -283,15 +274,19 @@ diff --git a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.
 index a2d813c..335e77b 100644
 --- a/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
 +++ b/Programs/Examples/Basics/FluidDynamics/PlaneWaveAdvection_Template.f90
-@@ -102,9 +102,11 @@ contains
+@@ -104,8 +104,14 @@ contains
      VZ = K ( 3 ) / ( dot_product ( K, K ) * Period )
 
      end associate !-- K
 
-+    call PF % UpdateDevice ( )
++#ifdef ENABLE_OMP_OFFLOAD
++      call PF % UpdateDevice ( )
++#endif
      call PF % ComputeAuxiliary ( PF % Value )
      call PF % ComputeConserved ( PF % Value )
-+    call PF % UpdateHost ( )
++#ifdef ENABLE_OMP_OFFLOAD
++      call PF % UpdateHost ( )
++#endif
 
      !-- FIXME: Implicit do-loop array needed to workaround Cray compiler
      !          crashes for elemental function argument of array and scalar

--- a/bin/run_genasis_flang_new.sh
+++ b/bin/run_genasis_flang_new.sh
@@ -101,8 +101,13 @@ else
     exit
 fi
 
+OMP_DEFINES="-DENABLE_OMP_OFFLOAD"
+if [ "$ENABLE_OMP_OFFLOAD" -eq "0" ] ; then
+    OMP_DEFINES=
+fi
+
 export LD_LIBRARY_PATH=$AOMP/lib:$AOMPHIP/lib:$OPENMPI_DIR/lib:$LD_LIBRARY_PATH
-export FORTRAN_COMPILE="$AOMP/bin/$FLANG -c -fopenmp --offload-arch=$GPU_ID -fPIC -I$OPENMPI_DIR/lib -cpp"
+export FORTRAN_COMPILE="$AOMP/bin/$FLANG -c -fopenmp --offload-arch=$GPU_ID -fPIC -I$OPENMPI_DIR/lib -cpp $OMP_DEFINES"
 export CC_COMPILE="$AOMP/bin/clang -fPIC"
 export FORTDEV_LIBS=${FORTDEV_LIBS-"-lFortranRuntimeHostDevice"}
 export OTHER_LIBS="-lm -L$AOMP/lib -lFortranRuntime $FORTDEV_LIBS -lFortranDecimal -lomp -lomptarget -z muldefs "


### PR DESCRIPTION
Patch for SineWaveAdvection should be applied only for GenASiS - target offload version.

If we specify ENABLE_OMP_OFFLOAD=0 then we run host version and we skip fix for SineVaweAdvection target version.