### PR TITLE
[Test] Add smoke test to cover new runtime envar

### DIFF
--- a/test/smoke-dev/rt-memory-threshold-env/AMDGPUMemoryManager_threshold_env.c
+++ b/test/smoke-dev/rt-memory-threshold-env/AMDGPUMemoryManager_threshold_env.c
@@ -34,5 +34,4 @@ int main() {
   return rc;
 }
 
-/// CHECK: TARGET AMDGPU RTL --> AMDGPUMemoryManager threshhold was set to:
-/// 1048576 B
+/// CHECK: TARGET AMDGPU RTL --> AMDGPUMemoryManager threshhold was set to: 1048576 B

--- a/test/smoke-dev/rt-memory-threshold-env/AMDGPUMemoryManager_threshold_env.c
+++ b/test/smoke-dev/rt-memory-threshold-env/AMDGPUMemoryManager_threshold_env.c
@@ -1,0 +1,38 @@
+#include <omp.h>
+#include <stdio.h>
+
+int main() {
+  int N = 10;
+
+  int a[N];
+  int b[N];
+
+  int i;
+
+  for (i = 0; i < N; i++)
+    a[i] = 0;
+
+  for (i = 0; i < N; i++)
+    b[i] = i;
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = b[j];
+  }
+
+  int rc = 0;
+  for (i = 0; i < N; i++)
+    if (a[i] != b[i]) {
+      rc++;
+      printf("Wrong varlue: a[%d]=%d\n", i, a[i]);
+    }
+
+  if (!rc)
+    printf("Success\n");
+
+  return rc;
+}
+
+/// CHECK: TARGET AMDGPU RTL --> AMDGPUMemoryManager threshhold was set to:
+/// 1048576 B

--- a/test/smoke-dev/rt-memory-threshold-env/Makefile
+++ b/test/smoke-dev/rt-memory-threshold-env/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = AMDGPUMemoryManager_threshold_env
+TESTSRC_MAIN = AMDGPUMemoryManager_threshold_env.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV       += LIBOMPTARGET_DEBUG=1
+RUNENV       += OMPX_AMD_MEMORY_MANAGER_THRESHOLD_EXP_2=20
+
+RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/rt-memory-threshold-env/Makefile
+++ b/test/smoke-dev/rt-memory-threshold-env/Makefile
@@ -5,8 +5,8 @@ TESTSRC_MAIN = AMDGPUMemoryManager_threshold_env.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 RUNENV       += LIBOMPTARGET_DEBUG=1
-RUNENV       += OMPX_AMD_MEMORY_MANAGER_THRESHOLD_EXP_2=20
-
+# This runtime flag sets the memory manager threshold to 2^20 = 1048576 B.
+RUNENV       += OMPX_AMD_MEMORY_MANAGER_THRESHOLD_EXP_2=20 
 RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
 
 CLANG        ?= clang


### PR DESCRIPTION
This smoke test is to cover the new runtime envar OMPX_AMD_MEMORY_MANAGER_THRESHOLD_EXP_2 which is designed for users to specify the threshold for the memory size handled by AMDGPUMemoryManager.

Please merge after the internal patch was landed.