### PR TITLE
Added 3 tests with min/max reduction using fmin/fmax.

### DIFF
--- a/test/smoke-dev/xteam-red-min-max-calls-target-fast/Makefile
+++ b/test/smoke-dev/xteam-red-min-max-calls-target-fast/Makefile
@@ -1,0 +1,17 @@
+include ../../Makefile.defs
+
+TESTNAME     = xteam-red-min-max-calls
+TESTSRC_MAIN = xteam-red-min-max-calls.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+CFLAGS      += -fopenmp-target-fast
+EXTRA_LDFLAGS     += -lm
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/xteam-red-min-max-calls-target-fast/xteam-red-min-max-calls.c
+++ b/test/smoke-dev/xteam-red-min-max-calls-target-fast/xteam-red-min-max-calls.c
@@ -1,0 +1,67 @@
+/*
+ * Test min/max reduction using fmin/fmax with unrelated calls in
+ * the kernels. Compile using -fopenmp-target-fast.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10000;
+
+  int a[N];
+
+  for (int i=0; i<N; i++)
+    a[i]=i+11;
+
+  int max1, max2, max3;
+  max1 = max2 = max3 = 0;
+  int min1, min2, min3;
+  min1 = min2 = min3 = 1000000;
+
+#pragma omp target teams distribute parallel for reduction(max : max1)
+  for (int j = 0; j < N; j = j + 1)
+  {
+    a[j] = abs(a[j]);
+    max1 = fmax(max1, a[j]);
+  }
+
+#pragma omp target teams distribute parallel for reduction(max : max2)
+  for (int j = 0; j < N; j = j + 1)
+    max2 = abs((int)fmax(max2, a[j]));
+
+#pragma omp target teams distribute parallel for reduction(max : max3)
+  for (int j = 1; j < N; j = j + 1)
+    max3 = fmax(max3, abs(a[j]));
+
+#pragma omp target teams distribute parallel for reduction(min : min1)
+  for (int j = 0; j < N; j = j + 1)
+  {
+    a[j] = abs(a[j]);
+    min1 = fmin(min1, a[j]);
+  }
+
+#pragma omp target teams distribute parallel for reduction(min : min2)
+  for (int j = 0; j < N; j = j + 1)
+    min2 = abs((int)fmin(min2, a[j]));
+
+#pragma omp target teams distribute parallel for reduction(min : min3)
+  for (int j = 1; j < N; j = j + 1)
+    min3 = fmin(min3, abs(a[j]));
+
+    printf("max1 = %d max2 = %d max3 = %d\n", max1, max2, max3);
+    printf("min1 = %d min2 = %d min3 = %d\n", min1, min2, min3);
+
+  int rc = (max1 != 10010) || (max2 != 10010) || (max3 != 10010) || (min1 != 11) || (min2 != 11) || (min3 != 12);
+
+  if (!rc)
+    printf("Success\n");
+  else
+    printf("Failed\n");
+
+  return rc;
+}
+
+

--- a/test/smoke-dev/xteam-red-min-max-calls/Makefile
+++ b/test/smoke-dev/xteam-red-min-max-calls/Makefile
@@ -1,0 +1,16 @@
+include ../../Makefile.defs
+
+TESTNAME     = xteam-red-min-max-calls
+TESTSRC_MAIN = xteam-red-min-max-calls.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+EXTRA_LDFLAGS     += -lm
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/xteam-red-min-max-calls/xteam-red-min-max-calls.c
+++ b/test/smoke-dev/xteam-red-min-max-calls/xteam-red-min-max-calls.c
@@ -1,0 +1,67 @@
+/*
+ * Test min/max reduction using fmin/fmax with unrelated calls in
+ * the kernels. Compile using -O3.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 10000;
+
+  int a[N];
+
+  for (int i=0; i<N; i++)
+    a[i]=i+11;
+
+  int max1, max2, max3;
+  max1 = max2 = max3 = 0;
+  int min1, min2, min3;
+  min1 = min2 = min3 = 1000000;
+
+#pragma omp target teams distribute parallel for reduction(max : max1)
+  for (int j = 0; j < N; j = j + 1)
+  {
+    a[j] = abs(a[j]);
+    max1 = fmax(max1, a[j]);
+  }
+
+#pragma omp target teams distribute parallel for reduction(max : max2)
+  for (int j = 0; j < N; j = j + 1)
+    max2 = abs((int)fmax(max2, a[j]));
+
+#pragma omp target teams distribute parallel for reduction(max : max3)
+  for (int j = 1; j < N; j = j + 1)
+    max3 = fmax(max3, abs(a[j]));
+
+#pragma omp target teams distribute parallel for reduction(min : min1)
+  for (int j = 0; j < N; j = j + 1)
+  {
+    a[j] = abs(a[j]);
+    min1 = fmin(min1, a[j]);
+  }
+
+#pragma omp target teams distribute parallel for reduction(min : min2)
+  for (int j = 0; j < N; j = j + 1)
+    min2 = abs((int)fmin(min2, a[j]));
+
+#pragma omp target teams distribute parallel for reduction(min : min3)
+  for (int j = 1; j < N; j = j + 1)
+    min3 = fmin(min3, abs(a[j]));
+
+    printf("max1 = %d max2 = %d max3 = %d\n", max1, max2, max3);
+    printf("min1 = %d min2 = %d min3 = %d\n", min1, min2, min3);
+
+  int rc = (max1 != 10010) || (max2 != 10010) || (max3 != 10010) || (min1 != 11) || (min2 != 11) || (min3 != 12);
+
+  if (!rc)
+    printf("Success\n");
+  else
+    printf("Failed\n");
+
+  return rc;
+}
+
+

--- a/test/smoke-dev/xteam-red-min-max-nested/Makefile
+++ b/test/smoke-dev/xteam-red-min-max-nested/Makefile
@@ -1,0 +1,16 @@
+include ../../Makefile.defs
+
+TESTNAME     = xteam-red-min-max-nested
+TESTSRC_MAIN = xteam-red-min-max-nested.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+
+EXTRA_LDFLAGS     += -lm
+CLANG        = clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/xteam-red-min-max-nested/xteam-red-min-max-nested.c
+++ b/test/smoke-dev/xteam-red-min-max-nested/xteam-red-min-max-nested.c
@@ -1,0 +1,50 @@
+/*
+ * Test min/max reduction using fmin/fmax but multiple occurences 
+ * of the reduction variables and in nested scopes.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <omp.h>
+
+int main()
+{
+  int N = 1000;
+
+  int a[N];
+  int b[N][N];
+
+  for (int i = 0; i < N; i++)
+  {
+    a[i] = i + 11;
+    for (int j = 0; j < N; ++j)
+      b[i][j] = i + j + 3;
+  }
+
+  int max1 = 0;
+  int min1 = 1000000;
+
+#pragma omp target teams distribute parallel for reduction(max : max1) reduction(min : min1)
+  for (int i = 0; i < N; i = i + 1)
+  {
+    max1 = fmax(max1, a[i]);
+    min1 = fmin(min1, a[i]);
+    for (int j = 0; j < N; ++j)
+    {
+      max1 = fmax(b[i][j], max1);
+      min1 = fmin(min1, b[i][j]);
+    }
+  }
+
+  printf("max1 = %d min1 = %d\n", max1, min1);
+  int rc = (max1 != 2001) || (min1 != 3);
+
+  if (!rc)
+    printf("Success\n");
+  else
+    printf("Failed\n");
+
+  return rc;
+}
+
+


### PR DESCRIPTION
(1) Uses unrelated calls in the kernel and is built at default -O3 (2) Same as above but uses -fopenmp-target-fast
(3) Multiple min/max reduction variables at nested scopes.