### PR TITLE
run_rocm_test - Use package manager detection for test package download

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -172,51 +172,74 @@ if [ "$aomp" != 1 ]; then
       fi
       rm -rf $tmpdir
       mkdir -p $tmpdir
-      # Determine OS and download package not using sudo.
-      if [[ "$os_name" =~ "Ubuntu" ]] || [[ "$os_name" =~ "Debian" ]]; then
+      # Determine package manager and download package not using sudo.
+      # apt support
+      echo Testing apt...
+      apt --version && pkg_mgr_found=1 || pkg_mgr_found=0
+      if [ $pkg_mgr_found -eq 1 ]; then
+        echo Using apt package manager
         cd $tmpdir
         apt-get download $test_package_name
         test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
         dpkg -x $test_package .
         script=$(find . -type f -name 'run_rocm_test.sh')
         cd $(dirname $script)
-      # CentOS/RHEL support. CentOS 7 requires a different method.
-      elif [[ "$os_name" =~ "CentOS" ]] || [[ "$os_name" =~ "Red Hat" ]] || [[ "$os_name" =~ "Oracle Linux Server" ]] || [[ "$os_name" =~ "Alibaba Linux Server" ]]; then
-        osversion=$(cat /etc/os-release | grep -e ^VERSION_ID)
-        if [[ $osversion =~ '"7' ]]; then
-          yumdownloader --destdir=$tmpdir $test_package_name
-        else
-          yum download --destdir $tmpdir $test_package_name
+      fi
+      # dnf/yum support, CentOS 7 requires a different method.
+      if [ $pkg_mgr_found -eq 0 ]; then
+        echo Testing dnf...
+        dnf --version && pkg_mgr_found=1 || pkg_mgr_found=0
+        if [ $pkg_mgr_found -eq 1 ]; then
+          echo Using dnf package manager
+	  dnf download --destdir=$tmpdir openmp-extras-tests
+	  test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
+	  extract_rpm $test_package
         fi
