### PR TITLE
[smoke-fails] Fixed gpus test follow up

### DIFF
--- a/test/smoke-fails/check_smoke_fails.sh
+++ b/test/smoke-fails/check_smoke_fails.sh
@@ -228,6 +228,8 @@ for directory in ./*/; do
     elif [ $base == 'flags' ] ; then
       make
       make run > /dev/null 2>&1
+    elif [ $base == "gpus" ]; then # Compile and link only test
+      echo "$base" >> ../passing-tests.txt
     elif [ $base == 'printf_parallel_for_target' ] ; then
       make verify-log
     else

--- a/test/smoke-fails/gpus/Makefile
+++ b/test/smoke-fails/gpus/Makefile
@@ -10,10 +10,11 @@ OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 
 include ../Makefile.rules
-LOCAL_OMP_FLAGS_NOARCH = $(filter-out -march=$(AOMP_GPU)$(AOMP_TARGET_FEATURES), $(OMP_FLAGS))
-LOCAL_OMP_FLAGS_NODEFINE = $(filter-out -D__OFFLOAD_ARCH_$(INSTALLED_GPU)__, $(LOCAL_OMP_FLAGS_NOARCH))
-LOCAL_OMP_FLAGS_NOTARGET = $(filter-out -fopenmp-targets=amdgcn-amd-amdhsa, $(LOCAL_OMP_FLAGS_NODEFINE))
-LOCAL_OMP_FLAGS = $(filter-out -Xopenmp-target=amdgcn-amd-amdhsa, $(LOCAL_OMP_FLAGS_NOTARGET))
+LOCAL_OMP_FLAGS_NO_OFFLOAD = $(filter-out --offload-arch=$(AOMP_GPU), $(OMP_FLAGS))
+LOCAL_OMP_FLAGS_NO_ARCH = $(filter-out -march=$(AOMP_GPU)$(AOMP_TARGET_FEATURES), $(LOCAL_OMP_FLAGS_NO_OFFLOAD))
+LOCAL_OMP_FLAGS_NO_DEFINE = $(filter-out -D__OFFLOAD_ARCH_$(INSTALLED_GPU)__, $(LOCAL_OMP_FLAGS_NO_ARCH))
+LOCAL_OMP_FLAGS_NO_TARGET = $(filter-out -fopenmp-targets=amdgcn-amd-amdhsa, $(LOCAL_OMP_FLAGS_NO_DEFINE))
+LOCAL_OMP_FLAGS = $(filter-out -Xopenmp-target=amdgcn-amd-amdhsa, $(LOCAL_OMP_FLAGS_NO_TARGET))
 
 # Process GFXLIST:
 #   (1) Replace double with single semicolons


### PR DESCRIPTION
Fixed check_smoke_fails.sh reporting gpus as regular test
 - But gpus is compile-only (see handling in check_smoke.sh)
 - Note: a failure only occurred when running in sequential mode

Fixed double occurrence of --offload-arch
 - Not necessarily an issue, but unexpected