### PR TITLE
[build][trunk] Make flang and clang cfg files match

### DIFF
--- a/trunk/build_project.sh
+++ b/trunk/build_project.sh
@@ -149,13 +149,9 @@ if [ "$1" == "install" ] ; then
 EOD
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang++.cfg
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang.cfg
-   # Do not add -L option to flang-new because it's not currently allowed
+   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang.cfg
    # flang-new also appears to be reading flang.cfg
-   cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/flang.cfg
--Wl,-rpath=<CFGDIR>/../lib
--Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
-EOD
-   ln -sf flang.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
+   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
    (
    # workaround for issue with triple subdir and shared builds
    # problem with libomptarget.so finding dependent libLLVM* libs

--- a/trunk/build_project_exper.sh
+++ b/trunk/build_project_exper.sh
@@ -150,13 +150,9 @@ if [ "$1" == "install" ] ; then
 EOD
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang++.cfg
    ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang.cfg
-   # Do not add -L option to flang-new because it's not currently allowed
+   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang.cfg
    # flang-new also appears to be reading flang.cfg
-   cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/flang.cfg
--Wl,-rpath=<CFGDIR>/../lib
--Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
-EOD
-   ln -sf flang.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
+   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
    (
    # workaround for issue with triple subdir and shared builds
    # problem with libomptarget.so finding dependent libLLVM* libs


### PR DESCRIPTION
This patch adds the `-L` lines in clang cfg files also to flang, making them the same. This is currently needed, in addition to https://github.com/llvm/llvm-project/pull/134230, to get the `-mcode-object-version` option to work properly for flang.