### PR TITLE
aomp_common_vars: Drop gfx70* & gfx80* from GFXLIST

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -286,7 +286,7 @@ fi
 
 # Set list of default amdgcn subarchitectures to build
 # Developers may override GFXLIST to shorten build time.
-GFXLIST=${GFXLIST:-"gfx700 gfx701 gfx801 gfx803 gfx900 gfx902 gfx906 gfx908 gfx90a gfx90c gfx942 gfx950 gfx1030 gfx1031 gfx1035 gfx1036 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201 gfx9-generic gfx9-4-generic gfx10-1-generic gfx10-3-generic gfx11-generic gfx12-generic"}
+GFXLIST=${GFXLIST:-"gfx900 gfx902 gfx906 gfx908 gfx90a gfx90c gfx942 gfx950 gfx1030 gfx1031 gfx1035 gfx1036 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201 gfx9-generic gfx9-4-generic gfx10-1-generic gfx10-3-generic gfx11-generic gfx12-generic"}
 export GFXLIST
 
 # _gfxlist is used in the build of rocmlibs. Some of the hip math libraries do not support older architectures.


### PR DESCRIPTION
  - These archs are not supported by ROCm and gfx70* breaks the UMT build via libflang_rt.hostdevice.a compiled for GFXLIST

    LLVM ERROR: Cannot select: intrinsic %llvm.amdgcn.ds.bpermute