### PR TITLE
[rocm-test] Enable strict sanity checks for USM tests

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -53,6 +53,11 @@ fi
 SKIP_USM=1
 export SKIP_USM=1
 export HSA_XNACK=${HSA_XNACK:-0}
+
+# Set this flag to 1 to report error instead of warning when USM tests are being
+# run on configurations that do not support USM.
+export OMPX_STRICT_SANITY_CHECKS={OMPX_STRICT_SANITY_CHECKS:-1}
+
 SUITE_LIST=${SUITE_LIST:-"examples smoke-limbo smoke smoke-asan omp5 openmpapps ovo sollve babelstream fortran-babelstream accel2023 hpc2021"}
 blockinglist="examples_fortran examples_openmp smoke smoke-limbo openmpapps sollve45 sollve50 babelstream ovo accel2023 hpc2021"
 else


### PR DESCRIPTION
An error should be reported instead of a warning when an USM test is being launched on configurations which do not support unified shared memory.