### PR TITLE
[BBots] Add upstream ubu-22 Dockerfile and README

### DIFF
--- a/upstream-buildbots/README.md
+++ b/upstream-buildbots/README.md
@@ -1,0 +1,30 @@
+# Upstream Buildbot Docker Recipes
+
+This folder contains the different Dockerfiles that serve as the basis for the LLVM upstream-buildbots that we maintain.
+These files can be used to recreate the docker container images and allow a developer to reproduce build and potentially test issues locally.
+During container build time certain ROCm components are pulled-in.
+Depending on the respective container / OS, this may result in a large container image.
+
+We build the containers with a docker invocation adjacent to
+
+```
+cd Ubu22
+sudo docker build -t upstreamimages/<OS>/<version>:date -f Dockerfile .
+```
+
+For starting the container we use different CPU sets to place multiple containers on a single physical node.
+A manual start of the container should look similar to
+
+```
+sudo docker run --rm -it --network=host --device=/dev/kfd --device=/dev/dri --group-add video --cpuset-cpus 0-31 --user botworker <container-image> bash
+```
+
+## Assumptions / Requirements
+- The images require a working AMDGPU dkms / KFD to be installed in order to test work on the GPU.
+- The images assume a group id for the `render` group of `109`.
+- This is currently hardcoded in the Dockerfile.
+  If this does apply on your system, please go ahead and change that accordingly.
+  Check the group id on your machine via `cat /etc/group | grep render`.
+- The CMake cache file sets individual timeouts per test case.
+  This requires the `psutil` Python module to be installed, which is done through ansible on the buildbots.
+  When running the container manually, you can install it via `python3 -m pip install psutil`.

--- a/upstream-buildbots/Ubu22/Dockerfile
+++ b/upstream-buildbots/Ubu22/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:jammy
+
+# Install prereqs
+COPY prerequisites /tmp/prerequisites
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y $(cat /tmp/prerequisites)
+
+# Prepare ROCm installation
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+    gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+RUN apt-get update
+COPY rocm.list /etc/apt/sources.list.d/rocm.list
+COPY rocm-pin-600 /etc/apt/preferences.d/rocm-pin-600
+RUN apt-get update
+# rocminfo brings in libhsa. hsa-rocr-dev brings in the libhsa cmake targets
+RUN apt-get install -y rocm-device-libs rocm-core rocminfo hsa-rocr-dev
+
+# Update the group id inside the container to match host (and get access to GPU)
+RUN groupadd --gid 109 render
+RUN groupmod -g 109 render
+
+# Create buildbot worker user inside the container
+RUN useradd --create-home -G video,render --shell /bin/bash botworker
+
+# This is required for offload tests to find libhsa and function correctly
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH

--- a/upstream-buildbots/Ubu22/prerequisites
+++ b/upstream-buildbots/Ubu22/prerequisites
@@ -1,0 +1,17 @@
+bison
+ccache
+cmake
+ninja-build
+g++
+gcc
+git
+libffi-dev
+libgtest-dev
+libpython3.10-dev
+python3
+python3-dev
+python3-pip
+python3-setuptools
+vim
+wget
+sudo

--- a/upstream-buildbots/Ubu22/rocm-pin-600
+++ b/upstream-buildbots/Ubu22/rocm-pin-600
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600

--- a/upstream-buildbots/Ubu22/rocm.list
+++ b/upstream-buildbots/Ubu22/rocm.list
@@ -1,0 +1,1 @@
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3 jammy main


### PR DESCRIPTION
To help developers, we containerize more of our upstream testing and make the Dockerfiles publicly available. This is an effort to help to enable developers to reproduce problems on the buildbots locally.

This adds the first Dockerfile for a Ubuntu 22 based dockerized post-commit buildbot that uses the AMDGPUBot.cmake CMake cache file inside the llvm-project/offload/cmake/cache directory.