### PR TITLE
[examples] Format and standardize READMEs and documentation

### DIFF
--- a/examples/openmp/atomic_vs_reduction/Makefile
+++ b/examples/openmp/atomic_vs_reduction/Makefile
@@ -1,58 +1,84 @@
 #-----------------------------------------------------------------------
 #
-#  Makefile: Cuda clang demo Makefile for both amdgcn and nvptx targets.
-#            amdgcn GPU targets begin with "gfx". nvptx targets begin
-#            with sm_.  Example: To build and run on k4000 do this:
+# This Makefile is designed to build and run OpenMP offloading examples
+# for both AMD (amdgcn) and NVIDIA (nvptx) GPU targets. 
 #
-#            export LLVM_GPU_ARCH=sm_30
-#            make run
+# Usage:
+# 1. Set the target GPU architecture using the LLVM_GPU_ARCH variable.
+#    Example: export LLVM_GPU_ARCH=sm_30
+# 2. Run `make` to build the example.
+# 3. Run `make run` to execute the example.
 #
-#  Run "make help" to see other options for this Makefile
+# Options:
+# - OFFLOAD_DEBUG=1: Enable debug mode for offloading.
+# - VERBOSE=1: Enable verbose compilation output.
+# - TEMPS=1: Save intermediate compilation and linking files.
+#
+# Cleanup:
+# Run `make clean` to remove all generated files.
+#
+# Additional Help:
+# Run `make help` to see other options for this Makefile.
+#-----------------------------------------------------------------------
+
+# Get the directory of the current Makefile
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Include helper scripts for GPU detection and installation directory
 include $(mkfile_dir)../../inc/find_gpu_and_install_dir.mk
 
+# Test name and source file
 TESTNAME = atomic_vs_reduction
 TESTSRC = atomic_vs_reduction.c
 
+# Adjust the source file path if the Makefile is invoked from a different directory
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC := $(mkfile_dir)$(TESTSRC)
 endif
 
+# Compiler and flags
 CC = $(LLVM_INSTALL_DIR)/bin/clang
-
 CFLAGS = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 
+# Enable debug mode if OFFLOAD_DEBUG is set
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
   CCENV  = env LIBRARY_PATH=$(LLVM_INSTALL_DIR)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
+# Enable verbose mode if VERBOSE is set
 ifeq ($(VERBOSE),1)
   $(info    Compilation VERBOSE Mode ON)
   CFLAGS += -v
 endif
 
+# Add a macro definition if the compiler is clang
 ifeq ($(LLVM_COMPILER_NAME),clang)
   CFLAGS += -D__LLVM_COMPILER_NAME_IS_CLANG__
 endif
 
+# Save intermediate files if TEMPS is set
 ifeq ($(TEMPS),1)
   $(info    Compilation and linking save-temp Mode ON)
   CFLAGS += -save-temps 
 endif
 
+# Append any extra flags passed via EXTRA_CFLAGS
 CFLAGS += $(EXTRA_CFLAGS)
 
+# Build target
 $(TESTNAME): $(TESTSRC)
 	$(CCENV) $(CC) $(CFLAGS) $(LFLAGS) $^ -o $@
 
+# Run target
 run: $(TESTNAME)
 	$(RUNENV) ./$(TESTNAME)
 
+# Include additional helper scripts
 include $(mkfile_dir)../../inc/obin.mk
 include $(mkfile_dir)../../inc/help.mk
 
-# Cleanup anything this makefile can create
+# Cleanup target
 clean:
 	rm -f $(TESTNAME) obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin

--- a/examples/openmp/atomic_vs_reduction/README.md
+++ b/examples/openmp/atomic_vs_reduction/README.md
@@ -1,7 +1,48 @@
-This example demonstrates the relative speed of an addition operations using:
+# Atomic vs Reduction Example
 
-1. OpenMP atomic with hint
-2. OpenMP atomic
-3. OpenMP reduction operation
+This example (`atomic_vs_reduction.c`) demonstrates the relative speed of addition operations using:
 
