### PR TITLE
[smoke-fort-fails] Add test case for flang_red_bug_51

### DIFF
--- a/test/smoke-fort-fails/Makefile
+++ b/test/smoke-fort-fails/Makefile
@@ -18,6 +18,7 @@ TESTS_DIR = \
     flang-gpu-stop-string \
     flang-gpu-exit \
     flang-gpu-abort \
+    flang_red_bug_51 \
     mathquad-tgt \
     rocm-aomp-issue-842 \
     rocm-issue-208 \

--- a/test/smoke-fort-fails/flang_red_bug_51/Makefile
+++ b/test/smoke-fort-fails/flang_red_bug_51/Makefile
@@ -1,0 +1,17 @@
+# NOOPT        = 1
+# NOOMP        = 1
+# OMP_FLANGS   = -DNO_OMP
+include ../../Makefile.defs
+
+TESTNAME     = flang_red_bug_51
+TESTSRC_MAIN = flang_red_bug_51.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang_red_bug_51/flang_red_bug_51.f90
+++ b/test/smoke-fort-fails/flang_red_bug_51/flang_red_bug_51.f90
@@ -1,0 +1,48 @@
+program main
+
+  use omp_lib
+
+  IMPLICIT NONE
+
+  integer :: count1, count2, rkm
+  integer :: counts_team
+
+
+  count1 = 0
+  !$OMP TARGET TEAMS MAP(tofrom: count1) PRIVATE(counts_team, rkm)
+       counts_team = 0
+       !$OMP PARALLEL
+            !$OMP DO 
+            DO rkm = 1,4
+                 !$OMP ATOMIC
+                 counts_team = counts_team + 1
+            END DO
+       !$OMP END PARALLEL
+       IF (omp_get_team_num() .eq. 0 ) THEN
+           count1 = counts_team
+       END IF
+  !$OMP END TARGET TEAMS
+  if (count1.ne. 4) then
+     print *, "FAIL COUNT 1"
+     stop 1
+  endif
+
+  count2 = 0
+  !$OMP TARGET TEAMS MAP(tofrom: count1) PRIVATE(counts_team, rkm)
+       counts_team = 0
+       !$OMP PARALLEL
+            !$OMP DO REDUCTION(+:counts_team)
+            DO rkm = 1,4
+                 counts_team = counts_team + 1
+            END DO
+       !$OMP END PARALLEL
+       IF (omp_get_team_num() .eq. 0 ) THEN
+           count2 = counts_team
+       END IF
+  !$OMP END TARGET TEAMS
+  if (count2.ne. 4) then
+     print *, "FAIL COUNT 2"
+     stop 1
+  endif
+
+end program main


### PR DESCRIPTION
This test case is the Fortran equivalent of smoke-dev/red_bug_51.