### PR TITLE
[smoke-fort-fails] Update for -fdo-concurrent-to-openmp

### DIFF
--- a/test/smoke-fort-fails/flang-523344-device/Makefile
+++ b/test/smoke-fort-fails/flang-523344-device/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -fdo-concurrent-parallel=device
+CFLAGS       = -fdo-concurrent-to-openmp=device
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-523344-host/Makefile
+++ b/test/smoke-fort-fails/flang-523344-host/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -fdo-concurrent-parallel=host
+CFLAGS       = -fdo-concurrent-to-openmp=host
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/rocm-issue-253-device/Makefile
+++ b/test/smoke-fort-fails/rocm-issue-253-device/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -fdo-concurrent-parallel=device
+CFLAGS       = -fdo-concurrent-to-openmp=device
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/rocm-issue-253-host/Makefile
+++ b/test/smoke-fort-fails/rocm-issue-253-host/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -fdo-concurrent-parallel=host
+CFLAGS       = -fdo-concurrent-to-openmp=host
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/rocm-issue-253-none/Makefile
+++ b/test/smoke-fort-fails/rocm-issue-253-none/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -fdo-concurrent-parallel=none
+CFLAGS       = -fdo-concurrent-to-openmp=none
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases


### PR DESCRIPTION
  - After upstream review, the option spelling for: -fdo-concurrent-parallel was changed to: -fdo-concurrent-to-openmp