### PR TITLE
[smoke-fort] Add test for omp_target_associate_ptr

### DIFF
--- a/test/smoke-fort/Makefile
+++ b/test/smoke-fort/Makefile
@@ -67,6 +67,7 @@ TESTS_DIR = \
     flang-479382-5 \
     flang-nested-parallel-do-loops \
     flang-use-device \
+    flang-target-associate-ptr \
     hellofort-nio \
     intrin-rename-func \
     intrin-rename-sub \

--- a/test/smoke-fort/flang-target-associate-ptr/Makefile
+++ b/test/smoke-fort/flang-target-associate-ptr/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = flang-target-associate-ptr
+TESTSRC_MAIN =
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+CLANG        ?= clang
+OMP_BIN      =
+CC           = AOMP=${AOMP} AOMP_GPU=${AOMP_GPU} FLANG=${FLANG} CLANG=${CLANG} ./buildit.sh
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort/flang-target-associate-ptr/buildit.sh
+++ b/test/smoke-fort/flang-target-associate-ptr/buildit.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+AOMP=${AOMP:-/opt/rocm/llvm}
+AOMP_GPU=${AOMP_GPU:-gfx90a}
+FLANG=${FLANG:-flang-new}
+CLANG=${CLANG:-clang}
+FC=${FC:-$AOMP/bin/$FLANG}
+CC=${CC:-$AOMP/bin/$CLANG}
+EXE=flang-target-associate-ptr
+
+FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+CCLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
+
+set -x
+rm -f $EXE *.o *.mod
+$FC $DEFINES $FFLAGS -c device-c-omp.f90
+$CC $DEFINES $CCLAGS -c device-omp.c
+$FC $DEFINES $FFLAGS flang-target-associate-ptr.f90 device-c-omp.o device-omp.o -o $EXE

--- a/test/smoke-fort/flang-target-associate-ptr/device-c-omp.f90
+++ b/test/smoke-fort/flang-target-associate-ptr/device-c-omp.f90
@@ -1,0 +1,61 @@
+module Device_C
+
+  use iso_c_binding
+  
+  implicit none
+  private
+  
+  public :: &
+    AllocateTargetDouble, &
+    AssociateTargetDouble, &
+    DeallocateTarget, &
+    DisassociateTarget
+  
+  interface 
+    
+    type ( c_ptr ) function AllocateTargetDouble ( nValues ) &
+                              bind ( c, name = 'AllocateTargetDouble_OMP' )
+      use iso_c_binding
+      implicit none
+      integer ( c_int ), value :: &
+        nValues
+    end function AllocateTargetDouble
+    
+     
+    integer ( c_int ) function AssociateTargetDouble &
+                        ( Host, Device, nValues, oValue ) &
+                        bind ( c, name = 'AssociateTargetDouble_OMP' )
+    
+      use iso_c_binding
+      implicit none
+      type ( c_ptr ), value :: &
+        Host, &
+        Device
+      integer ( c_int ), value :: &
+        nValues, &
+        oValue
+    end function AssociateTargetDouble
+    
+    
+    subroutine DeallocateTarget ( Device ) bind ( c, name = 'FreeTarget_OMP' )
+      use iso_c_binding
+      implicit none
+      type ( c_ptr ), value :: &
+        Device
+    
+    end subroutine DeallocateTarget
+
+    
+    integer ( c_int ) function DisassociateTarget ( Host ) &
+                        bind ( c, name = 'DisassociateTarget_OMP' )
+    
+      use iso_c_binding
+      implicit none
+      type ( c_ptr ), value :: &
+        Host
+    end function DisassociateTarget
+    
+    
+  end interface 
+
+end module Device_C

