### PR TITLE
[smoke-fort] Add -cpp to vadd<type> offload tests

### DIFF
--- a/test/smoke-fort/vaddt-complex2/Makefile
+++ b/test/smoke-fort/vaddt-complex2/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='complex(2)' -DCHKBYTES=4
+CFLAGS       = -cpp -DCHKTYPE='complex(2)' -DCHKBYTES=4
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-complex4/Makefile
+++ b/test/smoke-fort/vaddt-complex4/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='complex(4)' -DCHKBYTES=8
+CFLAGS       = -cpp -DCHKTYPE='complex(4)' -DCHKBYTES=8
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-complex8/Makefile
+++ b/test/smoke-fort/vaddt-complex8/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='complex(8)' -DCHKBYTES=16
+CFLAGS       = -cpp -DCHKTYPE='complex(8)' -DCHKBYTES=16
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-integer2/Makefile
+++ b/test/smoke-fort/vaddt-integer2/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='integer(2)' -DCHKBYTES=2
+CFLAGS       = -cpp -DCHKTYPE='integer(2)' -DCHKBYTES=2
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-integer4/Makefile
+++ b/test/smoke-fort/vaddt-integer4/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='integer(4)' -DCHKBYTES=4
+CFLAGS       = -cpp -DCHKTYPE='integer(4)' -DCHKBYTES=4
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-integer8/Makefile
+++ b/test/smoke-fort/vaddt-integer8/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='integer(8)' -DCHKBYTES=8
+CFLAGS       = -cpp -DCHKTYPE='integer(8)' -DCHKBYTES=8
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-real2/Makefile
+++ b/test/smoke-fort/vaddt-real2/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='real(2)' -DCHKBYTES=2
+CFLAGS       = -cpp -DCHKTYPE='real(2)' -DCHKBYTES=2
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-real4/Makefile
+++ b/test/smoke-fort/vaddt-real4/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='real(4)' -DCHKBYTES=4
+CFLAGS       = -cpp -DCHKTYPE='real(4)' -DCHKBYTES=4
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort/vaddt-real8/Makefile
+++ b/test/smoke-fort/vaddt-real8/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang-new
-CFLAGS       = -DCHKTYPE='real(8)' -DCHKBYTES=8
+CFLAGS       = -cpp -DCHKTYPE='real(8)' -DCHKBYTES=8
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases


### PR DESCRIPTION
  - flag needed for older AFAR flang-new builds