-concluding that the reduction operation is superior.
+1. **OpenMP Atomic with Hint**:
+   - Uses `#pragma omp atomic hint(AMD_fast_fp_atomics)` to perform atomic addition with a hint for fast floating-point atomic operations.
+   - This section is skipped if the compiler is not AMD's.
+
+2. **OpenMP Atomic without Hint**:
+   - Uses `#pragma omp atomic` for atomic addition without any hints.
+   - Demonstrates the performance of atomic operations using a compare-and-swap (CAS) loop.
+
+3. **OpenMP Reduction Operation**:
+   - Uses `#pragma omp target teams distribute parallel for reduction(+:variable)` to perform a reduction operation.
+   - Demonstrates the superior performance of reduction compared to atomic operations.
+
+Each section calculates the sum of integers from `0` to `N-1` and compares the result with the expected value. The execution time for each method is also measured and displayed.
+
+The example concludes that the reduction operation is superior.
+
+## Building and Running the Example
+
+### Prerequisites
+Ensure that the following are set up:
+1. The `LLVM_GPU_ARCH` environment variable is set to the target GPU architecture (e.g., `sm_30` for NVIDIA or `gfx90a` for AMD).
+2. The `LLVM_INSTALL_DIR` environment variable points to the LLVM installation directory.
+
+### Build Instructions
+To build the example, run:
+```bash
+make
+```
+
+### Run Instructions
+To execute the example, run:
+```bash
+make run
+```
+
+### Expected Output
+The output will display the results of the three operations (atomic with hint, atomic without hint, and reduction) along with their execution times. A successful run will look like this:
+```
+Success atomic with hint (AMD_fast_fp_atomics) sum of <N> integers is: <SUM> in <TIME> secs  
+Success atomic without hint (cas loop) sum of <N> integers is: <SUM> in <TIME> secs  
+Success reduction sum of <N> integers is: <SUM> in <TIME> secs
+```
+
+If there are any mismatches in the calculated sums, the output will indicate a failure.

--- a/examples/openmp/atomic_vs_reduction/atomic_vs_reduction.c
+++ b/examples/openmp/atomic_vs_reduction/atomic_vs_reduction.c
@@ -1,61 +1,82 @@
+/*
+ * atomic_vs_reduction.c
+ * 
+ * This program demonstrates the performance difference between atomic operations 
+ * and reductions in OpenMP. It calculates the sum of integers from 0 to N-1 using:
+ * 1. Atomic operations with a hint for fast floating-point atomics (if supported).
+ * 2. Atomic operations without any hint.
+ * 3. Reduction operations.
+ * 
+ * The program compares the execution time and correctness of each approach.
+ */
+
 #include <stdio.h>
 #include <omp.h>
