### PR TITLE
[run_rocm_test] - Attempt to download test package first for detection

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -170,20 +170,25 @@ if [ "$aomp" != 1 ]; then
   tmpdir="$HOME/tmp/openmp-extras"
   os_name=$(cat /etc/os-release | grep NAME)
   test_package_name="openmp-extras-tests"
+  rm -rf $tmpdir
+  mkdir -p $tmpdir
+
   if [ "$SKIP_TEST_PACKAGE" != 1 ] && [ "$TEST_BRANCH" == "" ]; then
     export debsupport=0
     export rpmsupport=0
     git --no-pager log -1
     #------- Begin testing for package manager -------
     echo Testing apt...
-    apt --version && pkg_mgr_found=1 || pkg_mgr_found=0
+    pushd $tmpdir
+    apt-get download $test_package_name && pkg_mgr_found=1 || pkg_mgr_found=0
+    popd
     if [ $pkg_mgr_found -eq 1 ]; then
       export debsupport=1
       apt=1
     fi
     if [ $pkg_mgr_found -eq 0 ]; then
       echo Testing dnf...
-      dnf --version && pkg_mgr_found=1 || pkg_mgr_found=0
+      dnf -y download --destdir=$tmpdir openmp-extras-tests && pkg_mgr_found=1 || pkg_mgr_found=0
       if [ $pkg_mgr_found -eq 1 ]; then
         export rpmsupport=1
 	dnf=1
@@ -191,7 +196,12 @@ if [ "$aomp" != 1 ]; then
     fi
     if [ $pkg_mgr_found -eq 0 ]; then
       echo Testing yum...
-      yum --version && pkg_mgr_found=1 || pkg_mgr_found=0
+      osversion=$(cat /etc/os-release | grep -e ^VERSION_ID)
+      if [[ $osversion =~ '"7' ]]; then
+        yumdownloader --destdir=$tmpdir $test_package_name && pkg_mgr_found=1 || pkg_mgr_found=0
+      else
+        yum download --destdir $tmpdir $test_package_name && pkg_mgr_found=1 || pkg_mgr_found=0
+      fi
       if [ $pkg_mgr_found -eq 1 ]; then
         yum=1
         export rpmsupport=1
@@ -199,7 +209,9 @@ if [ "$aomp" != 1 ]; then
     fi
     if [ $pkg_mgr_found -eq 0 ]; then
       echo Testing zypper...
-      zypper --version && pkg_mgr_found=1 || pkg_mgr_found=0
+      local_dir=~/openmp-extras-test
+      rm -f "$local_dir"/*
+      zypper --pkg-cache-dir $local_dir download $test_package_name && pkg_mgr_found=1 || pkg_mgr_found=0
       if [ $pkg_mgr_found -eq 1 ]; then
 	zypper=1
         export rpmsupport=1
@@ -211,14 +223,11 @@ if [ "$aomp" != 1 ]; then
         echo "Error: nPSDB should have the openmp-extras-tests package installed before this test step."
         exit 1
       fi
-      rm -rf $tmpdir
-      mkdir -p $tmpdir
       # Determine package manager and download package not using sudo.
       # apt support
       if [ "$apt" == "1" ]; then
         echo Using apt package manager
         cd $tmpdir
-        apt-get download $test_package_name
         test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
         dpkg -x $test_package .
         script=$(find . -type f -name 'run_rocm_test.sh')
@@ -226,25 +235,15 @@ if [ "$aomp" != 1 ]; then
       # dnf/yum support, CentOS 7 requires a different method.
       elif [ "$dnf" == "1" ]; then
         echo Using dnf package manager
-        dnf download --destdir=$tmpdir openmp-extras-tests
         test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
         extract_rpm $test_package
       elif [ "$yum" == "1" ]; then
         echo Using yum package manager
-        osversion=$(cat /etc/os-release | grep -e ^VERSION_ID)
-        if [[ $osversion =~ '"7' ]]; then
-          yumdownloader --destdir=$tmpdir $test_package_name
-        else
-          yum download --destdir $tmpdir $test_package_name
-        fi
         test_package=$(ls -lt $tmpdir | grep -Eo -m1 openmp-extras-tests.*)
         extract_rpm $test_package
       # zypper support
       elif [ "$zypper" == "1" ]; then
         echo Using zypper package manager
-        local_dir=~/openmp-extras-test
-        rm -f "$local_dir"/*
-        zypper --pkg-cache-dir $local_dir download $test_package_name
         test_package=$(ls -lt "$local_dir"/rocm/ | grep -Eo -m1 openmp-extras-tests.*)
         cp "$local_dir"/rocm/"$test_package" $tmpdir
         extract_rpm $test_package


### PR DESCRIPTION
We saw a situation where 'apt' was installed on a CentOS machine which then tried to use it for the test package download. Instead of checking package manager version we will attempt to download the openmp-extras-tests package and if that succeeds then we have properly identified the package manager.