### PR TITLE
[run_rocm_test] - add script fails to unexpected failures for the ret…

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -1094,4 +1094,4 @@ fi
 echo ""
 echo >> $summary
 cat $summary
-exit $totalunexpectedfails
+exit $((totalunexpectedfails + scriptfails))


### PR DESCRIPTION
…urn code

There was a situation where script errors prevented tests from running and this should have reported a non-zero return code.