### PR TITLE
[Examples] [OMPT] Restore passing in valid device to OMPT tracing APIs.

### DIFF
--- a/examples/tools/ompt/veccopy-ompt-target-tracing/veccopy-ompt-target-tracing.c
+++ b/examples/tools/ompt/veccopy-ompt-target-tracing/veccopy-ompt-target-tracing.c
@@ -4,6 +4,8 @@
 
 #include "callbacks.h"
 
+ompt_device_t *my_device = 0;
+
 // Calls to start/stop/flush_trace to be injected by the tool
 
 int main()


### PR DESCRIPTION
This partially reverts the unintended changes made to this example in 5146bedb.