--- a/test/smoke-fort/flang-target-associate-ptr/device-omp.c
+++ b/test/smoke-fort/flang-target-associate-ptr/device-omp.c
@@ -1,0 +1,52 @@
+#include <omp.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void *AllocateTargetDouble_OMP(int nValues) {
+  int iDevice;
+  void *D_Pointer;
+
+  D_Pointer = NULL;
+  iDevice = omp_get_default_device();
+
+  D_Pointer = omp_target_alloc(sizeof(double) * nValues, iDevice);
+
+  return D_Pointer;
+}
+
+int AssociateTargetDouble_OMP(void *Host, void *Device, int nValues,
+                              int oValue) {
+  int iDevice, retval;
+  size_t Size, Offset;
+
+  retval = -1;
+
+  Size = sizeof(double) * nValues;
+  Offset = sizeof(double) * oValue;
+  iDevice = omp_get_default_device();
+
+  retval = omp_target_associate_ptr(Host, Device, Size, Offset, iDevice);
+
+  return retval;
+}
+
+void FreeTarget_OMP(void *D_Pointer) {
+  int iDevice;
+
+  iDevice = omp_get_default_device();
+  omp_target_free(D_Pointer, iDevice);
+}
+
+int DisassociateTarget_OMP(void *Host) {
+  int iDevice, retval;
+
+  retval = -1;
+
+  iDevice = omp_get_default_device();
+
+  retval = omp_target_disassociate_ptr(Host, iDevice);
+
+  return retval;
+}
+

--- a/test/smoke-fort/flang-target-associate-ptr/flang-target-associate-ptr.f90
+++ b/test/smoke-fort/flang-target-associate-ptr/flang-target-associate-ptr.f90
@@ -1,0 +1,82 @@
+program main
+   use iso_c_binding
+   use Device_C
+interface
+subroutine testKernel ( A, B )
+  real ( 8 ), dimension ( : ), intent ( inout ) :: &
+    A
+  real ( 8 ), dimension ( : ), intent ( in ) :: &
+    B
+ 
+end subroutine testKernel
+end interface
+
+  real ( 8 ), dimension ( :, : ), pointer, contiguous :: &
+     dataArray => null (  )
+  real ( 8 ), dimension ( :, : ), pointer :: &
+      D_Scratch
+  type (c_ptr)  :: D_dataArray = c_null_ptr  !-- Device pointer to dataArray
+  integer :: i
+  integer ( c_int ) :: Error
+  allocate(dataArray(10,2))
+  ! explicitly allocate memory on the device
+  ! call OMP C runtime function:  omp_target_alloc
+  D_dataArray = AllocateTargetDouble(20)
+  call c_f_pointer (  D_dataArray, D_Scratch, [ 10, 2 ] )
+
+  ! Make link between host and device data subarrays
+  ! call OMP C runtime function: omp_target_associate_ptr
+  do iV = 1, 2
+     Error = AssociateTargetDouble ( c_loc(dataArray(:,iV)),  c_loc ( D_Scratch ( :, iV ) ), 10, 0 )
+  end do
+
+  do i = 1, size ( dataArray(:,1) )
+     dataArray(i,1) = 3
+  end do
+
+  call testKernel(dataArray(:,2),dataArray(:,1))
+
+  ! Check if 2nd column is not initialized by testKernel
+  do i = 1, size ( dataArray(:,1) )
+     if (dataArray(i,2) .eq. 3 ) then
+        print *, "2nd column should not be initialized"
+        stop 1
+     end if
+  end do
+
+  associate &
+      ( X  => dataArray ( :, 1 ) )
+  do i = 1, size ( dataArray(:,1) )
+     X(i)  = 5
+  end do
+  call testKernel(dataArray(:,2),dataArray(:,1))
+  end associate
+  ! Check if 2nd column is not initialized by testKernel
+  do i = 1, size ( dataArray(:,1) )
+     if (dataArray(i,2) .eq. 5 ) then
+        print *, "2nd column should not be initialized"
+        stop 1
+     end if
+  end do
+
+  ! Clear link between host and device data subarrays
+  ! call OMP C runtime function: omp_target_disassociate_ptr
+  do iV = 1, 2
+     Error = DisassociateTarget ( c_loc(dataArray(:,iV)))
+  end do
+  call DeallocateTarget(D_dataArray)
+  deallocate(dataArray)
+end program
+
+subroutine testKernel ( A, B ) 
+  real ( 8 ), dimension ( : ), intent ( inout ) :: &
+    A
+  real ( 8 ), dimension ( : ), intent ( in ) :: &
+    B
+  integer :: i
+!$omp target parallel do 
+  do i = 1, size ( A )
+     A(i) = B(i)
+  end do
+ end subroutine testKernel
+


### PR DESCRIPTION
OpenMP standard specifies that data copy is not needed
if there is link between host and target data pointers.
`omp_target_associate_ptr` can provide such link.
If we use this function, then there is no  data copy
to/from device before kernel launch.

See also: https://github.com/ROCm/aomp/pull/1181