+
 int main() {
-//
-//  atomic_vs_reduction.c: This test demonstrates how much faster reductions are than atomic operations 
-//
+  // Initialize return code and problem size
   int main_rc = 0;
-  int N       = 5001;
-  float expect = (float) (((float)N-1)*(float)N)/2.0;
+  int N = 5001; // Number of integers to sum
+  float expect = (float)(((float)N - 1) * (float)N) / 2.0; // Expected sum
 
 #if defined(__LLVM_COMPILER_NAME_IS_CLANG__)
+  // Skip fast FP atomic hint if not using AMD Compiler
   printf("Skipping fast FP atomic hint because this is not AMD Compiler\n");
 #else
-  float a    = 0.0;
+  // Test atomic operations with fast FP atomic hint
+  float a = 0.0;
   double t0 = omp_get_wtime();
-  #pragma omp target teams distribute parallel for map(tofrom:a)
-  for(int ii = 0; ii < N; ++ii) {
-    #pragma omp atomic hint(AMD_fast_fp_atomics)
-    a+=(float)ii;
+#pragma omp target teams distribute parallel for map(tofrom : a)
+  for (int ii = 0; ii < N; ++ii) {
+#pragma omp atomic hint(AMD_fast_fp_atomics)
+    a += (float)ii; // Atomic addition with hint
   }
-  double t1 = omp_get_wtime()-t0;
+  double t1 = omp_get_wtime() - t0;
+
+  // Check correctness and print results
   if (a == expect) {
-    printf("Success atomic with hint (fast FP atomic) sum of %d integers is: %f in \t\t%f secs\n",N,a,t1);
+    printf("Success atomic with hint (fast FP atomic) sum of %d integers is: %f in \t\t%f secs\n", N, a, t1);
   } else {
-    printf("FAIL ATOMIC SUM N:%d result: %f != expect: %f \n", N,a,expect);
-    main_rc=1;
+    printf("FAIL ATOMIC SUM N:%d result: %f != expect: %f \n", N, a, expect);
+    main_rc = 1;
   }
 #endif
 
-  float casa    = 0.0;
+  // Test atomic operations without any hint
+  float casa = 0.0;
   double t_cas0 = omp_get_wtime();
-  #pragma omp target teams distribute parallel for map(tofrom:casa)
-  for(int ii = 0; ii < N; ++ii) {
-    #pragma omp atomic
-    casa+=(float)ii;
+#pragma omp target teams distribute parallel for map(tofrom : casa)
+  for (int ii = 0; ii < N; ++ii) {
+#pragma omp atomic
+    casa += (float)ii; // Atomic addition without hint
   }
-  double t_cas1 = omp_get_wtime()-t_cas0;
+  double t_cas1 = omp_get_wtime() - t_cas0;
+
+  // Check correctness and print results
   if (casa == expect) {
-    printf("Success atomic without hint (cas loop) sum of %d integers is: %f in \t\t%f secs\n",N,casa,t_cas1);
+    printf("Success atomic without hint (cas loop) sum of %d integers is: %f in \t\t%f secs\n", N, casa, t_cas1);
   } else {
-    printf("FAIL ATOMIC SUM N:%d result: %f != expect: %f \n", N,casa,expect);
-    main_rc=1;
+    printf("FAIL ATOMIC SUM N:%d result: %f != expect: %f \n", N, casa, expect);
+    main_rc = 1;
   }
 
-  // Now do the sum as a reduction
+  // Test reduction operations
   float ra = 0.0;
   double t2 = omp_get_wtime();
-  #pragma omp target teams distribute parallel for reduction(+:ra) 
-  for(int ii = 0; ii < N; ++ii) {
-    ra+=(float)ii;
+#pragma omp target teams distribute parallel for reduction(+ : ra)
+  for (int ii = 0; ii < N; ++ii) {
+    ra += (float)ii; // Reduction addition
   }
   double t3 = omp_get_wtime() - t2;
 
+  // Check correctness and print results
   if (ra == expect) {
-    printf("Success reduction sum of %d integers is: %f in \t\t\t\t\t%f secs\n",N,ra,t3);
+    printf("Success reduction sum of %d integers is: %f in \t\t\t\t\t%f secs\n", N, ra, t3);
   } else {
-    printf("FAIL REDUCTION SUM N:%d result: %f != expect: %f \n", N,ra,expect);
-    main_rc=1;
+    printf("FAIL REDUCTION SUM N:%d result: %f != expect: %f \n", N, ra, expect);
+    main_rc = 1;
   }
+
+  // Return the overall result
   return main_rc;
 }

--- a/examples/openmp/declare_variant_if/Makefile
+++ b/examples/openmp/declare_variant_if/Makefile
@@ -1,55 +1,71 @@
 #-----------------------------------------------------------------------
+# Makefile for OpenMP offloading example using declare_variant_if.
+# This Makefile demonstrates building and running OpenMP programs
+# targeting both AMD GPUs (amdgcn) and NVIDIA GPUs (nvptx).
 #
-#  Makefile: Cuda clang demo Makefile for both amdgcn and nvptx targets.
-#            amdgcn GPU targets begin with "gfx". nvptx targets begin
-#            with sm_.  Example: To build and run on k4000 do this:
+# Usage:
+#   Set the target GPU architecture using LLVM_GPU_ARCH.
+#   Example: export LLVM_GPU_ARCH=sm_30
+#   Run `make run` to build and execute the program.
 #
-#            export LLVM_GPU_ARCH=sm_30
-#            make run
-#
-#  Run "make help" to see other options for this Makefile
+# Targets:
+#   - make: Builds the binary.
+#   - make run: Runs the binary.
+#   - make clean: Cleans up generated files.
+#   - make help: Displays help information.
+#-----------------------------------------------------------------------
 
 TESTNAME = declare_variant_if
 TESTSRC  = declare_variant_if.c
 
+# Determine the directory of the Makefile
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC := $(mkfile_dir)$(TESTSRC)
 endif
+
+# Include common scripts for GPU detection and installation paths
 include $(mkfile_dir)../../inc/find_gpu_and_install_dir.mk
 
+# Compiler and flags setup for OpenMP offloading
 CC = $(LLVM_INSTALL_DIR)/bin/clang
-# Sorry, clang openmp requires these complex options
+# OpenMP 5.0 requires -fopenmp-version=50 and --offload-arch for GPU targets
 CFLAGS = -O3 -fopenmp -fopenmp-version=50 --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 
+# Debug mode setup
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
   CCENV  = env LIBRARY_PATH=$(LLVM_INSTALL_DIR)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
+# Verbose mode setup
 ifeq ($(VERBOSE),1)
   $(info    Compilation VERBOSE Mode ON)
   CFLAGS += -v
 endif
 
+# Save intermediate files for debugging
 ifeq ($(TEMPS),1)
   $(info    Compilation and linking save-temp Mode ON)
   CFLAGS += -save-temps 
 endif
 
+# Add any extra flags passed via EXTRA_CFLAGS
 CFLAGS += $(EXTRA_CFLAGS)
 
-# ----- Demo compile and link in one step, no object code saved
+# Build target: Compile and link in one step
 $(TESTNAME): $(TESTSRC)
 	$(CCENV) $(CC) $(CFLAGS) $(LFLAGS) $^ -o $@
 
+# Run target: Execute the compiled binary
 run: $(TESTNAME)
 	$(RUNENV) ./$(TESTNAME)
 
+# Include additional help and utility scripts
 include $(mkfile_dir)../../inc/help.mk
 include $(mkfile_dir)../../inc/obin.mk
 
-# Cleanup anything this makefile can create
+# Cleanup target: Remove generated files
 clean:
 	rm -f $(TESTNAME) obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin

--- a/examples/openmp/declare_variant_if/README.md
+++ b/examples/openmp/declare_variant_if/README.md
@@ -1,4 +1,46 @@
+# Declare Variant with Conditional Target Offload Example
 
-This example shows that you must set -fopenmp-version=50 for OpenMP 5.0 functionality. 
-It shows how to use the if in pragmas for conditional target offload. 
-Lastly, it shows how to use function variants for different architectures.
+This example demonstrates the following:
+
+1. You must set `-fopenmp-version=50` for OpenMP 5.0 functionality.
+2. How to use the `if` clause in pragmas for conditional target offload.
+3. How to use function variants for different architectures.
+
+## Example Description
+
+The example implements the SAXPY (Single-Precision A·X Plus Y) operation using OpenMP. It demonstrates:
+
+- Conditional offloading using the `if` clause in `#pragma omp target`.
+- Architecture-specific function variants using `#pragma omp declare variant`.
+
+The base `saxpy` function runs on the host, while architecture-specific variants (`amdgcn_saxpy` and `nvptx_saxpy`) are executed on AMD and NVIDIA GPUs, respectively.
+
+## Build Instructions
+
+To build the example, run the following command:
+
+```bash
+make
+```
+
+Ensure that the `LLVM_GPU_ARCH` environment variable is set to the appropriate GPU architecture (e.g., `gfx90a` for AMD GPUs or `sm_70` for NVIDIA GPUs).
+
+## Execution Instructions
+
+To execute the example, run:
+
+```bash
+make run
+```
+
+## Expected Output
+
+The output will vary depending on the target architecture and the value of the `if` clause in the `#pragma omp target` directive. A typical output might look like:
+
+```
+Calling saxpy with high threshold for device execution
+saxpy: Running on host. IsHost:1
+Calling saxpy with low threshold for device execution
+amdgcn_saxpy: Running on amdgcn device. IsHost:0
+y[0],y[N-1]:     5   640
+```

--- a/examples/openmp/declare_variant_if/declare_variant_if.c
+++ b/examples/openmp/declare_variant_if/declare_variant_if.c
@@ -3,56 +3,75 @@
 #include <stdint.h>
 #include <omp.h>
 
-//  --- start of saxpy header with variants ---
+// The program includes host, AMDGCN, and NVPTX implementations of SAXPY
+// and uses OpenMP to select the appropriate variant based on the target device.
+
+// --- Start of SAXPY header with variants ---
 int saxpy(int, float, float *, float *);
 int amdgcn_saxpy(int, float, float *, float *);
 int nvptx_saxpy(int, float, float *, float *);
 
+// Declare architecture-specific variants for SAXPY
 #pragma omp declare variant(nvptx_saxpy) \
-  match(device = {arch(nvptx, nvptx64)}, implementation = {extension(match_any)})
-#pragma omp declare variant( amdgcn_saxpy )  \
-  match(device = {arch(amdgcn)}, implementation = {extension(match_any)})
-int saxpy(int n, float s, float *x, float *y)    // base function
-{
-   printf("saxpy: Running on host . IsHost:%d\n", omp_is_initial_device());
-   #pragma omp parallel for
-   for(int i=0; i<n; i++) y[i] = s*x[i] + y[i];
-   return 1;
+    match(device = {arch(nvptx, nvptx64)}, implementation = {extension(match_any)})
+#pragma omp declare variant(amdgcn_saxpy) \
+    match(device = {arch(amdgcn)}, implementation = {extension(match_any)})
+
+// Base SAXPY function for host execution
+int saxpy(int n, float s, float *x, float *y) {
+  printf("saxpy: Running on host. IsHost:%d\n", omp_is_initial_device());
+#pragma omp parallel for
+  for (int i = 0; i < n; i++) y[i] = s * x[i] + y[i]; // Perform SAXPY operation
+  return 1;
 }
-int amdgcn_saxpy(int n, float s, float *x, float *y)    //function variant
-{
-   printf("amdgcn_saxpY: Running on amdgcn device. IsHost:%d\n", omp_is_initial_device());
-   #pragma omp teams distribute parallel for
-   for(int i=0; i<n; i++) { y[i] = s*x[i] + y[i]; }
-   return 0;
+
+// Variant for AMDGCN devices
+int amdgcn_saxpy(int n, float s, float *x, float *y) {
+  printf("amdgcn_saxpy: Running on amdgcn device. IsHost:%d\n", omp_is_initial_device());
+#pragma omp teams distribute parallel for
+  for (int i = 0; i < n; i++) {
+    y[i] = s * x[i] + y[i]; // Perform SAXPY operation
+  }
+  return 0;
 }
-int nvptx_saxpy(int n, float s, float *x, float *y)    //function variant
-{
-   printf("nvptx_saxpy: Running on nvptx device. IsHost:%d\n",omp_is_initial_device());
-   #pragma omp teams distribute parallel for
-   for(int i=0; i<n; i++) y[i] = s*x[i] + y[i];
-   return 0;
+
+// Variant for NVPTX devices
+int nvptx_saxpy(int n, float s, float *x, float *y) {
+  printf("nvptx_saxpy: Running on nvptx device. IsHost:%d\n", omp_is_initial_device());
+#pragma omp teams distribute parallel for
+  for (int i = 0; i < n; i++) y[i] = s * x[i] + y[i]; // Perform SAXPY operation
+  return 0;
 }
-//  --- end of saxpy header with variants ----
+
+// --- End of SAXPY header with variants ---
 
 #define N 128
-#define THRESHOLD  127
+#define THRESHOLD 127
+
 int main() {
-   static float x[N],y[N] __attribute__ ((aligned(64)));
-   float s=2.0;
-   int return_code = 0 ;
+  // Allocate and align arrays
+  static float x[N], y[N] __attribute__((aligned(64)));
+  float s = 2.0;
+  int return_code = 0;
 
-   for(int i=0; i<N; i++){ x[i]=i+1; y[i]=i+1; } // initialize
- 
-   printf("Calling saxpy with high threshold for device execution\n");
-   #pragma omp target if (N>(THRESHOLD*2))
-   return_code = saxpy(N,s,x,y);
+  // Initialize arrays
+  for (int i = 0; i < N; i++) {
+    x[i] = i + 1;
+    y[i] = i + 1;
+  }
 
-   printf("Calling saxpy with low threshold for device execution\n");
-   #pragma omp target if (N>THRESHOLD)
-   return_code = saxpy(N,s,x,y); 
+  // Call SAXPY with a high threshold for device execution
+  printf("Calling saxpy with high threshold for device execution\n");
+#pragma omp target if (N > (THRESHOLD * 2))
+  return_code = saxpy(N, s, x, y);
 
-   printf("y[0],y[N-1]: %5.0f %5.0f\n",y[0],y[N-1]); //output: y...   5 640
+  // Call SAXPY with a low threshold for device execution
+  printf("Calling saxpy with low threshold for device execution\n");
+#pragma omp target if (N > THRESHOLD)
+  return_code = saxpy(N, s, x, y);
 
-   return return_code;
+  // Print results
+  printf("y[0],y[N-1]: %5.0f %5.0f\n", y[0], y[N - 1]); // Output: y[0] and y[N-1]
+
+  return return_code;
 }

--- a/examples/openmp/demo_offload_types/Makefile
+++ b/examples/openmp/demo_offload_types/Makefile
@@ -1,21 +1,25 @@
-#-----------------------------------------------------------------------
-#
+# --- Makefile for OpenMP Offload Types Demo ---
+# This Makefile demonstrates the compilation and execution of binaries
+# with different OpenMP offloading configurations, including no offload,
+# host offload, and GPU offload.
 
 TESTNAME = demo_offload_types
 TESTSRC  = $(TESTNAME).c
 
+# Determine the directory of the Makefile
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC := $(mkfile_dir)$(TESTSRC)
 endif
 include $(mkfile_dir)../../inc/find_gpu_and_install_dir.mk
 
+# Compiler and flags
 CC = $(LLVM_INSTALL_DIR)/bin/clang
-
 CFLAGS := -fopenmp
 OAFLAG := --offload-arch=$(LLVM_GPU_ARCH)
 OAQFLAG := --offload-arch=$(LLVM_GPU_ARCH):xnack+
 
+# Enable verbose mode if requested
 ifeq ($(VERBOSE),1)
   $(info    Compilation VERBOSE Mode ON)
   CFLAGS += -v
@@ -23,7 +27,8 @@ endif
 
 CFLAGS += $(EXTRA_CFLAGS)
 
-# ----- Demo compile and link in one step, no object code saved
+# --- Compilation and linking ---
+# Compile and link binaries for different offload configurations
 $(TESTNAME): $(TESTSRC)
 	@echo "------- DEMO BUILDS OF VARIOUS OFFLOAD TYPES --------"
 	@echo "1. Create binary that does not offload:	no-offload"
@@ -42,6 +47,8 @@ ifneq (sm_,$(findstring sm_,$(LLVM_GPU_ARCH)))
 	$(CC) $(CFLAGS) $(OAQFLAG) $^ -o $(TESTNAME)
 endif
 
+# --- Execution ---
+# Run the compiled binaries with different configurations
 run: $(TESTNAME)
 	@echo "------- DEMO DEFAULT EXECUTION -------"
 	@echo "1. no-offload"
@@ -103,6 +110,7 @@ else
 endif
 endif
 
-# Cleanup anything this makefile can create
+# --- Cleanup ---
+# Remove generated binaries and intermediate files
 clean:
 	rm -f $(TESTNAME) no-offload host-offload gpu-offload  obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin

--- a/examples/openmp/demo_offload_types/README.md
+++ b/examples/openmp/demo_offload_types/README.md
@@ -1,0 +1,52 @@
+# Demo Offload Types
+
+This example demonstrates the use of OpenMP target offloading with various configurations. It showcases how to compile and execute binaries for different offload types, including host-only, GPU offload, and GPU offload with `xnack+`.
+
+## Prerequisites
+
+- LLVM compiler with OpenMP support.
+- A compatible GPU and the appropriate runtime environment.
+
+## Build Instructions
+
+To build the example, run the following command:
+
+```bash
+make
+```
+
+This will generate the following binaries:
+- `no-offload`: Binary without offloading.
+- `host-offload`: Binary for host offloading (if supported).
+- `gpu-offload`: Binary for GPU offloading.
+- `demo_offload_types`: Binary for GPU offloading with `xnack+` (if applicable).
+
+## Run Instructions
+
+To execute the binaries, use the following command:
+
+```bash
+make run
+```
+
+This will run the binaries in various configurations, including:
+- Default execution.
+- Execution with `OMP_TARGET_OFFLOAD=DISABLED`.
+- Execution with `OMP_TARGET_OFFLOAD=MANDATORY`.
+
+### Example Output
+
+The output will display information about the host and target devices, including:
+- Initial and default devices.
+- Number of devices.
+- Threads and teams on the target device.
+
+## Cleanup
+
+To clean up the generated files, run:
+
+```bash
+make clean
+```
+
+This will remove all binaries and intermediate files created during the build process.

--- a/examples/openmp/demo_offload_types/demo_offload_types.c
+++ b/examples/openmp/demo_offload_types/demo_offload_types.c
@@ -1,15 +1,27 @@
 #include <omp.h>
 #include <stdio.h>
+
+// --- OpenMP Offload Types Demo ---
+// This program demonstrates the use of OpenMP offloading features.
+// It prints information about the host and target devices, including
+// the number of devices, threads, and teams available.
+
 int main() {
+  // Print host device information
   printf("   HOST:   initial_device:%d  default_device:%d   num_devices:%d\n",
          omp_get_initial_device(), omp_get_default_device(),
          omp_get_num_devices());
+
+  // Offload to target device and print device information
 #pragma omp target teams
 #pragma omp parallel
-  if ((omp_get_thread_num() == 0) && (omp_get_team_num() == 0))
+  if ((omp_get_thread_num() == 0) && (omp_get_team_num() == 0)) {
     printf("   TARGET: device_num:%d  num_devices:%d get_initial:%d  "
            "is_initial:%d \n           threads:%d  teams:%d\n",
            omp_get_device_num(), omp_get_num_devices(),
            omp_get_initial_device(), omp_is_initial_device(),
            omp_get_num_threads(), omp_get_num_teams());
+  }
+
+  return 0;
 }

--- a/examples/openmp/driver_tests/Makefile
+++ b/examples/openmp/driver_tests/Makefile
@@ -1,36 +1,58 @@
 #-----------------------------------------------------------------------
+# Makefile for OpenMP Driver Tests
 #
-#  Makefile: Cuda clang demo Makefile for both amdgcn and nvptx targets.
-#            amdgcn GPU targets begin with "gfx". nvptx targets begin
-#            with sm_.  Example: To build and run on k4000 do this:
+# This Makefile demonstrates various compiler options for building
+# OpenMP offloading applications targeting GPUs. It supports both
+# AMDGCN (e.g., gfx targets) and NVPTX (e.g., sm_ targets) architectures.
 #
-#            export LLVM_GPU_ARCH=sm_30
-#            make run
+# Usage:
+# 1. Set the target GPU architecture using the LLVM_GPU_ARCH variable.
+#    Example: export LLVM_GPU_ARCH=sm_30
+# 2. Run `make run` to compile and execute the application.
 #
-#  Run "make help" to see other options for this Makefile
+# Targets:
+# - `make`: Builds the application and generates intermediate files.
+# - `make run`: Runs the compiled application.
+# - `make clean`: Cleans up all generated files.
+#
+# Run `make help` to see additional options.
+#-----------------------------------------------------------------------
 
+# Define the test name and source file
 TESTNAME = driver_tests
 TESTSRC  = $(TESTNAME).c
 
+# Determine the directory of the Makefile
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC := $(mkfile_dir)$(TESTSRC)
 endif
+
+# Include helper script to find GPU and installation directory
 include $(mkfile_dir)../../inc/find_gpu_and_install_dir.mk
 
+# Compiler and flags
 CC = $(LLVM_INSTALL_DIR)/bin/clang
 
+# Base compiler flags for OpenMP
 CFLAGS := -fopenmp
+
+# Offload architecture flag
 OAFLAG := --offload-arch=$(LLVM_GPU_ARCH)
 
+# Enable verbose mode if VERBOSE=1
 ifeq ($(VERBOSE),1)
   $(info    Compilation VERBOSE Mode ON)
   CFLAGS += -v
 endif
 
+# Allow additional flags to be appended
 CFLAGS += $(EXTRA_CFLAGS)
 
-# ----- Demo compile and link in one step, no object code saved
+#-----------------------------------------------------------------------
+# Build target: Compile and link in one step, demonstrating various
+# compiler options and generating intermediate files.
+#-----------------------------------------------------------------------
 $(TESTNAME): $(TESTSRC)
 	@echo 
 	@echo "------- DEMO VARIOUS COMPILER OPTIONS --------"
@@ -60,9 +82,14 @@ $(TESTNAME): $(TESTSRC)
 	file $(TESTNAME)
 	@echo 
 
+#-----------------------------------------------------------------------
+# Run target: Execute the compiled application.
+#-----------------------------------------------------------------------
 run: $(TESTNAME)
 	./$(TESTNAME)
 
-# Cleanup anything this makefile can create
+#-----------------------------------------------------------------------
+# Clean target: Remove all generated files.
+#-----------------------------------------------------------------------
 clean:
 	rm -f $(TESTNAME) obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin

--- a/examples/openmp/driver_tests/README.md
+++ b/examples/openmp/driver_tests/README.md
@@ -1,0 +1,47 @@
+# Driver Tests
+
+This example demonstrates various compiler options and their outputs when using OpenMP target offloading. It showcases how to generate intermediate representations (IR), assembler files, and application binaries for both host and device.
+
+## Prerequisites
+
+- LLVM compiler with OpenMP support.
+- A compatible GPU and the appropriate runtime environment.
+
+## Build Instructions
+
+To build the example and generate various outputs, run the following command:
+
+```bash
+make
+```
+
+This will generate:
+1. Host LLVM IR (`driver_tests_host.ll`).
+2. Host LLVM bitcode (`driver_tests_host.bc`).
+3. Host assembler (`driver_tests_host.s`).
+4. Device LLVM bitcode (`driver_tests_device.bc`).
+5. Disassembled device LLVM IR (`driver_tests_device.ll`).
+6. Application binary (`driver_tests`).
+
+## Run Instructions
+
+To execute the application binary, use the following command:
+
+```bash
+make run
+```
+
+This will run the binary and display information about the host and target devices, including:
+- Initial and default devices.
+- Number of devices.
+- Threads and teams on the target device.
+
+## Cleanup
+
+To clean up the generated files, run:
+
+```bash
+make clean
+```
+
+This will remove all binaries and intermediate files created during the build process.

--- a/examples/openmp/hello/Makefile
+++ b/examples/openmp/hello/Makefile
@@ -1,14 +1,9 @@
 #-----------------------------------------------------------------------
-#
-#  Makefile: Cuda clang demo Makefile for both amdgcn and nvptx targets.
-#            amdgcn GPU targets begin with "gfx". nvptx targets begin
-#            with sm_.  Example: To build and run on k4000 do this:
-#
-#            export LLVM_GPU_ARCH=sm_30
-#            make run
-#
-#  Run "make help" to see other options for this Makefile
+# Makefile for building and running OpenMP Hello World examples.
+# Demonstrates different modes of execution using OpenMP.
+#-----------------------------------------------------------------------
 
+# Define test names and source files
 TESTNAME1 = hello1
 TESTSRC1  = hello1.c
 
@@ -24,8 +19,10 @@ TESTSRC4  = hello4.c
 TESTNAME5 = hello5
 TESTSRC5  = hello5.c
 
-
+# Determine the directory of the Makefile
 mkfile_dir := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Adjust source file paths if running out-of-tree
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC1 := $(mkfile_dir)$(TESTSRC1)
 endif
@@ -41,27 +38,32 @@ endif
 ifneq ($(CURDIR)/,$(mkfile_dir))
   TESTSRC5 := $(mkfile_dir)$(TESTSRC5)
 endif
+
+# Include helper Makefile for GPU and compiler setup
 include $(mkfile_dir)../../inc/find_gpu_and_install_dir.mk
 
+# Compiler and flags
 CC       = $(LLVM_INSTALL_DIR)/bin/clang
-
 CFLAGS1   = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 CFLAGS2   = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 CFLAGS3   = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 CFLAGS4   = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 CFLAGS5   = -O3 -fopenmp --offload-arch=$(LLVM_GPU_ARCH)$(AOMP_TARGET_FEATURES)
 
+# Enable debug mode if OFFLOAD_DEBUG is set
 ifeq ($(OFFLOAD_DEBUG),1)
   $(info    DEBUG Mode ON)
   CCENV  = env LIBRARY_PATH=$(LLVM_INSTALL_DIR)/lib-debug
   RUNENV = LIBOMPTARGET_DEBUG=1
 endif
 
+# Enable verbose mode if VERBOSE is set
 ifeq ($(VERBOSE),1)
   $(info    Compilation VERBOSE Mode ON)
   CFLAGS += -v
 endif
 
+# Enable saving temporary files if TEMPS is set
 ifeq ($(TEMPS),1)
   $(info    Compilation and linking save-temp Mode ON)
   CFLAGS += -save-temps 
@@ -69,10 +71,10 @@ endif
 
 CFLAGS += $(EXTRA_CFLAGS)
 
-#
-# ----- Demo compile and link of five variations
+# Build all examples
 all: $(TESTNAME1) $(TESTNAME2) $(TESTNAME3) $(TESTNAME4) $(TESTNAME5) 
 
+# Compile and link each example
 $(TESTNAME1): $(TESTSRC1)
 	$(CCENV) $(CC) $(CFLAGS1) $(LFLAGS) $^ -o $@
 
@@ -88,6 +90,7 @@ $(TESTNAME4): $(TESTSRC4)
 $(TESTNAME5): $(TESTSRC5)
 	$(CCENV) $(CC) $(CFLAGS5) $(LFLAGS) $^ -o $@
 
+# Run all examples
 run: $(TESTNAME1) $(TESTNAME2) $(TESTNAME3) $(TESTNAME4) $(TESTNAME5)
 	$(RUNENV) ./$(TESTNAME1)
 	$(RUNENV) ./$(TESTNAME2)
@@ -95,10 +98,11 @@ run: $(TESTNAME1) $(TESTNAME2) $(TESTNAME3) $(TESTNAME4) $(TESTNAME5)
 	$(RUNENV) ./$(TESTNAME4)
 	$(RUNENV) ./$(TESTNAME5)
 
+# Include additional helper Makefiles
 include $(mkfile_dir)../../inc/obin.mk
 include $(mkfile_dir)../../inc/help.mk
 
-# Cleanup anything this makefile can create
+# Cleanup generated files
 clean:
 	rm -f $(TESTNAME1) $(TESTNAME2) $(TESTNAME3) $(TESTNAME4) $(TESTNAME5) \
 		obin *.i *.ii *.bc *.lk a.out-* *.ll *.s *.o *.cubin

--- a/examples/openmp/hello/README.md
+++ b/examples/openmp/hello/README.md
@@ -1,7 +1,59 @@
-These five examples illustrate a simple hello world program executing in five different modes:
+# OpenMP Hello World Examples
 
-hello1: On the CPU
-hello2: In parallel on the CPU distributed across threads
-hello3: On the GPU 
-hello4: In parallel on the GPU distrubuted across threads
-hello5: In parallel on the GPU distributed across teams and threads
+This directory contains five examples illustrating a simple "Hello World" program executed in different modes using OpenMP.
+
+## Examples
+
+1. **hello1**: Runs on the CPU.
+2. **hello2**: Runs in parallel on the CPU, distributed across threads.
+3. **hello3**: Runs on the GPU.
+4. **hello4**: Runs in parallel on the GPU, distributed across threads.
+5. **hello5**: Runs in parallel on the GPU, distributed across teams and threads.
+
+## Prerequisites
+
+- LLVM compiler with OpenMP support.
+- A compatible GPU and the appropriate runtime environment.
+
+## Build Instructions
+
+To build all examples, run:
+
+```bash
+make
+```
+
+This will generate the following binaries:
+- `hello1`
+- `hello2`
+- `hello3`
+- `hello4`
+- `hello5`
+
+## Run Instructions
+
+To execute all examples, use:
+
+```bash
+make run
+```
+
+This will run each binary and display the output for the respective example.
+
+### Example Outputs
+
+- **hello1**: Prints a message from the CPU and checks if it is running on the initial device.
+- **hello2**: Prints messages from multiple threads running in parallel on the CPU.
+- **hello3**: Prints a message from the GPU and checks if it is running on the initial device.
+- **hello4**: Prints messages from multiple threads running in parallel on the GPU.
+- **hello5**: Prints messages from multiple threads and teams running in parallel on the GPU.
+
+## Cleanup
+
+To clean up the generated files, run:
+
+```bash
+make clean
+```
+
+This will remove all binaries and intermediate files created during the build process.


### PR DESCRIPTION
Format all README files in markdown format. Add comments in the Makefile and source code as required.