### PR TITLE
Update existing UMT script to work with newer versions of UMT and LLVM Flang

### DIFF
--- a/bin/patches/UMT-amdflang-mods.patch
+++ b/bin/patches/UMT-amdflang-mods.patch
@@ -1,0 +1,240 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9d9c8f3..72b2c24 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -143,7 +143,31 @@ if(ENABLE_OPENMP)
+ 
+          target_link_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--rocm-path=${HIP_ROOT_DIR} -target-accel=amd_${CMAKE_HIP_ARCHITECTURES}>)
+          target_compile_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--rocm-path=${HIP_ROOT_DIR} -target-accel=amd_${CMAKE_HIP_ARCHITECTURES}>)
+-         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::amdhip64)
++         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::device)
++         target_include_directories( OpenMP::OpenMP_Fortran INTERFACE ${HIP_ROOT_DIR}/include)
++
++      elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang")
++
++         message( STATUS "Detected Flang Fortran OpenMP offload support requested.  Adding additional flags to pull in HIP backend needed by Cray Fortran compiler.")
++
++         if (DEFINED CMAKE_HIP_ARCHITECTURES)
++            message( STATUS "Setting target gpu architecture to ${CMAKE_HIP_ARCHITECTURES}")
++         else()
++            message( FATAL_ERROR " Must set CMAKE_HIP_ARCHITECTURES when using LLVM Flang compiler openmp offload functionality.")
++         endif()
++
++         if (DEFINED CMAKE_FORTRAN_OFFLOAD_LIB)
++            message( STATUS "Setting Fortran GPU offload library to ${CMAKE_FORTRAN_OFFLOAD_LIB}")
++         else()
++            message( FATAL_ERROR " Must set CMAKE_FORTRAN_OFFLOAD_LIB when using LLVM Flang compiler openmp offload functionality.")
++         endif()
++
++         find_package(hip REQUIRED)
++         add_compile_definitions( "TETON_ENABLE_HIP" )
++
++         target_link_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--offload-arch=${CMAKE_HIP_ARCHITECTURES}>)
++         target_compile_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--offload-arch=${CMAKE_HIP_ARCHITECTURES}>)
++         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::device)
+          target_include_directories( OpenMP::OpenMP_Fortran INTERFACE ${HIP_ROOT_DIR}/include)
+ 
+       endif()
+diff --git a/src/teton/CMakeLists.txt b/src/teton/CMakeLists.txt
+index d78f861..61dd403 100644
+--- a/src/teton/CMakeLists.txt
++++ b/src/teton/CMakeLists.txt
+@@ -204,8 +204,10 @@ if(ENABLE_TESTS)
+                               ${CONDUIT_INCLUDE_DIR}/conduit
+                             )
+ 
++if ( ENABLE_OPENMP AND CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+   target_link_libraries( test_driver PUBLIC
+-                         teton
++                         $<LINK_LIBRARY:WHOLE_ARCHIVE,teton>
++                         -Wl,--no-nvptx-whole-archive
+                          ${CONDUIT_LIBRARIES}
+                          ${CONDUITRELAY_LIBRARIES}
+                          ${CONDUITBLUEPRINT_LIBRARIES}
+@@ -213,9 +215,25 @@ if(ENABLE_TESTS)
+                          ${CONDUITRELAYMPI_LIBRARIES}
+                          ${CONDUITRELAYMPIIO_LIBRARIES}
+                        )
++else()
++  target_link_libraries( test_driver PUBLIC
++                        teton
++                        ${CONDUIT_LIBRARIES}
++                        ${CONDUITRELAY_LIBRARIES}
++                        ${CONDUITBLUEPRINT_LIBRARIES}
++                        ${CONDUITBLUEPRINTMPI_LIBRARIES}
++                        ${CONDUITRELAYMPI_LIBRARIES}
++                        ${CONDUITRELAYMPIIO_LIBRARIES}
++                      )
++endif()
+ 
+   if( ENABLE_OPENMP )
+-    target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran)
++    if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang")
++      target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran
++                             ${CMAKE_FORTRAN_OFFLOAD_LIB})
++    else()
++      target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran)
++    endif()
+ 
+     # The target_link_options command has trouble with adding flags if there is
+     # a space, it keeps putting quotes around the whole line.  Use the older
+@@ -247,7 +265,7 @@ if(ENABLE_TESTS)
+   if (ENABLE_UMPIRE)
+     target_include_directories( test_driver PUBLIC ${UMPIRE_INCLUDE_DIR} 
+                                                    ${UMPIRE_FORTRAN_MODULES_DIR})
+-    target_link_libraries( test_driver PUBLIC ${UMPIRE_LIBRARIES})
++    target_link_libraries( test_driver PUBLIC ${UMPIRE_LIBRARIES} rt)
+ 
+     if (FMT_ROOT)
+       target_include_directories( test_driver PUBLIC ${FMT_INCLUDE_DIR})
+diff --git a/src/teton/driver/test_driver.cc b/src/teton/driver/test_driver.cc
+index 3fcc51c..ede09b8 100644
+--- a/src/teton/driver/test_driver.cc
++++ b/src/teton/driver/test_driver.cc
+@@ -712,7 +712,10 @@ int TetonDriver::execute()
+                << std::endl;
+          }
+          options["iteration/incidentFluxMaxIt"] = 99;
+-         options["iteration/outerMaxIt"] = 1;
++
++         // A default of 1 outerMaxIt for LLVM Flang AMDGPU doesn't work, it currently requiress more
++         // outer iterations to converge. So set to 50 which was the default in v5.5.0.
++         options["iteration/outerMaxIt"] = 50;
+          if (!options.has_path("iteration/relativeTolerance"))
+          {
+             options["iteration/relativeTolerance"] = energy_check_tolerance / 10.0;
+diff --git a/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90 b/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
+index 61bbc95..afc5fb0 100644
+--- a/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
++++ b/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
+@@ -145,7 +145,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets,Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle))
++   TOMPC(private(ASet, angle, setID))
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+ 
+@@ -177,7 +177,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nAngleSets, Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2))
++   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90 b/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
+index 3548de8..0927dea 100644
+--- a/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
++++ b/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
+@@ -145,7 +145,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets,nGTASets,Geom,nSets,Quad )&)
+-   TOMPC(private(Set))
++   TOMPC(private(Set, SetID))
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+ 
+@@ -411,7 +411,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nGTASets, Geom, GTA, Quad, angleList, nSets)&)
+-   TOMPC(private(Set, ASet, angle, angle0, quadwt, quadTauW1, quadTauW2))
++   TOMPC(private(Set, ASet, angle, angle0, quadwt, quadTauW1, quadTauW2, setID))
+ 
+    ZoneSetLoop2: do zSetID=1,nZoneSets
+      do setID=1,nGTASets
+diff --git a/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90 b/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
+index 44e9098..ae35ab9 100644
+--- a/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
++++ b/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
+@@ -572,7 +572,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nGTASets, nSets, GTA, angleList, Quad, Geom)&)
+-   TOMPC(private(Set, ASet, angle, quadwt)) 
++   TOMPC(private(Set, ASet, angle, quadwt, setID))
+ 
+    ZoneSetLoop3: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/gpu/SweepUCBrz_OMPOL.F90 b/src/teton/gpu/SweepUCBrz_OMPOL.F90
+index bcfbbdb..1f540b2 100644
+--- a/src/teton/gpu/SweepUCBrz_OMPOL.F90
++++ b/src/teton/gpu/SweepUCBrz_OMPOL.F90
+@@ -139,7 +139,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets,Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle))
++   TOMPC(private(ASet, angle, setID))
+ 
+    ZoneSetLoop: do zSetID=1,nZoneSets
+ 
+@@ -171,7 +171,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nAngleSets, Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2))
++   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+@@ -254,7 +254,6 @@
+ 
+ 
+    if ( nHyperDomains > 1 ) then
+-
+      TOMP(target teams distribute collapse(2) num_teams(nZoneSets*nSets) &)
+      TOMPC(thread_limit(omp_device_team_thread_limit) default(none) &)
+      TOMPC(shared(sendIndex, Quad, nZoneSets, nSets) &)
+diff --git a/src/teton/gpu/SweepUCBxyz_OMPOL.F90 b/src/teton/gpu/SweepUCBxyz_OMPOL.F90
+index 350ffcc..9c9c0dc 100644
+--- a/src/teton/gpu/SweepUCBxyz_OMPOL.F90
++++ b/src/teton/gpu/SweepUCBxyz_OMPOL.F90
+@@ -138,7 +138,7 @@
+    TOMP_MAP(target enter data map(to: tau, sendIndex, angleList))
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+-   TOMPC(private(ASet, angle) &)
++   TOMPC(private(ASet, angle, setID) &)
+    TOMPC(shared(nZoneSets, angleList, Quad, Geom, nAngleSets) )
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+@@ -186,7 +186,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets, Quad, Geom) &)
+-   TOMPC(private(ASet))
++   TOMPC(private(ASet, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/mods/Datastore_mod.F90 b/src/teton/mods/Datastore_mod.F90
+index 0b12b3c..9d35b5c 100644
+--- a/src/teton/mods/Datastore_mod.F90
++++ b/src/teton/mods/Datastore_mod.F90
+@@ -101,7 +101,7 @@ contains
+       endif
+     endif
+     ! Get the value from the environment
+-    call getenv("TETON_PARTITION", str)
++    call get_environment_variable("TETON_PARTITION", str)
+     if (str .ne. " ") then
+       value = 0
+       read (str,*) value
+diff --git a/src/teton/rt/addGreyCorrections_OMPOL.F90 b/src/teton/rt/addGreyCorrections_OMPOL.F90
+index 4592199..a13d3aa 100644
+--- a/src/teton/rt/addGreyCorrections_OMPOL.F90
++++ b/src/teton/rt/addGreyCorrections_OMPOL.F90
+@@ -142,7 +142,7 @@
+      TOMP(target teams distribute collapse(2) num_teams(nZoneSets*nSets) &)
+      TOMPC(thread_limit(omp_device_team_thread_limit) default(none) &)
+      TOMPC(shared(nZoneSets, nSets, Quad, GTA, wtiso)&)
+-     TOMPC(private(Set, ASet, HypPlanePtr, Groups, NumAngles, c, g0))
++     TOMPC(private(Set, ASet, HypPlanePtr, Groups, NumAngles, c, g0, angle))
+ 
+      ZoneSetLoop1: do zSetID=1,nZoneSets
+        SetLoop1: do setID=1,nSets

--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -1,27 +1,47 @@
 #!/bin/bash
+#
+#  run_umt.sh
+#
+# UMT depends on a number of LLNL projects: BLT, CAMP, Conduit and Umpire
 
 # --- Start standard header to set AOMP environment variables ----
 realpath=`realpath $0`
 thisdir=`dirname $realpath`
+export AOMP_USE_CCACHE=0
+
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 
-export AOMP=${AOMP:-/usr/lib/aomp}
-export MPI_PATH=${HOME}/local/openmpi
+# Setup AOMP variables
+export AOMP=${AOMP:-$HOME/rocm/aomp/llvm}
+export AOMPHIP=${AOMP:-$HOME/rocm/aomp/llvm}
+# for ROCm utilities (e.g. rocm_agent_enumerator)
+export  ROCM=${AOMP:-$HOME/rocm/aomp/llvm}
 
-export UMT_PATH=${HOME}/git/aomp-test/UMT
-export UMT_INSTALL_PATH=${UMT_PATH}/umt_workspace/install
+CC=${AOMP}/llvm/bin/clang
+CXX=${AOMP}/llvm/bin/clang++
+FC=${AOMP}/llvm/bin/flang
 
-export LD_LIBRARY_PATH=${AOMP}/lib:${MPI_PATH}/lib:${LD_LIBRARY_PATH}
+echo "AOMP    = $AOMP"
+echo "AOMPHIP = $AOMPHIP"
+echo "ROCM    = $ROCM"
 
-CC=${AOMP}/bin/clang
-CXX=${AOMP}/bin/clang++
-FC=${AOMP}/bin/flang
+# Use function to set and test AOMP_GPU
+setaompgpu
 
-export PATH=${AOMP}/bin:${MPI_PATH}/bin:${PATH}
+export BLT_SRC_DIR=${BLT_SRC_DIR:-BLT}
+export UMT_SRC_DIR=${UMT_SRC_DIR:-UMT}
+export  CAMP_SRC_DIR=${CAMP_SRC_DIR:-CAMP}
+export CONDUIT_SRC_DIR=${CONDUIT_SRC_DIR:-CONDUIT}
+export UMPIRE_SRC_DIR=${UMPIRE_SRC_DIR:-UMPIRE}
 
-#Queried by patchrepo
-export OMP_APPLY_ROCM_PATCHES=1
+export AOMP_SUPP=${AOMP_SUPP:-$HOME/local}
+
+export CMAKE=$AOMP_SUPP/cmake/bin
+export MPI=$AOMP_SUPP/llvm-flang/openmpi
+export LIBRARY_PATH=$AOMP/llvm/lib:$AOMP/lib:$MPI/bin:$MPI/include:$LIBRARY_PATH
+export LD_LIBRARY_PATH=$AOMP/llvm/lib:$AOMP/lib:$MPI/bin:$MPI/include:$LD_LIBRARY_PATH
+export PATH=$MPI:$AOMP/llvm/bin:$AOMP/bin:$MPI/bin:$MPI/include:$PATH
 
 function usage(){
   echo ""
@@ -32,76 +52,118 @@ function usage(){
   echo ""
 }
 
-# Build UMT
+# Clone and Build UMT and dependencies
+# NOTE: May wish to add fixed release/tag versions of each repository rather
+# than most recent dev branch. But catching errors as they come seems helpful
+# for the moment. But need to see how much fallout from the churn there is.
 if [ "$1" == "build_umt" ]; then
+    echo "UMT and its dependencies will be installed in $AOMP_REPOS_TEST"
 
-    if [ ! -d "${UMT_PATH}" ]; then
-        echo "*************************************************************************************"
-        echo "UMT not found. Expecting the sources in ${UMT_PATH}". Call script with clone_umt first.
-        echo "*************************************************************************************"
-        exit 0;
-    fi
+    mkdir -p $AOMP_REPOS_TEST/$BLT_SRC_DIR
+    mkdir -p $AOMP_REPOS_TEST/$CAMP_SRC_DIR
+    mkdir -p $AOMP_REPOS_TEST/$CONDUIT_SRC_DIR
+    mkdir -p $AOMP_REPOS_TEST/$UMPIRE_SRC_DIR
+    mkdir -p $AOMP_REPOS_TEST/$UMT_SRC_DIR
 
-    pushd ${UMT_PATH}
-    mkdir -p ${UMT_INSTALL_PATH}
-    pushd ${UMT_PATH}/umt_workspace
-
-    git clone --recurse-submodules  https://github.com/LLNL/conduit.git conduit -b v0.9.0
-
-    cmake -S ${UMT_PATH}/umt_workspace/conduit/src -B build_conduit \
-                        -DCMAKE_INSTALL_PREFIX=${UMT_INSTALL_PATH} \
-                        -DCMAKE_C_COMPILER=${CC} \
-                        -DCMAKE_CXX_COMPILER=${CXX} \
-                        -DCMAKE_Fortran_COMPILER=${FC} \
-                        -DMPI_CXX_COMPILER=mpicxx \
-                        -DMPI_Fortran_COMPILER=mpifort \
-                        -DBUILD_SHARED_LIBS=OFF \
-                        -DENABLE_TESTS=OFF \
-                        -DENABLE_EXAMPLES=OFF \
-                        -DENABLE_DOCS=OFF \
-                        -DENABLE_FORTRAN=ON \
-                        -DENABLE_MPI=ON \
-                        -DENABLE_PYTHON=OFF
-    
-    cmake --build build_conduit --parallel
-    cmake --install build_conduit
+    # no build required for BLT
+    pushd $AOMP_REPOS_TEST/$BLT_SRC_DIR
+    git clone https://github.com/LLNL/blt.git .
     popd
-    
-    # apply patch
-    git reset --hard 30b0175228af4c5eb084c3e219db6a7cd3f27ead
-    patchrepo $AOMP_REPOS_TEST/UMT
 
-    # Build UMT
-  
-    # Run CMake on UMT, compile, and install.
-    cmake -S ${UMT_PATH}/src -B build_umt \
-            -DCMAKE_BUILD_TYPE=Release \
-    		-DSTRICT_FPP_MODE=YES \
-            -DENABLE_OPENMP=YES \
-    		-DENABLE_OPENMP_OFFLOAD=Yes \
-            -DOPENMP_HAS_USE_DEVICE_ADDR=Yes \
-    		-DOPENMP_HAS_FORTRAN_INTERFACE=NO \
-            -DCMAKE_CXX_COMPILER=${CXX} \
-    		-DCMAKE_Fortran_COMPILER=${FC} \
-            -DMPI_CXX_COMPILER=${MPI_PATH}/bin/mpicxx \
-            -DMPI_Fortran_COMPILER=${MPI_PATH}/bin/mpifort \
-            -DCMAKE_INSTALL_PREFIX=${UMT_INSTALL_PATH} \
-            -DCONDUIT_ROOT=${UMT_INSTALL_PATH}
-    
-    cmake --build build_umt --parallel
-    cmake --install build_umt
-    
-    # undo patch
-    removepatch ${AOMP_REPOS_TEST}/UMT
+    pushd $AOMP_REPOS_TEST/$CAMP_SRC_DIR
+    git clone https://github.com/LLNL/camp.git .
+    mkdir build
+    pushd build
+    $CMAKE/cmake -DCMAKE_INSTALL_PREFIX=$AOMP_REPOS_TEST/$CAMP_SRC_DIR/install \
+          -DBLT_SOURCE_DIR=$AOMP_REPOS_TEST/$BLT_SRC_DIR \
+          -DCMAKE_C_COMPILER=$CC \
+          -DCMAKE_CXX_COMPILER=$CXX \
+          -DCMAKE_Fortran_COMPILER=$FC \
+          ../
+    make install
+    popd
+    popd
 
-popd
-exit 1
+    pushd $AOMP_REPOS_TEST/$CONDUIT_SRC_DIR
+    git clone https://github.com/LLNL/conduit.git .
+    mkdir build
+    pushd build
+    $CMAKE/cmake ../src -DCMAKE_INSTALL_PREFIX=$AOMP_REPOS_TEST/$CONDUIT_SRC_DIR/install \
+    -DBLT_SOURCE_DIR=$AOMP_REPOS_TEST/$BLT_SRC_DIR -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF \
+    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_Fortran_COMPILER=$FC \
+    -DENABLE_DOCS=OFF -DENABLE_FORTRAN=ON -DENABLE_MPI=ON -DENABLE_PYTHON=OFF
+    make install
+    popd
+    popd
+
+    pushd $AOMP_REPOS_TEST/$UMPIRE_SRC_DIR
+    git clone https://github.com/LLNL/Umpire.git .
+    git submodule update --init
+    mkdir build
+    pushd build
+    $CMAKE/cmake ../ -DCMAKE_INSTALL_PREFIX=$AOMP_REPOS_TEST/$UMPIRE_SRC_DIR/install \
+    -DMPI_CXX_SKIP_MPICXX=TRUE \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBLT_SOURCE_DIR=$AOMP_REPOS_TEST/$BLT_SRC_DIR \
+    -DMPI_Fortran_COMPILER=$MPI/bin/mpif90 \
+    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_Fortran_COMPILER=$FC \
+    -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTS=OFF -DENABLE_EXAMPLES=OFF \
+    -DENABLE_DOCS=OFF -DENABLE_FORTRAN=ON -DENABLE_MPI=ON -DENABLE_HIP=ON
+    make install
+    popd
+    popd
+
+    pushd $AOMP_REPOS_TEST/$UMT_SRC_DIR
+    git clone https://github.com/LLNL/UMT.git .
+
+    # This applies specific tweaks to UMT required for Flang, we can likely
+    # remove this in the near future once it's incorporated into UMT and
+    # one or two smaller flang bugs are squashed
+    git apply $thisdir/patches/UMT-amdflang-mods.patch
+
+    mkdir build
+    pushd build
+
+    $CMAKE/cmake ../src \
+    -DCMAKE_INSTALL_PREFIX=$AOMP_REPOS_TEST/$UMT_SRC_DIR/install \
+    -DCONDUIT_ROOT=$AOMP_REPOS_TEST/$CONDUIT_SRC_DIR/install \
+    -DUMPIRE_ROOT=$AOMP_REPOS_TEST/$UMPIRE_SRC_DIR/install \
+    -DCAMP_ROOT=$AOMP_REPOS_TEST/$CAMP_SRC_DIR/install \
+    -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_Fortran_COMPILER=$FC \
+    -DCMAKE_FORTRAN_OFFLOAD_LIB=$AOMP/llvm/lib/flang_rt.hostdevice.a \
+    -DCMAKE_Fortran_LINKER_WRAPPER_FLAG="-Wl," \
+    -DENABLE_CUDA=OFF \
+    -DENABLE_OPENMP=ON -DOPENMP_HAS_FORTRAN_INTERFACE=ON \
+    -DENABLE_OPENMP_OFFLOAD=ON -DOPENMP_HAS_USE_DEVICE_ADDR=ON \
+    -DHIP_ROOT_DIR=$AOMPHIP \
+    -DCMAKE_HIP_PLATFORM=amd \
+    -DCMAKE_HIP_ARCHITECTURES=$AOMP_GPU \
+    -DENABLE_UMPIRE=TRUE
+
+    make install
+    popd
+    popd
+
+# 7) if all works ...Ask Dan how the grep for success / check other runs / ask Dan for grep code  or if the check code is a seperate script/thing, seems to be, probably part of internal test harness
+    exit 1
 fi
 
 # Run UMT
 if [ "$1" == "run_umt" ]; then
-    ${UMT_INSTALL_PATH}/bin/test_driver -c 10 -B local -d 8,8,0 --benchmark_problem 2
-    ${UMT_INSTALL_PATH}/bin/test_driver -c 10 -B local -d 4,4,4 --benchmark_problem 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 0 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 1 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 2 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 0 -d 3,3,3 -b 1
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 1 -d 3,3,3 -b 1
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B global -g -c 10 -u 2 -d 3,3,3 -b 1
+
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 0 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 1 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 2 -d 3,3,3 -b 2
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 0 -d 3,3,3 -b 1
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 1 -d 3,3,3 -b 1
+    $AOMP_REPOS_TEST/$UMT_SRC_DIR/install/bin/test_driver -B local -g -c 10 -u 2 -d 3,3,3 -b 1
+
     exit 1
 fi
 

--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -144,7 +144,6 @@ if [ "$1" == "build_umt" ]; then
     popd
     popd
 
-# 7) if all works ...Ask Dan how the grep for success / check other runs / ask Dan for grep code  or if the check code is a seperate script/thing, seems to be, probably part of internal test harness
     exit 1
 fi
 


### PR DESCRIPTION
Adds an initial update to the UMT script to build and run the newer version of LLNL UMT.

It currently requires a patch to be applied to UMT, which I've added into the patches directory, hopefully this will be removeable as we progress a bit further (removal of a small bug or two and incorporating some of the changes into LLNL UMT in the near future).

As it's my first time writing a script for AOMP, this might benefit from a look over from someone with a keen eye for the intricacies of the script infrastructure we have... in particular the environment variables and install directory infrastructure. 

It builds locally after running build_aomp.sh/build_project.sh and installing the components, but for the moment the tests won't pass as there's been a bit of breakage in the past couple of days that I need to track down and try to fix or revert (temporarily).
