### PR TITLE
[smoke-limbo][omptest] Fix flaky behavior of omptest-device-emi

### DIFF
--- a/test/smoke-limbo/omptest-device-emi/omptest-device-emi.cpp
+++ b/test/smoke-limbo/omptest-device-emi/omptest-device-emi.cpp
@@ -937,7 +937,7 @@ TEST(VeccopyTraces, OnDeviceCallbacks_teams_distribute_parallel_for_nowait_w_tim
   OMPT_ASSERT_SET(BufferRecord, CB_DATAOP);
   OMPT_ASSERT_SET(BufferRecord, CB_DATAOP);
   OMPT_ASSERT_SET(BufferRecord, CB_DATAOP);
-  OMPT_ASSERT_SET(BufferRecord, CB_KERNEL, {5000, 40000});
+  OMPT_ASSERT_SET(BufferRecord, CB_KERNEL, {4000, 40000});
   OMPT_ASSERT_SET(BufferRecord, CB_TARGET, TARGET, END);
   OMPT_ASSERT_SET(TargetEmi, TARGET, BEGIN, 0);
   OMPT_ASSERT_SET(TargetDataOpEmi, ALLOC, BEGIN, N * sizeof(int)); // a ?


### PR DESCRIPTION
Reduced the minimum duration a specific record may take
Reason: Observed durations as low as 4800 ns (avg: 4950 ns)

Failing sub-test was:
`OnDeviceCallbacks_teams_distribute_parallel_for_nowait_w_timelimit`