### PR TITLE
[OpenMP test] Rename -lFortranRuntime to -lflang_rt.runtime

### DIFF
--- a/bin/build_llvm-flang-rt-host-dev.sh
+++ b/bin/build_llvm-flang-rt-host-dev.sh
@@ -4,7 +4,7 @@
 #
 #   Standalone script to build the flang runtime with host-device support
 #   This script should only be run after build_aomp.sh
-#   Installs in: ${AOMP}/lib/libFortranRuntimeHostDevice.a
+#   Installs in: ${AOMP}/lib/libflang_rt.hostdevice.a
 #
 # References:
 #

--- a/bin/run_genasis_flang_new.sh
+++ b/bin/run_genasis_flang_new.sh
@@ -109,8 +109,8 @@ fi
 export LD_LIBRARY_PATH=$AOMP/lib:$AOMPHIP/lib:$OPENMPI_DIR/lib:$LD_LIBRARY_PATH
 export FORTRAN_COMPILE="$AOMP/bin/$FLANG -c -fopenmp --offload-arch=$GPU_ID -fPIC -I$OPENMPI_DIR/lib -cpp $OMP_DEFINES"
 export CC_COMPILE="$AOMP/bin/clang -fPIC"
-export FORTDEV_LIBS=${FORTDEV_LIBS-"-lFortranRuntimeHostDevice"}
-export OTHER_LIBS="-lm -L$AOMP/lib -lFortranRuntime $FORTDEV_LIBS -lFortranDecimal -lomp -lomptarget -z muldefs "
+export FORTDEV_LIBS=${FORTDEV_LIBS-"-lflang_rt.hostdevice"}
+export OTHER_LIBS="-lm -L$AOMP/lib -lflang_rt.runtime $FORTDEV_LIBS -lomp -lomptarget -z muldefs "
 export FORTRAN_LINK="$AOMP/bin/clang $OTHER_LIBS"
 export DEVICE_COMPILE="$AOMPHIP/bin/hipcc -D__HIP_PLATFORM_HCC__"
 export HIP_DIR=$ROCM

--- a/test/smoke-fort-fails/rocm-issue-201/Makefile
+++ b/test/smoke-fort-fails/rocm-issue-201/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -lFortranRuntimeHostDevice
+CFLAGS       = -lflang_rt.hostdevice
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/flang-462537/Makefile
+++ b/test/smoke-fort/flang-462537/Makefile
@@ -16,4 +16,4 @@ flang-462537: $(TESTSRC_ALL)
 	$(CC) $(OMP_FLAGS) -c constants.f90
 	$(CC) $(OMP_FLAGS) -c flang-462537.f90
 	ar r constants.a constants.o
-	$(AOMP)/bin/$(CLANG) -lm -L$(AOMP)/lib -lFortranRuntime -lFortranDecimal -lomp -lomptarget $(OMP_FLAGS) -o flang-462537 flang-462537.o constants.a
+	$(AOMP)/bin/$(CLANG) -lm -L$(AOMP)/lib -lflang_rt.runtime -lomp -lomptarget $(OMP_FLAGS) -o flang-462537 flang-462537.o constants.a

--- a/test/smoke-fort/flang-464660-1/Makefile
+++ b/test/smoke-fort/flang-464660-1/Makefile
@@ -13,4 +13,4 @@ include ../Makefile.rules
 
 flang-464660-1: $(TESTSRC_ALL)
 	$(CC) $(OMP_FLAGS) -O2 -c flang-464660-1.f90
-	$(AOMP)/bin/$(CLANG) -lm -L$(AOMP)/lib -lFortranRuntime -lFortranDecimal -lomp -lomptarget $(OMP_FLAGS) -o $@ flang-464660-1.o
+	$(AOMP)/bin/$(CLANG) -lm -L$(AOMP)/lib -lflang_rt.runtime -lomp -lomptarget $(OMP_FLAGS) -o $@ flang-464660-1.o

--- a/test/smoke-fort/flang-464660-2/Makefile
+++ b/test/smoke-fort/flang-464660-2/Makefile
@@ -9,7 +9,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        ?= flang-new
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-OMP_FLAGS   += -lFortranRuntimeHostDevice
+OMP_FLAGS   += -lflang_rt.hostdevice
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fort/flang-use-device/Makefile
+++ b/test/smoke-fort/flang-use-device/Makefile
@@ -14,4 +14,4 @@ include ../Makefile.rules
 flang-use-device: $(TESTSRC_ALL)
 	$(AOMP)/bin/$(CLANG) $(VERBOSE) $(OMP_FLAGS) -c use-device_c.c
 	$(AOMP)/bin/$(FLANG) $(VERBOSE) $(OMP_FLAGS) -c use-device_fortran.f90
-	$(AOMP)/bin/$(CLANG)  -L$(AOMP)/lib -lFortranRuntime -lFortranDecimal  -lm  $(OMP_FLAGS) -lomptarget use-device_c.o use-device_fortran.o -o ${TESTNAME}
+	$(AOMP)/bin/$(CLANG)  -L$(AOMP)/lib -lflang_rt.runtime -lm  $(OMP_FLAGS) -lomptarget use-device_c.o use-device_fortran.o -o ${TESTNAME}


### PR DESCRIPTION
    - Rename -lFortranRuntimeHostDevice to -lflang_rt.hostdevice
    - Remove -lFortranDecimal since now included in -lflang_rt.runtime