### PR TITLE
Allow AOMP env var to end in lib/llvm.

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -31,14 +31,25 @@ AOMP_VERSION_STRING=${AOMP_VERSION_STRING:-"$AOMP_VERSION-$AOMP_VERSION_MOD"}
 ROCM_EXPECTED_MODVERSION=${ROCM_EXPECTED_MODVERSION:-6.2.4}
 export AOMP_VERSION_STRING AOMP_VERSION AOMP_VERSION_MOD ROCM_VERSION ROCM_EXPECTED_MODVERSION
 
-# Set install directory and the link directory.
-# AOMP will be a symbolic link AOMP_INSTALL_DIR is the versioned dir name
-AOMP=${AOMP:-$HOME/rocm/aomp}
-AOMP_INSTALL_DIR=${AOMP}_${AOMP_VERSION_STRING}
+# Determine AOMP_INSTALL_DIR based on AOMP and if AOMP ends in lib/llvm
+# strip off the lib/llvm. BUILD scripts should only use AOMP_INSTALL_DIR, not AOMP.
 
-# For example, if AOMP_REPOS=$HOME/git/aomp11, then the primary aomp repo
-# is stored in $HOME/git/aomp11/aomp and the mono repo is stored in
-# $HOME/aomp/llvm-project.
+# NOTE regarding test scripts and test makefiles:
+# TEST scripts or Makefiles should use AOMP env variable to find the compiler
+# and runtimes. AOMP has a historic default to $HOME/rocm/aomp. But with the
+# new convention, that follows the ROCm directory structure, AOMP should really
+# be set to $HOME/rocm/aomp/lib/llvm. Some test scripts detect this historic
+# default and add the lib/llvm to find the compiler. Since AOMP uses the same
+# directory structure as /opt/rocm, setting AOMP=/opt/rocm/lib/llvm will use the
+# ROCm compiler.
+
+AOMP=${AOMP:-$HOME/rocm/aomp} # Assume test scripts will correct this.
+
+# In case AOMP ws preset and ends in lib/llvm (like most testers correctly do),
+# strip off the lib/llvm to determine AOMP_INSTALL_DIR.
+_aomp_libllvm_stripped=${AOMP%*\/lib\/llvm}
+AOMP_INSTALL_DIR=${AOMP_INSTALL_DIR:-${_aomp_libllvm_stripped}_${AOMP_VERSION_STRING}}
+
 AOMP_MAJOR_VERSION=${AOMP_VERSION%.*}
 export AOMP_MAJOR_VERSION
 AOMP_REPOS=${AOMP_REPOS:-${HOME}/git/aomp${AOMP_VERSION}}
@@ -170,6 +181,10 @@ AOMP_CXX_COMPILER=${AOMP_CXX_COMPILER:-$GCCXX}
 # Non standalone builds are done with ROCm builds.
 AOMP_STANDALONE_BUILD=${AOMP_STANDALONE_BUILD:-1}
 
+# BUILD scripts use the higher level AOMP_INSTALL_DIR for NON-compiler COMPONENTS
+# such as HIP, debugger, and profiler.  Compiler COMPONENTS are installed into
+# the lower level LLVM_INSTALL_LOC . If LLVM_INSTALL_LOC is not set, it defaults
+# to AOMP_INSTALL_DIR/lib/llvm. We strongly recommend NOT overriding LLVM_INSTALL_LOC.
 if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
   LLVM_INSTALL_LOC=$AOMP_INSTALL_DIR/lib/llvm
 else

--- a/bin/build_flang-classic.sh
+++ b/bin/build_flang-classic.sh
@@ -84,14 +84,16 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   help_build_aomp
 fi
 
-if [ $AOMP_STANDALONE_BUILD == 1 ] ; then 
-   if [ ! -L $AOMP ] ; then 
-     if [ -d $AOMP ] ; then 
-        echo "ERROR: Directory $AOMP is a physical directory."
-        echo "       It must be a symbolic link or not exist"
-        exit 1
-     fi
-   fi
+if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
+  _aomp_libllvm_stripped=${AOMP%*\/lib\/llvm}
+  if [ ! -L $_aomp_libllvm_stripped ] ; then
+    if [ -d $_aomp_libllvm_stripped ] ; then
+      echo "ERROR: Directory $_aomp_libllvm_stripped is a physical directory."
+      echo "       It must be a symbolic link or not exist"
+      echo "       Specify a different value for AOMP env variable"
+      exit 1
+    fi
+  fi
 fi
 
 # Make sure we can update the install directory

