### PR TITLE
[AOMP] Allow override of AOMP_OPENMPVV_REPO_NAME

### DIFF
--- a/bin/run_OpenMP_VV.sh
+++ b/bin/run_OpenMP_VV.sh
@@ -5,7 +5,7 @@
 
 ulimit -t 120
 
-AOMP_OPENMPVV_REPO_NAME=OpenMP_VV
+AOMP_OPENMPVV_REPO_NAME=${AOMP_OPENMPVV_REPO_NAME:-OpenMP_VV}
 
 # --- Start standard header to set AOMP environment variables ----
 realpath=`realpath $0`


### PR DESCRIPTION
This patch allows AOMP_OPENMPVV_REPO_NAME to be overridden in run_openmpvv.sh.  An alternative might be just to remove the line, if that's preferable.