-        test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
-        extract_rpm $test_package
-      # SLES support.
-      elif [[ "$os_name" =~ "SLES" ]]; then
-        local_dir=~/openmp-extras-test
-        rm -f "$local_dir"/*
-        zypper --pkg-cache-dir $local_dir download $test_package_name
-        test_package=$(ls -lt "$local_dir"/rocm/ | grep -Eo -m1 openmp-extras-tests.*)
-        cp "$local_dir"/rocm/"$test_package" $tmpdir
-        extract_rpm $test_package
-      elif [[ "$os_name" =~ "Microsoft Azure Linux" ]]; then
-	dnf download --destdir=$tmpdir openmp-extras-tests
-	test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
-	extract_rpm $test_package
-      else
-        echo "Error: Could not determine operating system package manager type."
+      fi
+      if [ $pkg_mgr_found -eq 0 ]; then
+        echo Testing yum...
+        yum --version && pkg_mgr_found=1 || pkg_mgr_found=0
+        if [ $pkg_mgr_found -eq 1 ]; then
+          echo Using yum package manager
+          osversion=$(cat /etc/os-release | grep -e ^VERSION_ID)
+          if [[ $osversion =~ '"7' ]]; then
+            yumdownloader --destdir=$tmpdir $test_package_name
+          else
+            yum download --destdir $tmpdir $test_package_name
+          fi
+          test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
+          extract_rpm $test_package
+        fi
+      fi
+      # zypper support
+      if [ $pkg_mgr_found -eq 0 ]; then
+        echo Testing zypper...
+        zypper --version && pkg_mgr_found=1 || pkg_mgr_found=0
+        if [ $pkg_mgr_found -eq 1 ]; then
+          echo Using zypper package manager
+          local_dir=~/openmp-extras-test
+          rm -f "$local_dir"/*
+          zypper --pkg-cache-dir $local_dir download $test_package_name
+          test_package=$(ls -lt "$local_dir"/rocm/ | grep -Eo -m1 openmp-extras-tests.*)
+          cp "$local_dir"/rocm/"$test_package" $tmpdir
+          extract_rpm $test_package
+        fi
+      fi
+      if [ $pkg_mgr_found -eq 0 ]; then
+        echo "Error: Could not determine package manager type."
         exit 1
       fi
-    # Environment already has test package
+    # Environment already has test package, use it
     else
       rm -rf $tmpdir
       mkdir -p $tmpdir
       cp -ra "$ROCMINF"/share/openmp-extras/tests $tmpdir
       cd $tmpdir/tests/bin
     fi
-  ./rocm_quick_check.sh
-  export SKIP_TEST_PACKAGE=1
-  ./run_rocm_test.sh
-  exit $?
+    ./rocm_quick_check.sh
+    export SKIP_TEST_PACKAGE=1
+    ./run_rocm_test.sh
+    exit $?
   fi
 fi
 echo $AOMP $REAL_AOMP using test branch $TEST_BRANCH

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -164,6 +164,8 @@ if [ "$aomp" != 1 ]; then
   os_name=$(cat /etc/os-release | grep NAME)
   test_package_name="openmp-extras-tests"
   if [ "$SKIP_TEST_PACKAGE" != 1 ] && [ "$TEST_BRANCH" == "" ]; then
+    export debsupport=0
+    export rpmsupport=0
     git --no-pager log -1
     if [ ! -e "$ROCMINF/share/openmp-extras/tests/bin/run_rocm_test.sh" ]; then
       if [ "$EPSDB" == "1" ]; then
@@ -184,6 +186,7 @@ if [ "$aomp" != 1 ]; then
         dpkg -x $test_package .
         script=$(find . -type f -name 'run_rocm_test.sh')
         cd $(dirname $script)
+        export debsupport=1
       fi
       # dnf/yum support, CentOS 7 requires a different method.
       if [ $pkg_mgr_found -eq 0 ]; then
@@ -191,9 +194,10 @@ if [ "$aomp" != 1 ]; then
         dnf --version && pkg_mgr_found=1 || pkg_mgr_found=0
         if [ $pkg_mgr_found -eq 1 ]; then
           echo Using dnf package manager
-	  dnf download --destdir=$tmpdir openmp-extras-tests
-	  test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
-	  extract_rpm $test_package
+          dnf download --destdir=$tmpdir openmp-extras-tests
+          test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
+          extract_rpm $test_package
+          export rpmsupport=1
         fi
       fi
       if [ $pkg_mgr_found -eq 0 ]; then
@@ -209,6 +213,7 @@ if [ "$aomp" != 1 ]; then
           fi
           test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
           extract_rpm $test_package
+          export rpmsupport=1
         fi
       fi
       # zypper support
@@ -223,6 +228,7 @@ if [ "$aomp" != 1 ]; then
           test_package=$(ls -lt "$local_dir"/rocm/ | grep -Eo -m1 openmp-extras-tests.*)
           cp "$local_dir"/rocm/"$test_package" $tmpdir
           extract_rpm $test_package
+          export rpmsupport=1
         fi
       fi
       if [ $pkg_mgr_found -eq 0 ]; then
@@ -370,11 +376,11 @@ function getversion(){
     ompextrasregex="openmp-extras-?[a-z]*-?\s*[0-9]+\.([0-9]+)\.([0-9]+)"
     rpmregex="Red Hat|CentOS|SLES|Oracle Linux Server|Microsoft Azure Linux|Alibaba Linux Server"
     echo $osname
-    if [[ "$osname" =~ $rpmregex ]]; then
-      echo "Red Hat/CentOS/SLES/Oracle/Microsoft Azure/Alibaba Linux Server found"
+    if [ $rpmsupport -eq 1 ]; then
+      echo "OS with rpm support found"
       ompextraspkg=$(rpm -qa | grep openmp-extras | tail -1)
-    elif [[ "$os_name" =~ "Ubuntu" ]] || [[ "$os_name" =~ "Debian" ]]; then
-      echo "Ubuntu/Debian found"
+    elif [ $debsupport -eq 1 ]; then
+      echo "OS with deb support found"
       ompextraspkg=$(dpkg --list | grep openmp-extras | tail -1)
     fi
     if [[ "$ompextraspkg" =~ $ompextrasregex ]]; then


### PR DESCRIPTION
If new OS support is added the script would fall over. We now try to determine the package manager to cover a wider range of operating systems.