--- a/bin/build_llvm-classic.sh
+++ b/bin/build_llvm-classic.sh
@@ -92,10 +92,12 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
 fi
 
 if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
-   if [ ! -L $AOMP ] ; then
-     if [ -d $AOMP ] ; then
-        echo "ERROR: Directory $AOMP is a physical directory."
+   _aomp_libllvm_stripped=${AOMP%*\/lib\/llvm}
+   if [ ! -L $_aomp_libllvm_stripped ] ; then
+     if [ -d $_aomp_libllvm_stripped ] ; then
+        echo "ERROR: Directory $_aomp_libllvm_stripped is a physical directory."
         echo "       It must be a symbolic link or not exist"
+        echo "       Specify a different value for AOMP env variable"
         exit 1
      fi
    fi

--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -140,10 +140,12 @@ if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
 fi
 
 if [ $AOMP_STANDALONE_BUILD == 1 ] ; then 
-   if [ ! -L $AOMP ] ; then 
-     if [ -d $AOMP ] ; then 
-        echo "ERROR: Directory $AOMP is a physical directory."
+   _aomp_libllvm_stripped=${AOMP%*\/lib\/llvm}
+   if [ ! -L $_aomp_libllvm_stripped ] ; then
+     if [ -d $_aomp_libllvm_stripped ] ; then
+        echo "ERROR: Directory $_aomp_libllvm_stripped is a physical directory."
         echo "       It must be a symbolic link or not exist"
+        echo "       Specify a different value for AOMP env variable"
         exit 1
      fi
    fi
@@ -258,12 +260,12 @@ if [ "$1" == "install" ] ; then
    fi
    if [ $AOMP_STANDALONE_BUILD == 1 ] ; then 
       echo " "
-      echo "------ Linking $INSTALL_PROJECT to $AOMP -------"
-      if [ -L $AOMP ] ; then 
-         $SUDO rm $AOMP   
+      _aomp_libllvm_stripped=${AOMP%*\/lib\/llvm}
+      echo "------ Linking $AOMP_INSTALL_DIR to $_aomp_libllvm_stripped -------"
+      if [ -L $_aomp_libllvm_stripped ] ; then
+         $SUDO rm $_aomp_libllvm_stripped
       fi
-      $SUDO ln -sf $AOMP_INSTALL_DIR $AOMP
-
+      $SUDO ln -sf $AOMP_INSTALL_DIR $_aomp_libllvm_stripped
    fi
 
    # add executables forgot by make install but needed for testing


### PR DESCRIPTION
Historically the AOMP environment variable was intended to indicate where to install the AOMP compiler, AND for test scripts to identify where the compiler to test is found.   For example clang++ is in $AOMP/bin/clang++.   But we made a change to build and install AOMP using the ROCm installation directory structure, where compiler components go in the directory lib/llvm.   Build scripts were changed to install compiler components in $AOMP_INSTALL_DIR/lib/llvm and non-compiler components such as debugger, hipcc, etc get installed in $AOMP_INSTALL_DIR .  For the most part, we did NOT change testing scripts.   That is, they expect to find clang++ at $AOMP/bin/clang++ etc.   So for testing, AOMP should be set to AOMP_INSTALL_DIR/lib/llvm.    

But what about build?  What should AOMP be set to?  We need to assume that AOMP is always pointing to the lowerer level directory (./lib/llvm) where the compiler is installed.   This allows us to test ROCm, and trunk-built compilers.   So if you dont want the script default to AOMP, set it to $HOME/rocm/aomp/lib/llvm.    This set of changes will set AOMP_INSTALL_DIR to the higher level directory by setting AOMP_INSTALL_DIR to AOMP stripped of "lib/llvm" and adding on the version number.  It also enforces that the stripped directory (without the version number) does not exist or is a symbolic link.   The build_project.sh script will continue to link the versioned directory (e.g. aomp__21.0-0) to the stripped directory (aomp) upon successful compiler installation to AOMP_INSTALL_DIR/lib/llvm. 

There are clarifying comments added to aomp_common_var.  

