### PR TITLE
[build] - Move aomp-extras scripts to aomp/utils

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -26,7 +26,6 @@ each component build script with the name build_\<component name\>.sh .
 | SPIRV-LLVM-Translator   | amd-staging | $HOME/git/aomp21.0/SPIRV-LLVM-Translator      | [SPIRV-LLVM-Translator](https://github.com/ROCm/SPIRV-LLVM-Translator)
 | rocprofiler-register   | Latest ROCm | $HOME/git/aomp21.0/rocprofiler-register     | [rocprofiler-register](https://github.com/ROCm/rocprofiler-register)
 | openmp    | amd-staging | $HOME/git/aomp21.0/llvm-project/openmp | [llvm-project/openmp](https://github.com/ROCm/llvm-project)
-| extras    | aomp-dev   | $HOME/git/aomp21.0/aomp-extras         | [aomp-extras](https://github.com/ROCm/aomp-extras)
 | flang     | aomp-dev   | $HOME/git/aomp21.0/flang               | [flang](https://github.com/ROCm/flang)
 | pgmath    | aomp-dev   | $HOME/git/aomp21.0/flang/runtime/libpgmath | [flang](https://github.com/ROCm/flang)
 | llvm-classic  | aomp-dev | $HOME/git/aomp21.0/flang/flang-classic/17.0-4/llvm-classic | [flang](https://github.com/ROCm/flang/flang-classic/17.0-4/llvm-classic)

--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -355,7 +355,6 @@ else
     AOMP_PROJECT_REPO_NAME="../llvm-project"
   fi
 fi
-AOMP_EXTRAS_REPO_NAME=${AOMP_EXTRAS_REPO_NAME:-aomp-extras}
 AOMP_FLANG_REPO_NAME=${AOMP_FLANG_REPO_NAME:-flang}
 
 # Last version of rocm (5.5) that supports the legacy driver (command generation)

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -120,6 +120,6 @@ if [ "$1" == "install" ] ; then
   cp $BUILD_DIR/build/extras/* $INSTALL_EXTRAS/bin
   for util in $install_list; do
     echo "-- Installing: $INSTALL_EXTRAS/bin/$util"
-    echo "$INSTALL_EXTRAS/bin/$util" >> installed_manifest.txt
+    echo "$INSTALL_EXTRAS/bin/$util" >> install_manifest.txt
   done
 fi

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
 #
 #  File: build_extras.sh
-#        Build the extras host and device runtimes, 
-#        The install option will install components into the aomp installation. 
-#        The components include:
-#          gpusrv headers installed in $AOMP/include
-#          gpusrv host runtime installed in $AOMP/lib
-#          gpusrv device runtime installed in $AOMP/lib/libdevice
+#        Modify and copy former aomp-extras (now in aomp) utilities to aomp install.
+#        The install option will install components into the aomp installation.
+#        Note: this script does not use cmake or make steps.
 #
 # MIT License
 #
@@ -38,66 +35,49 @@ thisdir=`dirname $realpath`
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 
-EXTRAS_REPO_DIR=$AOMP_REPOS/$AOMP_EXTRAS_REPO_NAME
+AOMP_REPO_DIR=$AOMP_REPOS/$AOMP_REPO_NAME
 
 BUILD_DIR=${BUILD_AOMP}
-
-BUILDTYPE="Release"
 
 INSTALL_EXTRAS=${INSTALL_EXTRAS:-$LLVM_INSTALL_LOC}
 export LLVM_DIR=$LLVM_INSTALL_LOC
 
+if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
+  install_list="gpurun rebundle_hip_lib.sh raja_build.sh kokkos_build.sh aompversion blt.patch raja.patch modulefile"
+else
+  install_list="gpurun"
+fi
+
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then
   echo " "
   echo "Example commands and actions: "
-  echo "  ./build_extras.sh                   cmake, make, NO Install "
-  echo "  ./build_extras.sh nocmake           NO cmake, make,  NO install "
-  echo "  ./build_extras.sh install           NO Cmake, make install "
+  echo "  ./build_extras.sh                   copy to build location, NO Install "
+  echo "  ./build_extras.sh install           install "
   echo " "
   exit
 fi
 
-if [ ! -d $EXTRAS_REPO_DIR ] ; then
-   echo "ERROR:  Missing repository $EXTRAS_REPO_DIR/"
-   exit 1
-fi
-
-if [ ! -f $LLVM_INSTALL_LOC/bin/clang ] ; then
-   echo "ERROR:  Missing file $AOMP/bin/clang"
-   echo "        Build and install the AOMP clang compiler in $AOMP first"
-   echo "        This is needed to build extras "
-   echo " "
-   exit 1
-fi
-
 # Make sure we can update the install directory
 if [ "$1" == "install" ] ; then
-   $SUDO mkdir -p $INSTALL_EXTRAS
-   $SUDO touch $INSTALL_EXTRAS/testfile
-   if [ $? != 0 ] ; then
-      echo "ERROR: No update access to $INSTALL_EXTRAS"
-      exit 1
-   fi
-   $SUDO rm $INSTALL_EXTRAS/testfile
+  $SUDO mkdir -p $INSTALL_EXTRAS
+  $SUDO touch $INSTALL_EXTRAS/testfile
+  if [ $? != 0 ] ; then
+  echo "ERROR: No update access to $INSTALL_EXTRAS"
+  exit 1
+fi
+  $SUDO rm $INSTALL_EXTRAS/testfile
 fi
 
-if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
-
+if [ "$1" != "install" ] ; then
   if [ -d "$BUILD_DIR/build/extras" ] ; then
-     echo
-     echo "FRESH START , CLEANING UP FROM PREVIOUS BUILD"
-     echo rm -rf $BUILD_DIR/build/extras
-     rm -rf $BUILD_DIR/build/extras
+    echo
+    echo "FRESH START , CLEANING UP FROM PREVIOUS BUILD"
+    echo rm -rf $BUILD_DIR/build/extras
+    rm -rf $BUILD_DIR/build/extras
   fi
 
-  if [ $AOMP_STANDALONE_BUILD == 1 ] ; then
-    MYCMAKEOPTS="-DLLVM_DIR=$LLVM_DIR -DCMAKE_BUILD_TYPE=$BUILDTYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_EXTRAS -DAOMP_VERSION_STRING=$AOMP_VERSION_STRING -DCMAKE_PREFIX_PATH=$BUILD_DIR/build/libdevice"
-  else
-    MYCMAKEOPTS="-DLLVM_DIR=$INSTALL_PREFIX/llvm \
-     -DCMAKE_BUILD_TYPE=$BUILDTYPE \
-     -DCMAKE_INSTALL_PREFIX=$INSTALL_EXTRAS \
-     -DAOMP_VERSION_STRING=$ROCM_VERSION \
-     -DAOMP_STANDALONE_BUILD=0 "
+  if [ $AOMP_STANDALONE_BUILD == 0 ] ; then
+    export AOMP_VERSION_STRING=$ROCM_VERSION
   fi
 
   mkdir -p $BUILD_DIR/build/extras
@@ -110,49 +90,36 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   fi
 
   export SED_INSTALL_DIR
-  echo
-  echo " -----Running cmake ---- "
-  echo ${AOMP_CMAKE} $MYCMAKEOPTS $EXTRAS_REPO_DIR
-  ${AOMP_CMAKE} $MYCMAKEOPTS $EXTRAS_REPO_DIR 
-  if [ $? != 0 ] ; then
-      echo "ERROR extras cmake failed. Cmake flags"
-      echo "      $MYCMAKEOPTS"
-      exit 1
-  fi
-fi
 
-if [ "$1" = "cmake" ]; then
-  exit 0
+  echo "----- Copy util scripts to $BUILD_DIR/build/extras -----"
+  cp $AOMP_REPO_DIR/utils/* $BUILD_DIR/build/extras
+
+  for util in $install_list; do
+    if [ "$util" == "rebundle_hip_lib.sh" ]; then
+      /bin/sed -i -e "s/X\\.Y\\-Z/${AOMP_VERSION_STRING}/g" -e "s/_LLVM_INSTALL_DIR_/${SED_INSTALL_DIR}/g" $util
+    else
+      /bin/sed -i -e "s/X\\.Y\\-Z/${AOMP_VERSION_STRING}/g" -e "s/_AOMP_INSTALL_DIR_/${SED_INSTALL_DIR}/g" $util
+    fi
+  done
 fi
 
 cd $BUILD_DIR/build/extras
 echo
-echo " -----Running make for extras ---- "
-make -j $AOMP_JOB_THREADS 
-if [ $? != 0 ] ; then
-      echo " "
-      echo "ERROR: make -j $AOMP_JOB_THREADS  FAILED"
-      echo "To restart:"
-      echo "  cd $BUILD_DIR/build/extras"
-      echo "  make "
-      exit 1
-else
-  if [ "$1" != "install" ] ; then
-      echo
-      echo " BUILD COMPLETE! To install extras component run this command:"
-      echo "  $0 install"
-      echo
-  fi
+if [ "$1" != "install" ] ; then
+  echo
+  echo " BUILD COMPLETE! To install extras component run this command:"
+  echo "  $0 install"
+  echo
 fi
 
 #  ----------- Install only if asked  ----------------------------
 if [ "$1" == "install" ] ; then
-      cd $BUILD_DIR/build/extras
-      echo
-      echo " -----Installing to $INSTALL_EXTRAS ----- "
-      $SUDO make install
-      if [ $? != 0 ] ; then
-         echo "ERROR make install failed "
-         exit 1
-      fi
+  cd $BUILD_DIR/build/extras
+  echo
+  echo " -----Installing to $INSTALL_EXTRAS/bin ----- "
+  cp $BUILD_DIR/build/extras/* $INSTALL_EXTRAS/bin
+  for util in $install_list; do
+    echo "-- Installing: $INSTALL_EXTRAS/bin/$util"
+    echo "$INSTALL_EXTRAS/bin/$util" >> installed_manifest.txt
+  done
 fi

--- a/bin/build_extras.sh
+++ b/bin/build_extras.sh
@@ -115,11 +115,10 @@ fi
 #  ----------- Install only if asked  ----------------------------
 if [ "$1" == "install" ] ; then
   cd $BUILD_DIR/build/extras
-  echo
   echo " -----Installing to $INSTALL_EXTRAS/bin ----- "
-  cp $BUILD_DIR/build/extras/* $INSTALL_EXTRAS/bin
   for util in $install_list; do
     echo "-- Installing: $INSTALL_EXTRAS/bin/$util"
+    cp "$BUILD_DIR"/build/extras/"$util" "$INSTALL_EXTRAS"/bin
     echo "$INSTALL_EXTRAS/bin/$util" >> install_manifest.txt
   done
 fi

--- a/docs/SOURCEINSTALL.md
+++ b/docs/SOURCEINSTALL.md
@@ -81,7 +81,6 @@ The above command will produce output like this showing you the location and bra
        emu  amd-staging         llvm-project lightning/ec/llvm-project f986706166c9 2023-12-06      Ron Lieberman            JP Lehr
        emu  amd-staging   SPIRV-LLVM-Translator  SPIRV-LLVM-Translator 0659e45216b2 2024-12-04            AlexVlx            AlexVlx
        roc     aomp-dev                flang                     flang 88b81b0a8ead 2023-11-30             GitHub    Emma Pilkington
-       roc     aomp-dev          aomp-extras               aomp-extras 7097f3e2ba36 2023-12-04      Ron Lieberman      Ron Lieberman
        roc     aomp-dev                 aomp                      aomp df5b5d8ddffa 2023-12-05 Dhruva Chakrabarti Dhruva Chakrabarti
        roc   release/rocm-rel-6.4 rocprofiler               rocprofiler 4e190a02e60e 2023-10-30             GitHub      Ammar ELWazir
        roc   release/rocm-rel-6.4   roctracer                 roctracer 6fbf7673aa7f 2023-07-13 Ranjith Ramakrishnan Ranjith Ramakrishnan

--- a/manifests/aomp_21.0.xml
+++ b/manifests/aomp_21.0.xml
@@ -11,7 +11,6 @@
     <project remote="roc" path="SPIRV-LLVM-Translator" name="SPIRV-LLVM-Translator"    revision="amd-staging" groups="unlocked" />
 
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
-    <project remote="roc" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
     <project remote="roc" path="rocprofiler" name="rocprofiler"              revision="release/rocm-rel-6.4" groups="unlocked" />

--- a/manifests/aompi_21.0.xml
+++ b/manifests/aompi_21.0.xml
@@ -10,7 +10,6 @@
     <project remote="githubemu-lightning" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
 
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
-    <project remote="roc" path="aomp-extras" name="aomp-extras"   revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
     <project remote="roc" path="rocprofiler" name="rocprofiler"              revision="release/rocm-rel-6.4" groups="unlocked" />

--- a/utils/aompversion
+++ b/utils/aompversion
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+#  aompversion: Print the current version of aomp that is installed and active
+#
+#  Written by Greg Rodgers  Gregory.Rodgers@amd.com
+#
+# This string is changed by cmake when building and installing aomp utils.
+PROGVERSION="X.Y-Z"
+#
+# Copyright(C) 2018 Advanced Micro Devices, Inc. All rights reserved.
+# 
+# AMD is granting you permission to use this software and documentation (if any) (collectively, the 
+# Materials) pursuant to the terms and conditions of the Software License Agreement included with the 
+# Materials.  If you do not have a copy of the Software License Agreement, contact your AMD 
+# representative for a copy.
+# 
+# You agree that you will not reverse engineer or decompile the Materials, in whole or in part, except for 
+# example code which is provided in source code form and as allowed by applicable law.
+# 
+# WARRANTY DISCLAIMER: THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+# KIND.  AMD DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING BUT NOT 
+# LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+# PURPOSE, TITLE, NON-INFRINGEMENT, THAT THE SOFTWARE WILL RUN UNINTERRUPTED OR ERROR-
+# FREE OR WARRANTIES ARISING FROM CUSTOM OF TRADE OR COURSE OF USAGE.  THE ENTIRE RISK 
+# ASSOCIATED WITH THE USE OF THE SOFTWARE IS ASSUMED BY YOU.  Some jurisdictions do not 
+# allow the exclusion of implied warranties, so the above exclusion may not apply to You. 
+# 
+# LIMITATION OF LIABILITY AND INDEMNIFICATION:  AMD AND ITS LICENSORS WILL NOT, 
+# UNDER ANY CIRCUMSTANCES BE LIABLE TO YOU FOR ANY PUNITIVE, DIRECT, INCIDENTAL, 
+# INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING FROM USE OF THE SOFTWARE OR THIS 
+# AGREEMENT EVEN IF AMD AND ITS LICENSORS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH 
+# DAMAGES.  In no event shall AMD's total liability to You for all damages, losses, and 
+# causes of action (whether in contract, tort (including negligence) or otherwise) 
+# exceed the amount of $100 USD.  You agree to defend, indemnify and hold harmless 
+# AMD and its licensors, and any of their directors, officers, employees, affiliates or 
+# agents from and against any and all loss, damage, liability and other expenses 
+# (including reasonable attorneys' fees), resulting from Your use of the Software or 
+# violation of the terms and conditions of this Agreement.  
+# 
+# U.S. GOVERNMENT RESTRICTED RIGHTS: The Materials are provided with "RESTRICTED RIGHTS." 
+# Use, duplication, or disclosure by the Government is subject to the restrictions as set 
+# forth in FAR 52.227-14 and DFAR252.227-7013, et seq., or its successor.  Use of the 
+# Materials by the Government constitutes acknowledgement of AMD's proprietary rights in them.
+# 
+# EXPORT RESTRICTIONS: The Materials may be subject to export restrictions as stated in the 
+# Software License Agreement.
+# 
+
+echo $PROGVERSION
+exit 0

--- a/utils/blt.patch
+++ b/utils/blt.patch
@@ -1,0 +1,15 @@
+# Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved.
+diff --git a/cmake/SetupCompilerOptions.cmake b/cmake/SetupCompilerOptions.cmake
+index a9e0743..d5f9da8 100644
+--- a/cmake/SetupCompilerOptions.cmake
++++ b/cmake/SetupCompilerOptions.cmake
+@@ -135,8 +135,7 @@ message(STATUS "Adding optional BLT definitions and compiler flags")
+ ####################################################
+ # create relocatable static libs by default
+ ####################################################
+-set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+-
++set(CMAKE_POSITION_INDEPENDENT_CODE TRUE CACHE BOOL "SET IF FPIC NEEDED")
+ ##############################################
+ # Support extra definitions for all targets
+ ##############################################

--- a/utils/extractTestsFromGTest.py
+++ b/utils/extractTestsFromGTest.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import typing
+import subprocess
+import shlex
+import os
+
+parser = argparse.ArgumentParser(prog='GTest TestCase Extractor')
+parser.add_argument('executable', help='The name of the executable to query')
+
+
+def process(gtest_output):
+  split_out = gtest_output.split('\n')
+  currTestSuite=''
+  currTestCase=''
+  tests = []
+  for s in split_out:
+    if s.find('.') != -1:
+      currTestSuite=s[:s.find('.')]
+      currTestCase = '' # Reset
+    else:
+      currTestCase=s.strip()
+    if len(currTestSuite) > 0 and len(currTestCase) == 0:
+      continue
+
+    tests.append(currTestSuite + '.' + currTestCase)
+  return tests
+
+def myMain(args) -> None:
+  sh_command = "{} --gtest_list_tests".format(args.executable)
+  sh_args = shlex.split(sh_command)
+  os.environ['OMP_NUM_THREADS']='2'
+  os.environ['OMP_PROC_BIND']='spread'
+  cp = subprocess.run(sh_args, shell=False, check=True, capture_output=True, text=True) # TODO: wire-up out/err streams
+  output = cp.stdout
+
+  tests_to_run = process(output)
+  for t in tests_to_run:
+    print(t)
+
+if __name__ == "__main__":
+  myMain(parser.parse_args())

--- a/utils/gpurun
+++ b/utils/gpurun
@@ -1,0 +1,672 @@
+#!/bin/bash
+# Copyright(C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+#  gpurun: Process launch utility for GPU applications. This is a wrapper
+#          to execute application binaries including OpenMPI GPU applications.
+#          See help message below (gpurun -h) for more information.
+#
+#  Usage Examples:
+#    gpurun true
+#    mpirun -np  4 gpurun env | grep ROCR_VISIBLE_DEVICES
+#
+
+# If set to 1, just invoke the rest of the command line without doing anything
+# else.
+GPURUN_BYPASS=${GPURUN_BYPASS:-0}
+
+function execOnError() {
+   exec "$@"
+}
+
+if  [ "$GPURUN_BYPASS" = "1" ]; then
+  execOnError "$@"
+fi
+
+# PROGVERSION string is updated by cmake when component is installed
+PROGVERSION=X.Y-Z
+function version(){
+   echo $0 version $PROGVERSION
+   exit 0
+}
+function usage(){
+/bin/cat 2>&1 <<"EOF"
+
+   gpurun: Application process launch utility for GPUs.
+           This utility ensures the process will enable either a single
+	   GPU or the number specified with -md (multi-device) option.
+           It launches the application binary with either the 'taskset'
+           or 'numactl' utility so the process only runs on CPU cores
+           in the same NUMA domain as the selected GPUs.
+           This utility sets environment variable ROCR_VISIBLE_DEVICES
+	   to selected GPUs ONLY if it was not already set by the
+	   callers environment AND the number of GPUs is not 1.
+           This utility also sets environment variable HSA_CU_MASK
+           to control which CUs are available to the process.
+	   HSA_CU_MASK is set only when more than one OpenMPI process
+	   (rank) will utilize the same GPU and it is not preset.
+           Lastly, it sets env variable OMPX_TARGET_TEAM_PROCS to the
+           number of CUs available to the process after masking.
+
+   Usage:
+      gpurun <executable> [ <executable args> ]
+      mpirun -np <num ranks>  gpurun <executable> [ <executable args> ]
+
+   Options:
+      -h   Print this help message and exit
+      -md  Set number of desired devices for multi-device mode, default=1
+      -s   suppress output, often useful in benchmarking
+      -q   suppress output, quiet, alias of -s, same as GPURUN_VERBOSE=0
+      -v   Verbose output, same as GPURUN_VERBOSE=1
+      -vv  Verbose output, same as GPURUN_VERBOSE=2
+      -m   use numactl membind to CPUs in same NUMA domain. Note: Allocation
+           fails when not enough memory available on these nodes.
+      -l   use numactl localalloc to CPUs in same NUMA domain. Note: If
+           memory cannot be allocated, alloc falls back to other nodes.
+      --version Print version of gpurun and exit
+
+   Optional Input environment variables:
+      GPURUN_VERBOSE
+        0:  default for silent operation, no trace printed to stderr
+        1:  -v prints trace record including process launch cmd to stderr
+        2:  -vv prints trace and other summary diagnostics
+      ROCMINFO_BINARY  Set location of rocminfo binary
+      AOMP: location of AOMP or ROCM
+      GPURUN_DEVICE_BIAS: amount to shift device number to avoid dev 0.
+                          This only works for single device mode.
+      GPURUN_VISIBLE_DEVICE_TYPES: useful if machine has different GPU cards
+      GPURUN_MASK_POLICY : useful if machine has different GPU cards
+      ROCR_VISIBLE_DEVICES: See description above
+      OMPI_COMM_WORLD_LOCAL_SIZE Number of ranks on this node set by openmpi
+      OMPI_COMM_WORLD_LOCAL_RANK The local rank number 0-(nranks-1) from openmpi
+      This also checks for MPI_LOCALNRANKS/MPI_LOCALRANKID
+      and MPI_COMM_WORLD_LOCAL_SIZE/MPI_COMM_WORLD_LOCAL_RANK
+
+   Generated (output) Environment Variables:
+      OMPX_TARGET_TEAM_PROCS - Number of CUs available to process
+      ROCR_VISIBLE_DEVICES - list of GPU Uuids for the selected devices if not preset
+      HSA_CU_MASK - The CU mask for the device.
+      LIBOMPTARGET_NUM_MULTI_DEVICES - the value set by -md argument
+      GPU_MAX_HW_QUEUES
+      LIBOMPTARGET_AMDGPU_NUM_HSA_QUEUES"
+
+   Limitations:
+   - Currently, gpurun creates masks that are mutually exclusive of each other.
+     That is, the MPI processes will not share CUs. If number of ranks is not
+     perfectly divisible by number of CUs or number of GPUs, some resources
+     would be unused.
+     Set GPURUN_VERBOSE=1 or 2 to see overall cu utilization.
+   - Works with AOMP 19.0-0 or ROCM 6.1 or greater
+   - cu masking is not available when multiple devices per process are enabled
+     with -md option (multi-device) mode.
+
+   Notes:
+     With MPI, this utility distributes GPUs and their CUs across
+     multiple ranks of an MPI job into mutually exclusive sets of CUs.
+     It uses OpenMPI environment variables OMPI_COMM_WORLD_LOCAL_SIZE
+     and OMPI_COMM_WORLD_LOCAL_RANK to set visible devices and a
+     the mutually exclusive CU mask.
+
+     An rplace (rank place) is a subset of CUs for a rank. 
+     gpurun calculates the number of rplaces needed to contain all
+     the specified number of ranks for this node. If number of ranks not
+     divisible by number of GPUs, then there will be more rplaces than ranks.
+     The number of CUs in an rplace is calculated by dividing the number of
+     CUs per GPU by the number of rplaces per GPU. This is also the number of
+     bits set in the CU mask. This is also the number of physical locations
+     available for an OpenMP team to execute. This utility exports that number
+     to the environment variable OMPX_TARGET_TEAM_PROCS. This value
+     could be used by the application or runtume to adjust the number
+     of desired teams in a target region. If no masking occurs, the entire
+     GPU is available for the process and OMPX_TARGET_TEAM_PROCS is set to
+     the total number of CUs on the GPU.
+
+   Copyright (c) 2024  ADVANCED MICRO DEVICES, INC.
+
+EOF
+  exit 0
+}
+
+_end_gpurun_opts=0
+_devices_per_mdset=1
+_uses_multi_device=0
+while [ "$_end_gpurun_opts" == "0"  ] ; do
+   case "$1" in
+      -s)          GPURUN_VERBOSE=0;;
+      -q)          GPURUN_VERBOSE=0;;
+      --quiet)     GPURUN_VERBOSE=0;;
+      -h)          usage ;;
+      -help)       usage ;;
+      --help)      usage ;;
+      -version)    version ;;
+      --version)   version ;;
+      -v)          GPURUN_VERBOSE=1;;
+      -vv)         GPURUN_VERBOSE=2;;
+      -m)          _use_numactl_membind=1;;
+      -md)         shift; _devices_per_mdset=$1; _uses_multi_device=1;;
+      -l)          _use_numactl_localalloc=1;;
+      -nomask)     GPURUN_MASK_POLICY="nomask";;
+      *)           _end_gpurun_opts=1; break;;
+   esac
+   if [ "$_end_gpurun_opts" == "0" ] ; then
+     shift
+   fi
+done
+
+# Default: quiet operation
+GPURUN_VERBOSE=${GPURUN_VERBOSE:-0}
+# Default: create mutually exclusive sets of CUs when GPU is oversubscribed
+GPURUN_MASK_POLICY=${GPURUN_MASK_POLICY:-mutex}
+# switch mask policy to preset if HSA_CU_MASK was preset
+[[ ! -z "$HSA_CU_MASK" ]] && GPURUN_MASK_POLICY=preset
+# switch mask policy to nomask for multi-device
+[[ $_uses_multi_device == 1 ]] && GPURUN_MASK_POLICY=nomask
+# Offset selected device to avoid some heavily used GPUs
+GPURUN_DEVICE_BIAS=${GPURUN_DEVICE_BIAS:-0}
+
+#  Get environment variables set by OpenMPI
+_num_local_ranks=$OMPI_COMM_WORLD_LOCAL_SIZE
+_local_rank_num=$OMPI_COMM_WORLD_LOCAL_RANK
+# If not OpenMPI, check for Platform MPI, MVAPICH
+if [ -z "$_num_local_ranks" ] ; then
+   _num_local_ranks=$MPI_LOCALNRANKS
+   _local_rank_num=$MPI_LOCALRANKID
+fi
+# Also try MPI_COMM_WORLD env vars
+if [ -z "$_num_local_ranks" ] ; then
+   _num_local_ranks=$MPI_COMM_WORLD_LOCAL_SIZE
+   _local_rank_num=$MPI_COMM_WORLD_LOCAL_RANK
+fi
+# Check if SLURM was used
+if [ -z "$_num_local_ranks" ] && [ ! -z $SLURM_CPUS_ON_NODE ] ; then
+   _num_local_ranks=$SLURM_CPUS_ON_NODE
+   _local_rank_num=$SLURM_LOCALID
+fi
+# If none of the above MPIs, assume gpurun is wrapper for single process on single GPU
+if [ -z "$_num_local_ranks" ] ; then
+   _num_local_ranks=1
+   _local_rank_num=0
+fi
+
+# Find location of the rocminfo binary
+AOMP=${AOMP:-_AOMP_INSTALL_DIR_}
+if [ ! -d $AOMP ] ; then
+   AOMP="_AOMP_INSTALL_DIR_"
+fi
+if [ ! -d $AOMP ] ; then
+   AOMP="/opt/rocm/lib/llvm"
+fi
+if [ ! -d $AOMP ] ; then
+   AOMP="/opt/rocm/llvm"
+fi
+if [ ! -d $AOMP ] ; then
+   realpath=`realpath $0`
+   thisdir=`dirname $realpath`
+   AOMP=$thisdir/..
+fi
+if [ ! -d $AOMP ] ; then
+   >&2 echo "ERROR: AOMP not found at $AOMP"
+   >&2 echo "       Please install AOMP or correctly set env-var AOMP"
+   execOnError "$@"
+fi
+ROCMINFO_BINARY=${ROCMINFO_BINARY:-$AOMP/bin/rocminfo}
+[ ! -f $ROCMINFO_BINARY ] && ROCMINFO_BINARY=$AOMP/../bin/rocminfo
+[ ! -f $ROCMINFO_BINARY ] && ROCMINFO_BINARY=$AOMP/../../bin/rocminfo
+if [ ! -f $ROCMINFO_BINARY ] ; then
+   >&2 echo "ERROR: Could not find binary for rocminfo,"
+   >&2 echo "       Please correct installation of ROCM or AOMP compiler"
+   execOnError "$@"
+fi
+
+# Use rocminfo to find number number of CUs and gfxids for each GPU.
+_tfile="/tmp/rinfo_out$$"
+$ROCMINFO_BINARY 2>/dev/null | grep -E "    Name:| Compute Unit:| Device Type:| BDFID:| Uuid:" >$_tfile
+_tfile_lines=`wc -l $_tfile | cut -d" " -f1`
+if [ $_tfile_lines == 0 ] ; then
+  >&2 echo "ERROR: $ROCMINFO_BINARY failed to find GPU devices"
+  rm $_tfile
+  execOnError "$@"
+fi
+# Create 3 _ri_ arrays by parsing rocminfo (ri), one array entry per device
+_ri_all_gfxids=""
+_ri_gfxids=()
+_ri_cucount=()
+_ri_bdfids=()
+_ri_dev_idx=()
+_ri_num_devices=0
+_last_cu_count=0
+_ri_uuid=()
+_last_device_type_was_gpu=0
+_device_type_preset=0
+_ri_num_all_devices=0
+[ ! -z $GPURUN_VISIBLE_DEVICE_TYPES ] && _device_type_preset=1
+while read _linepair ; do
+  _fieldvalue=`echo $_linepair | cut -d":" -f2`
+  _fieldtype=`echo $_linepair | cut -d":" -f1`
+  if [ $_fieldvalue == "CPU" ] ; then
+     _last_device_type_was_gpu=0
+  elif [ $_fieldvalue == "GPU" ] ; then
+     _last_device_type_was_gpu=1
+  elif [ "$_fieldtype" == "Uuid" ] ; then
+     _this_uuid=$_fieldvalue
+  elif [ "$_fieldtype" == "BDFID" ] ; then
+     if [[ $_last_device_type_was_gpu == 1 ]] ; then
+        # _domain="$(echo "$_fieldvalue / (2^32)" | bc)"
+        _bus="$(echo "($_fieldvalue / (2^8)) % (2^8)" | bc)"
+        _devfn="$(echo "($_fieldvalue % (2^8))" | bc)"
+        _bdfidstr="$(printf "%.2x:%.2x" "$_bus" "$_devfn")"
+     fi
+  elif [ "$_fieldtype" == "Name" ] ; then
+     #  The device name field is last in rocminfo output, so we can create new _ri_ array entry
+     if [[ $_last_device_type_was_gpu == 1 ]] ; then
+	_this_gfxid=`echo $_fieldvalue | cut -d'-' -f5`
+        ! [[ ${_ri_all_gfxids} == *"$_this_gfxid"* ]] && _ri_all_gfxids+=" $_this_gfxid"
+        _is_type_visible=1
+	if [ $_device_type_preset == 1 ] ; then
+           _is_type_visible=0
+           if [[ ${GPURUN_VISIBLE_DEVICE_TYPES} == *"$_this_gfxid"* ]] ; then
+	     _is_type_visible=1
+	   fi
+	fi
+        if [ $_is_type_visible == 1 ] ; then
+           _ri_gfxids+=( $_this_gfxid )
+           _ri_cucount+=( $_last_cu_count )
+           _ri_bdfids+=( $_bdfidstr )
+	   _ri_dev_idx+=( $_ri_num_all_devices )
+	   _ri_uuid+=( $_this_uuid )
+           _ri_num_devices=$(( $_ri_num_devices + 1 ))
+	fi
+        _ri_num_all_devices=$(( $_ri_num_all_devices + 1 ))
+     fi
+  else
+     # else the _fieldvalue was the number of CUs or GCPUs
+     if [[ $_last_device_type_was_gpu == 1 ]] ; then
+        _last_cu_count=$_fieldvalue
+     fi
+  fi
+done < $_tfile
+rm $_tfile
+
+if [ $_ri_num_devices == 0 ] ; then
+   if [ $_local_rank_num == 0 ] ; then
+      if [ $_device_type_preset == 1 ] ; then
+         >&2 echo "ERROR: No amdgpu devices found by $ROCMINFO_BINARY of type $GPURUN_VISIBLE_DEVICE_TYPES."
+         >&2 echo "       Set GPURUN_VISIBLE_DEVICE_TYPES to one of these types: ${_ri_all_gfxids}"
+      else
+         >&2 echo "ERROR: No amdgpu devices found by $ROCMINFO_BINARY"
+      fi
+      if [ ! -z $ROCR_VISIBLE_DEVICES ] ; then
+         >&2 echo "       ROCR_VISIBLE_DEVICES was preset to $ROCR_VISIBLE_DEVICES"
+         >&2 echo "       Consider unset ROCR_VISIBLE_DEVICES and let gpurun set it correctly."
+      fi
+      execOnError "$@"
+   else
+      execOnError "$@"
+   fi
+fi
+
+# Scan /sys/bus/pci/devices (_ss_) for amdgpu devices and store info in 6 per
+# device arrays indexed by device num. The arrays are _ss_cpulist _ss_bdfids,
+# _ss_numanode, _ss_uuid, _ss_gfxid, and _ss_cucount. Some information
+# (cucount, gfxid, dev_idx) must be copied from the _ri_ arrays built above
+# by scanning output from rocminfo.
+_sysdevdir="/sys/bus/pci/devices"
+_ss_num_devices=0
+_ss_cpulist=()
+_ss_bdfid=()
+_ss_numanode=()
+_ss_uuid=()
+_ss_gfxid=()
+_ss_cucount=()
+for _devid in `ls $_sysdevdir` ; do
+   if [ -f $_sysdevdir/$_devid/device ] ; then
+      _driver_name=`cat $_sysdevdir/$_devid/uevent | grep DRIVER | awk '{print $1}'`
+      if [ ! -z $_driver_name ] ; then
+         if [ $_driver_name  == "DRIVER=amdgpu" ] ; then
+            _numa_node=`cat $_sysdevdir/$_devid/numa_node`
+            [ "$_numa_node" == "-1" ] && _numa_node=0
+            _this_uuid=0
+	    if [ -f $_sysdevdir/$_devid/unique_id ] ; then
+               _this_uuid=`cat $_sysdevdir/$_devid/unique_id`
+	       if [ -z $_this_uuid ] ; then
+                  _this_uuid=0
+		  _has_unique_id_file=0
+	       else
+                  _this_uuid="GPU-$_this_uuid"
+		  _has_unique_id_file=1
+	       fi
+	    fi
+            _this_cpulist=`cat $_sysdevdir/$_devid/local_cpulist`
+	    _match_uuid_count=0
+	    for _ri_i in ${!_ri_bdfids[@]} ; do
+               _ss_value=$_this_uuid
+               _ri_value=${_ri_uuid[$_ri_i]}
+               if [ $_ss_value == $_ri_value ] ; then
+                  _match_uuid_count=$(( $_match_uuid_count + 1 ))
+	       fi
+	    done
+            # Search _ri_ arrays for matching uuids or matching bdfids.
+	    for _ri_i in ${!_ri_bdfids[@]} ; do
+	       if [ "$_has_unique_id_file" == "1" ] ; then
+                  _ss_value=$_this_uuid
+                  _ri_value=${_ri_uuid[$_ri_i]}
+               elif [ "${_ri_bdfids[$_ri_i]}" == "00:00" ]; then
+                  # Under Hyper-V, we may see a zero BDFID.  Fall back to UUID.
+                  _ss_value=$_devid
+                  _ri_value=$_devid
+	       else
+                  _ss_value=$_devid
+                  _ri_value="0000:${_ri_bdfids[$_ri_i]}.0"
+               fi
+               if [ $_ss_value == $_ri_value ] ; then
+	          if [ $_this_uuid == 0 ] || [ $_match_uuid_count -gt 1 ] ; then
+	             # Some GPUs do not have unique_id or TPX mode creates multiple
+		     # identical uuids, so use device index for RVD
+                     _ss_uuid+=( ${_ri_dev_idx[$_ri_i]} )
+		  else
+                     _ss_uuid+=( $_this_uuid )
+		  fi
+		  _ss_gfxid+=( ${_ri_gfxids[$_ri_i]} )
+		  _ss_cucount+=( ${_ri_cucount[$_ri_i]} )
+                  _ss_bdfid+=( $_devid )
+                  _ss_numanode+=( $_numa_node )
+                  _ss_cpulist+=( $_this_cpulist )
+                  _ss_num_devices=$(( $_ss_num_devices + 1 ))
+               fi
+            done
+         fi
+      fi
+   fi
+done
+
+if [[ $_ss_num_devices -lt 1  ]] ; then
+   if [ $_device_type_preset == 1 ] ; then
+      >&2 echo "ERROR: No amdgpu devices found in $_sysdevdir of type $GPURUN_VISIBLE_DEVICE_TYPES."
+      >&2 echo "       Set GPURUN_VISIBLE_DEVICE_TYPES to one of these types: ${_ri_all_gfxids}"
+   else
+      >&2 echo "ERROR: No amdgpu devices found in $_sysdevdir."
+   fi
+   execOnError "$@"
+fi
+
+# check for taskset or numactl cmd
+if [ "$_use_numactl_membind" == "1" ] || [ "$_use_numactl_localalloc" == "1" ] ; then
+  _launch_process_cmd_binary=`which numactl`
+  if [ $? != 0 ] ; then
+    >&2 echo "ERROR: The -m (membind) or -l (localalloc) require numactl to be installed."
+    execOnError "$@"
+  fi
+else
+  _launch_process_cmd_binary=`which taskset`
+  if [ $? != 0 ] ; then
+    >&2 echo "ERROR: $0 requires the taskset command to be installed."
+    execOnError "$@"
+  fi
+fi
+if [ "$_use_numactl_membind" == "1" ] && [ "$_use_numactl_localalloc" == "1" ] ; then
+  >&2 echo "GPURUN WARNING: When -l and -m are both set, -m is ignored."
+  _use_numactl_membind=0
+fi
+
+_utilized_devices=$_ri_num_devices
+[ $_ri_num_devices -gt $_num_local_ranks ] && _utilized_devices=$_num_local_ranks
+
+# Calculate number of GPUs to use to evenly spread ranks across GPUs.
+# An rplace is a set of CUs that will be used for a rank.
+# The number of rplaces must be at least the number of ranks.
+_uncovered_ranks=$(( $_num_local_ranks % $_utilized_devices ))
+_number_of_rplaces_per_GPU=$(( $_num_local_ranks / $_utilized_devices ))
+if [ $_uncovered_ranks != 0 ] ; then
+   # If _num_local_ranks not divisible by number of GPUs,
+   # then add an extra rplace per GPU to make room for remainder.
+   _number_of_rplaces_per_GPU=$(( $_number_of_rplaces_per_GPU + 1 ))
+fi
+if [ $GPURUN_MASK_POLICY == "mutex" ] ; then
+   # For mutex policy, adjacent ranks are assigned to the same device.
+   _rplace_num=$(( $_local_rank_num / $_number_of_rplaces_per_GPU ))
+   # Some users want to avoid dev 0 etc, by setting GPURUN_DEVICE_BIAS
+   _device_num=$(( ( $_rplace_num + $GPURUN_DEVICE_BIAS ) % $_ri_num_devices ))
+else
+   # for mask policies nomask or preset, adjacent ranks are assigned to
+   # different GPUs and oversubscribed ranks are assigned round robin
+   _device_num=$(( ( $_local_rank_num + $GPURUN_DEVICE_BIAS ) % $_ri_num_devices ))
+fi
+
+_node_cus=$(( $_ri_num_devices * ${_ss_cucount[$_device_num]} ))
+if [ $_num_local_ranks -gt $_node_cus ] ; then
+   >&2 echo "ERROR: Not enough CUs ($_node_cus) for $_num_local_ranks ranks "
+   execOnError "$@"
+fi
+
+if [ $_uses_multi_device == 1 ]; then
+   # Enforce some rules on the use of -md option
+   # Note -md forces GPURUN_MASK_POLICY=nomask
+   if [[ ! -z $ROCR_VISIBLE_DEVICES ]] ; then
+      >&2 echo "ERROR: DO NOT PRESET ROCR_VISIBLE_DEVICES in gpurun multi-device (-md) mode"
+      execOnError "$@"
+   fi
+   if [ $_devices_per_mdset -gt $_ri_num_devices ] ; then
+      >&2 echo "ERROR: More devices requested ($_devices_per_mdset) than available ($_ri_num_devices)"
+      execOnError "$@"
+   fi
+   _md_total_devices=$(( $_num_local_ranks * $_devices_per_mdset ))
+   if [ $_md_total_devices -gt $_ri_num_devices ] &&  [ $_local_rank_num == 0 ] ; then
+      printf "WARNING: processes($_num_local_ranks) * md set size($_devices_per_mdset) = $_md_total_devices > than available devices ($_ri_num_devices)\n         Some multi-device sets will overlap.\n" >&2
+   fi
+   _md_device_set_start=$(( ( $_local_rank_num * $_devices_per_mdset ) % $_ri_num_devices))
+   _md_device_set_end=$(( $_md_device_set_start + $_devices_per_mdset - 1 ))
+
+   # merge entries for this mdset from per device arrays
+   _md_bdfs=""
+   _md_cpus=""
+   _md_nns=""
+   _md_uuids=""
+   _md_dev_idxs=""
+   _sep=""
+   for i in `seq $_md_device_set_start $_md_device_set_end` ; do
+      _dev_index=$i
+      # handle index wrap around number of devices
+      [ $i -ge $_ri_num_devices ] && _dev_index=$(( $i % $_ri_num_devices ))
+      _md_bdfs+=$_sep${_ss_bdfid[$_dev_index]}
+      _new_nn=${_ss_numanode[$_dev_index]}
+      SAVEIFS=$IFS
+      IFS=","
+      _found=0
+      for _existing_nn in $_md_nns ; do
+         [ $_existing_nn == $_new_nn ] && _found=1
+      done
+      IFS=$SAVEIFS
+      if [ $_found == 0 ] ; then
+	 # only add new numa node and cpulist, if not already in the md set
+         _md_nns+=$_sep$_new_nn
+         _md_cpus+=$_sep${_ss_cpulist[$_dev_index]}
+      fi
+      _md_uuids+=$_sep${_ss_uuid[$_dev_index]}
+      _md_dev_idxs+=$_sep$_dev_index
+      _sep=","
+   done
+   _device_num=$_md_device_set_start
+fi
+
+_available_CUs_per_device=${_ss_cucount[$_device_num]}
+_gfxid=${_ss_gfxid[$_device_num]}
+
+_node_cus=$(( $_ri_num_devices * ${_ss_cucount[$_device_num]} ))
+if [ $_num_local_ranks -gt $_node_cus ] ; then
+   >&2 echo "ERROR: Not enough CUs ($_node_cus) for $_num_local_ranks ranks "
+   execOnError "$@"
+fi
+
+_utilized_CUs_per_device=$_available_CUs_per_device
+_rem2=$(( $_utilized_CUs_per_device % $_number_of_rplaces_per_GPU ))
+# Lower utilized CUs till divisible by number of rplaces per GPU
+while [ $_rem2 != 0 ] ; do
+   _utilized_CUs_per_device=$(( $_utilized_CUs_per_device - 1 ))
+   _rem2=$(( $_utilized_CUs_per_device % $_number_of_rplaces_per_GPU ))
+done
+_CUs_per_rplace=$(( $_utilized_CUs_per_device / $_number_of_rplaces_per_GPU ))
+
+# --- THIS BLOCK ONLY FOR VERBOSE DIAGS PRINTED FROM RANK 0
+if [ $_local_rank_num == 0 ] && [[ "$GPURUN_VERBOSE" == "2" ]]; then
+   if [ $_uses_multi_device == 0 ] ; then
+      _wasted_CUs_on_each_GPU=$(( $_available_CUs_per_device - $_utilized_CUs_per_device ))
+      _total_GPU_rplaces=$(( $_number_of_rplaces_per_GPU * $_ri_num_devices ))
+      _total_wasted_rplaces=$(( $_total_GPU_rplaces - $_num_local_ranks ))
+      _wasted_GPUs=$(( $_total_wasted_rplaces / $_number_of_rplaces_per_GPU ))
+      _used_cus=$(( $_num_local_ranks * $_CUs_per_rplace ))
+      _utilization=$(( ( $_used_cus * 100 ) / $_node_cus ))
+      if ! [ $_ri_num_devices -gt $_num_local_ranks ] ; then
+         if [ $_wasted_CUs_on_each_GPU != 0 ] || [ $_total_wasted_rplaces != 0 ] ; then
+            _extra_diags=true
+         fi
+      fi
+      >&2 echo "-  ROCMINFO LOCATION:   $ROCMINFO_BINARY"
+      >&2 echo "-  PROCESSES:           $_num_local_ranks (RANKS)"
+      >&2 echo "-  AVAILABLE GPUS:      $_ri_num_devices"
+      [ $_extra_diags ] && \
+      >&2 echo "-- USED GPUS:           $(( $_ri_num_devices - $_wasted_GPUs ))"
+      [ $_extra_diags ] && \
+      >&2 echo "-- UNUSED GPUS:         $(( $_total_wasted_rplaces / $_number_of_rplaces_per_GPU )) "
+      [ $_extra_diags ] && echo
+      >&2 echo "-  RPLACEs PER NODE:    $_total_GPU_rplaces"
+      >&2 echo "-  RPLACEs PER GPU:     $_number_of_rplaces_per_GPU"
+      [ $_extra_diags ] && \
+      >&2 echo "-- USED RPLACEs:        $_num_local_ranks (RANKS)"
+      [ $_extra_diags ] && \
+      >&2 echo "-- UNUSED RPLACEs:      $_total_wasted_rplaces" ; \
+      >&2 echo "-  gfxids               ${_ss_gfxid[@]}"
+      >&2 echo "-  CUs PER GPU:         ${_ss_cucount[@]}"
+      [ $_extra_diags ] && \
+      >&2 echo "-- USED on CUs RANK0:   $_utilized_CUs_per_device"
+      [ $_extra_diags ] && \
+      >&2 echo "-- UNUSED CUs RANK0 :   $_wasted_CUs_on_each_GPU"
+      >&2 echo "-  CUs per RPLACE RANK0:$_CUs_per_rplace (OMPX_TARGET_TEAM_PROCS)"
+      >&2 echo "-  FORMULA: OMPX_TARGET_TEAM_PROCS = $_utilized_CUs_per_device / $_number_of_rplaces_per_GPU"
+      if [[ ! -z "$ROCR_VISIBLE_DEVICES" ]] ; then
+         >&2 echo "-  Preset ROCR_VISIBLE_DEVICES:  $ROCR_VISIBLE_DEVICES"
+      fi
+      if [[ ! -z "$HSA_CU_MASK" ]] ; then
+         # node utilizatino could be incorrect with preset cumask.
+         >&2 echo "-  Preset HSA_CU_MASK: $HSA_CU_MASK"
+      else
+         >&2 echo "-  NODE UTILIZATION:  $_utilization %"
+      fi
+   else
+      >&2 echo "-  ROCMINFO LOCATION: $ROCMINFO_BINARY"
+      >&2 echo "-  PROCESSES:         $_num_local_ranks (RANKS)"
+      >&2 echo "-  AVAILABLE GPUS:    $_ri_num_devices"
+      >&2 echo "-  DEVS PER RANK:     $_devices_per_mdset"
+      >&2 echo "-  MULTI-DEVICE GPUS: $_md_total_devices (RANKS*DEVS-PER-RANK)"
+      _md_utilization=$(( $_md_total_devices * 100 / $_ri_num_devices ))
+      >&2 echo "-  NODE UTILIZATION:  $_md_utilization %"
+   fi
+fi
+#  --- END OF DIAGNOSTIC BLOCK
+
+if [ $_CUs_per_rplace != $_available_CUs_per_device ] && [ $GPURUN_MASK_POLICY == "mutex" ] ; then
+   #  Build the CU mask for this rank, bits_to_set = _CUs_per_rplace
+   _bits_to_set=$_CUs_per_rplace
+   #  This formula keeps adjacent ranks on same GPU which should be preferred
+   _bits_to_shift=$(( ( $_local_rank_num * $_bits_to_set) - ( _device_num * $_utilized_CUs_per_device) ))
+   # use bc because these values can be very large
+   _unshifted_bits=`echo "(2 ^ $_bits_to_set) - 1" | bc`
+   _mask=`echo "obase=16; $_unshifted_bits * (2 ^ $_bits_to_shift)" | bc`
+   # Calculate the number of leading zeros needed for this mask
+   _lz=$(( ( $_utilized_CUs_per_device / 4 ) - ${#_mask} + 1 ))
+   for i in `seq 1 $_lz` ; do
+      _mask="0$_mask"
+   done
+   _mask="0x$_mask"
+fi
+
+_launch_process_cmd=""
+if [ $_uses_multi_device == 0 ] ; then
+   # retrieve scanned info from per device arrays
+   _bdfidstrc=${_ss_bdfid[$_device_num]}
+   NUMANODE=${_ss_numanode[$_device_num]}
+   _list_of_cpu_cores=${_ss_cpulist[$_device_num]}
+   _this_uuid=${_ss_uuid[$_device_num]}
+else
+   # Use multi-device values
+   _bdfidstrc=$_md_bdfs
+   NUMANODE=$_md_nns
+   _list_of_cpu_cores=$_md_cpus
+   _this_uuid=$_md_uuids
+   _launch_process_cmd+="env LIBOMPTARGET_NUM_MULTI_DEVICES=$_devices_per_mdset "
+fi
+if [ "$_use_numactl_localalloc" == "1" ] ; then
+   _launch_process_cmd+="$_launch_process_cmd_binary --localalloc --cpunodebind=$NUMANODE"
+elif [ "$_use_numactl_membind" == "1" ] ; then
+   _launch_process_cmd+="$_launch_process_cmd_binary --membind=$NUMANODE --cpunodebind=$NUMANODE"
+else
+   _launch_process_cmd+="$_launch_process_cmd_binary -c $_list_of_cpu_cores"
+fi
+
+# If gpurun was not given command to execute, then dont run _launch_process_cmd
+[ "$*" == "" ] && _launch_process_cmd=""
+
+# only set ROCR_VISIBLE_DEVICES if not already set
+if [[ -z $ROCR_VISIBLE_DEVICES ]] ; then
+   export ROCR_VISIBLE_DEVICES=$_this_uuid
+   _log_word="RVD"
+else
+   _log_word="PRESET-RVD"
+fi
+
+export OMPX_TARGET_TEAM_PROCS=$_CUs_per_rplace
+
+#  - Limit HSA queues when multiple ranks per GPU
+if [ $_number_of_rplaces_per_GPU != 1 ] ; then
+   # Only set these env controls if not set by caller
+   [[ -z "$GPU_MAX_HW_QUEUES" ]] && export GPU_MAX_HW_QUEUES=1
+   [[ -z "$LIBOMPTARGET_AMDGPU_NUM_HSA_QUEUES" ]] && export LIBOMPTARGET_AMDGPU_NUM_HSA_QUEUES=1
+fi
+
+[[ ! -z "$HSA_CU_MASK" ]] && [[ "$GPURUN_VERBOSE" != "0"  ]] && \
+   [[ $_local_rank_num == 0 ]] && >&2 echo "WARNING: preset HSA_CU_MASK:$HSA_CU_MASK"
+
+if [ $_CUs_per_rplace == $_available_CUs_per_device ] || [ "$GPURUN_MASK_POLICY" == "nomask" ] ; then
+   # --- HSA_CU_MASK is NOT USED in this code block, This code block covers all multi-device execution.
+   if [ "$GPURUN_VERBOSE" != "0" ] ; then
+      if [ $_uses_multi_device == 1 ] ; then
+         printf "RANK:$_local_rank_num D:$_md_dev_idxs NNs:$_md_nns GPUTYPE:$_gfxid $_log_word:$ROCR_VISIBLE_DEVICES\n     CMD:$_launch_process_cmd $*\n" >&2
+      else
+         printf "RANK:$_local_rank_num D:%d PCI:%5s NN:%d GPUTYPE:$_gfxid $_log_word:%s \n     CMD:%s $*\n" $_device_num $_bdfidstrc $NUMANODE $ROCR_VISIBLE_DEVICES "$_launch_process_cmd" >&2
+      fi
+   fi
+   $_launch_process_cmd $*
+   # --- end code block
+else
+   # --- HSA_CU_MASK is required in this code block, assumes no multi-device
+   if [[ -z "$HSA_CU_MASK" ]] ; then
+      # Since ROCR_VISIBLE_DEVICES only enables 1 GPU, HSA_CU_MASK starts with 0:
+      export HSA_CU_MASK=0:$_mask
+   else
+      # use preset mask
+      _mask=$HSA_CU_MASK
+   fi
+   if [ "$GPURUN_VERBOSE" != "0" ] ; then
+      printf "RANK:$_local_rank_num D:%d PCI:%5s NN:%d $_gfxid CUMASK:$_mask $_log_word:$ROCR_VISIBLE_DEVICES \n     CMD:%s $*\n" $_device_num $_bdfidstrc $NUMANODE "$_launch_process_cmd" >&2
+   fi
+   HSA_CU_MASK=0:$_mask \
+   $_launch_process_cmd $*
+   # --- end code block
+fi
+exit $?

--- a/utils/kokkos_build-cgsolve.sh
+++ b/utils/kokkos_build-cgsolve.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright(C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+#  kokkos_build.sh: Script to clone and build kokkos for a specific GPU
+#                   This will build kokkos in directory $HOME/kokkos_build.<GPUNAME>
+#
+#
+#  Written by Jan-Patrick Lehr <JanPatrick.Lehr@amd.com>
+#
+PROGVERSION="X.Y-Z"
+#
+
+function print_info() {
+  toPrint="$1"
+
+  echo "[Info]: $toPrint"
+}
+function print_error() {
+  toPrint="$1"
+
+  echo "[Error]: $toPrint"
+}
+
+AOMP="${AOMP:-_AOMP_INSTALL_DIR_}"
+
+if [ ! -d $AOMP ] ; then
+   print_error "AOMP is not installed in ${AOMP}. Please set the environment variable."
+   exit 1
+fi
+
+GIT_DIR=${GIT_DIR:-$HOME/git}
+KOKKOS_SOURCE_DIR=${KOKKOS_SOURCE_DIR:-$GIT_DIR/kokkos}
+KOKKOS_EXAMPLES_SOURCE_DIR=${KOKKOS_EXAMPLES_SOURCE_DIR:-$GIT_DIR/kokkos-openmptarget-examples}
+KOKKOS_EXAMPLES_REPO=https://github.com/kokkos/kokkos-openmptarget-examples.git
+NUM_THREADS=${NUM_THREADS:-8}
+
+COMPILERNAME_TO_USE=${_COMPILER_TO_USE_:-clang++}
+AOMP_VERSION=$($AOMP/bin/${COMPILERNAME_TO_USE} --version | head -n 1)
+
+cd $GIT_DIR || exit 1
+
+if [ "$1" == "clean" ]; then
+  print_info "Removing $KOKKOS_EXAMPLES_SOURCE_DIR"
+  rm -rf $KOKKOS_EXAMPLES_SOURCE_DIR
+  exit 0
+fi
+
+# Get the source code
+git clone $KOKKOS_EXAMPLES_REPO $KOKKOS_EXAMPLES_SOURCE_DIR
+
+# Change to the directory
+cd $KOKKOS_EXAMPLES_SOURCE_DIR || exit 1
+
+cd cgsolve || exit 1
+
+# The Makefile in the repo does not make use of a Kokkos installation
+# Instead, it needs to be pointed to the Kokkos repository and fed additional config flags
+# For now, we simply stick with what the Kokkos developers did, but we may want to change it
+# But one thing we may need to change is the compiler name. let's do brute force for now.
+sed -i "s/amdclang++/${COMPILERNAME_TO_USE}/g" ../Makefile.inc
+# Do not use debug info for the time being.
+sed -i "s/-O3 -g/-O3/g" Makefile
+# Replace hard coded gfx90a with AOMP_GPU env var
+echo "updating Makefile.inc for AOMP_GPU=$AOMP_GPU"
+sed -i "s/-march=gfx90a/-march=$AOMP_GPU/" ../Makefile.inc
+
+cmd="PATH=$AOMP/bin:$PATH CXX=clang++ make KOKKOS_PATH=$KOKKOS_SOURCE_DIR arch=MI250x backend=ompt comp=rocmclang"
+
+print_info "$cmd"
+PATH=$AOMP/bin:$PATH CXX=clang++ make KOKKOS_PATH=$KOKKOS_SOURCE_DIR arch=MI250x backend=ompt comp=rocmclang -j${NUM_THREADS}
+#OFFLOAD_FLAGS='-ffast-math -fopenmp-target-fast'
+
+

--- a/utils/kokkos_build.sh
+++ b/utils/kokkos_build.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+#  kokkos_build.sh: Script to clone and build kokkos for a specific GPU
+#                   This will build kokkos in directory $HOME/kokkos_build.<GPUNAME>
+#
+#
+#  Written by Greg Rodgers  Gregory.Rodgers@amd.com, Jan-Patrick Lehr JanPatrick.Lehr@amd.com
+#
+PROGVERSION="X.Y-Z"
+#
+
+function print_info() {
+  toPrint="$1"
+
+  echo "[Info]: $toPrint"
+}
+function print_error() {
+  toPrint="$1"
+
+  echo "[Error]: $toPrint"
+}
+echo "$AOMP"
+AOMP="${AOMP:-AOMP_INSTALL_DIR}"
+echo "$AOMP"
+if [ ! -d $AOMP ] ; then
+   print_error "AOMP is not installed in ${AOMP}. Please set the environment variable."
+   exit 1
+fi
+
+KOKKOS_SOURCE_PREFIX=${KOKKOS_SOURCE_PREFIX:-$HOME/git}
+KOKKOS_SOURCE_DIR=${KOKKOS_SOURCE_DIR:-$KOKKOS_SOURCE_PREFIX/kokkos}
+KOKKOS_URL=https://github.com/kokkos/kokkos.git
+# Per default (for now) we want to use release 3.7.00 to establish a working baseline.
+KOKKOS_TAG=${_KOKKOS_TAG_:-3.7.01}
+# For development we also want to pull-in (most recent) devel
+KOKKOS_BRANCH=${_KOKKOS_BRANCH_:-develop}
+KOKKOS_SHA=7c76889 # This is pretty old
+KOKKOS_SHA=${_KOKKOS_SHA_:-}
+NUM_THREADS=${NUM_THREADS:-8}
+
+COMPILERNAME_TO_USE=${_COMPILER_TO_USE_:-clang++}
+
+
+if [[ "$AOMP" =~ "opt" ]]; then
+  # xargs trims the string off whitespaces
+  export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
+  print_info "Set AOMP_GPU with rocminfo: $DETECTED_GPU"
+  #print_info "Set AOMP_GPU with rocm_agent_enumerator.
+  #export DETECTED_GPU=$($AOMP/../bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
+else
+  print_info "Set AOMP_GPU with offload-arch."
+  if [ -a $AOMP/bin/rocminfo ]; then
+    export DETECTED_GPU=$($AOMP/bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
+  else
+    export DETECTED_GPU=$($AOMP/bin/offload-arch | grep -m 1 -E gfx[^0]{1}.{2})
+  fi
+fi
+
+AOMP_VERSION=$($AOMP/bin/${COMPILERNAME_TO_USE} --version | head -n 1)
+
+AOMP_GPU=${AOMP_GPU:-$DETECTED_GPU}
+
+# Determine if AOMP_GPU is supported in KOKKOS. Currently looks for AMD only.
+kokkos_regex="gfx(.*)"
+supported_arch_vega="900 906 908 90a"
+supported_arch_navi="1030 1100"
+declare -A arch_array
+print_info "Supported KOKKOS GFX: $supported_arch_vega $supported_arch_navi"
+
+# Store arch in associative array
+for arch in $supported_arch_vega; do
+  # Add name used in Kokkos CMake for Architecture
+  arch_str="VEGA${arch^^}"
+  arch_array[$arch]=$arch_str
+done
+
+for arch in $supported_arch_navi; do
+  # Add name used in Kokkos CMake for Architecture
+  arch_str="NAVI${arch^^}"
+  arch_array[$arch]=$arch_str
+done
+
+if [[ "$AOMP_GPU" =~ $kokkos_regex ]]; then
+  matched_arch=${BASH_REMATCH[1]}
+else
+  print_error "Error: Cannot determine KOKKOS_ARCH"
+fi
+
+# Check if matched_arch is present in array
+if [[  -v arch_array[$matched_arch] ]]; then
+  # Get Kokkos name for arch
+  KOKKOS_ARCH=${KOKKOS_ARCH:-${arch_array["$matched_arch"]}}
+else
+  print_error "Error: gfx${matched_arch} is currently not supported in KOKKOS"
+  exit 1
+fi
+
+print_info "Using configuration"
+print_info "AOMP_GPU    = $AOMP_GPU"
+print_info "KOKKOS_TAG  = $KOKKOS_TAG"
+print_info "KOKKOS_ARCH = $KOKKOS_ARCH"
+print_info "KOKKOS_SOURCE = $KOKKOS_SOURCE_DIR"
+print_info "AOMP        = $AOMP"
+print_info "AOMP Version = $AOMP_VERSION"
+
+if [ "$AOMP_GPU" == "" ] || [ "$AOMP_GPU" == "unknown" ]; then
+  print_error "Error: AOMP_GPU not properly set...exiting."
+  exit 1
+fi
+
+KOKKOS_BUILD_PREFIX=${KOKKOS_BUILD_PREFIX:-$HOME}
+
+if [ -f /usr/local/cmake/bin/cmake ] ; then
+  AOMP_CMAKE=${AOMP_CMAKE:-/usr/local/cmake/bin/cmake}
+else
+  AOMP_CMAKE=${AOMP_CMAKE:-cmake}
+fi
+
+if [ "$1" == "hip" ] ; then
+   kokkos_backend="hip"
+   KOKKOS_BUILD_DIR=${KOKKOS_BUILD_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_build_hip.$AOMP_GPU}
+   KOKKOS_INSTALL_DIR=${KOKKOS_INSTALL_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_hip.$AOMP_GPU}
+else
+   kokkos_backend="openmp"
+   KOKKOS_BUILD_DIR=${KOKKOS_BUILD_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_build_omp.$AOMP_GPU}
+   KOKKOS_INSTALL_DIR=${KOKKOS_INSTALL_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_omp.$AOMP_GPU}
+fi
+
+# Clean install, build and source directories
+if [ "$1" == "clean" ] ; then
+  print_info "Cleaning:"
+  print_info "SOURCE_DIR: $KOKKOS_SOURCE_DIR"
+  print_info "BUILD_DIR: $KOKKOS_BUILD_DIR"
+  print_info "INSTALL_DIR: $KOKKOS_INSTALL_DIR"
+  rm -rf $KOKKOS_SOURCE_DIR
+  rm -rf $KOKKOS_BUILD_DIR
+  rm -rf $KOKKOS_INSTALL_DIR
+  exit 0
+fi
+
+# This patch is required for builds of Clang/LLVM w/ assertions enabled for a Clang assertion failing
+# otherwise: Non-trivially copyable data types used by Kokkos.
+function patchkokkos(){
+patchfile1=/tmp/kokkos1_$$.patch
+/bin/cat >$patchfile1 <<"EOF"
+From e1a19dda160751eefb6b70a204a21db7a93c48b1 Mon Sep 17 00:00:00 2001
+From: JP Lehr <JanPatrick.Lehr@amd.com>
+Date: Mon, 31 Oct 2022 15:17:58 +0000
+Subject: [PATCH] Only to create a path
+
+---
+core/unit_test/TestNonTrivialScalarTypes.hpp | 2 ++
+1 file changed, 2 insertions(+)
+
+diff --git a/core/unit_test/TestNonTrivialScalarTypes.hpp b/core/unit_test/TestNonTrivialScalarTypes.hpp
+index 02064d2fc..e593e7e3d 100644
+--- a/core/unit_test/TestNonTrivialScalarTypes.hpp
++++ b/core/unit_test/TestNonTrivialScalarTypes.hpp
+@@ -158,10 +158,12 @@ struct array_reduce {
+   array_reduce() {
+     for (int i = 0; i < N; i++) data[i] = scalar_t();
+   }
++#if 0
+   KOKKOS_INLINE_FUNCTION
+   array_reduce(const array_reduce &rhs) {
+     for (int i = 0; i < N; i++) data[i] = rhs.data[i];
+   }
++#endif
+   KOKKOS_INLINE_FUNCTION
+   array_reduce(const scalar_t value) {
+     for (int i = 0; i < N; i++) data[i] = scalar_t(value);
+---
+2.25.1
+
+EOF
+  print_info "patch -p1 < $patchfile1"
+  patch -p1 < $patchfile1
+  if [[ $? -ne 0 ]]; then
+    print_error "Patching unsuccessful"
+    exit -1
+  fi
+ rm $patchfile1
+}
+
+mkdir -p $KOKKOS_SOURCE_PREFIX
+cd $KOKKOS_SOURCE_PREFIX || exit 1
+if [ ! -d $KOKKOS_SOURCE_DIR ] ; then
+   print_info "git clone $KOKKOS_URL $KOKKOS_SOURCE_DIR"
+   git clone $KOKKOS_URL $KOKKOS_SOURCE_DIR
+   if [ $? != 0 ] ; then
+      echo
+      print_error "ERROR: Could not git clone $KOKKOS_URL "
+      exit 1
+   fi
+   cd $KOKKOS_SOURCE_DIR || exit 1
+   print_info "Checking out Kokkos branch: ${KOKKOS_BRANCH}"
+   git checkout $KOKKOS_BRANCH
+   if [ $? != 0 ] ; then
+      echo
+      print_error "ERROR: Could not check out $KOKKOS_BRANCH"
+      exit 1
+   fi
+   if [[ ! -z $KOKKOS_TAG ]]; then
+     print_info "Switch to Kokkos tag: ${KOKKOS_TAG}"
+     git checkout $KOKKOS_TAG
+   elif [[ ! -z $KOKKOS_SHA ]]; then
+     print_info "Switch to Kokkos SHA: ${KOKKOS_SHA}"
+     git checkout $KOKKOS_SHA
+   else
+     print_info "Running on $KOKKOS_BRANCH HEAD"
+   fi
+   if [ "$PATCH" != 0 ]; then
+     print_info "patching..."
+     patchkokkos
+   else
+     print_info "PATCH=0 - not patching KOKKOS"
+   fi
+else
+   echo
+   echo "  WARNING: Directory $KOKKOS_SOURCE_DIR already exists."
+   echo "           No changes will be made to the sources"
+   echo
+fi
+
+if [ -d "$KOKKOS_BUILD_DIR" ] ; then
+   echo
+   echo " FRESH START:  Removing $KOKKOS_BUILD_DIR"
+   echo "               rm -rf $KOKKOS_BUILD_DIR"
+   echo
+   rm -rf  $KOKKOS_BUILD_DIR
+fi
+if [ -d "$KOKKOS_INSTALL_DIR" ] ; then
+   echo "               rm -rf $KOKKOS_INSTALL_DIR"
+   echo
+   rm -rf  $KOKKOS_INSTALL_DIR
+fi
+
+print_info "$KOKKOS_BUILD_DIR"
+
+mkdir -p $KOKKOS_BUILD_DIR
+cd "$KOKKOS_BUILD_DIR"
+
+UNAMEP=`uname -m`
+AOMP_CPUTARGET="${UNAMEP}-pc-linux-gnu"
+if [ "$UNAMEP" == "ppc64le" ] ; then
+   AOMP_CPUTARGET="ppc64le-linux-gnu"
+fi
+
+export PATH=$HOME/local/install/cmake/bin:$PATH
+which cmake
+
+if [ "$kokkos_backend" == "hip" ] ; then
+  export PATH=$AOMP/bin:$PATH
+  export ROCM_PATH=$AOMP # Kokkos searches this for HIP parts
+  ARGS=(
+    -D CMAKE_BUILD_TYPE=Debug
+    -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
+    -D CMAKE_CXX_STANDARD=17
+    -D CMAKE_CXX_EXTENSIONS=OFF
+    -D CMAKE_CXX_COMPILER=$AOMP/bin/clang++
+    -D Kokkos_ARCH_NATIVE=ON
+    -D Kokkos_ARCH_"$KOKKOS_ARCH"=ON
+    -D Kokkos_ENABLE_OPENMP=ON
+    -D Kokkos_ENABLE_HIP=ON
+    -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
+    -D Kokkos_ENABLE_TESTS=OFF
+  )
+
+else
+  #AOMP=$HOME/llvm-AMDGPU-NG
+   # ensure kokkos finds AOMP clang first
+   export PATH=$AOMP/bin:$PATH
+   ARGS=(
+    -D CMAKE_BUILD_TYPE=Release
+    -D CMAKE_CXX_STANDARD=17
+    -D CMAKE_CXX_EXTENSIONS=OFF
+    -D CMAKE_INSTALL_PREFIX=$KOKKOS_INSTALL_DIR
+    -D CMAKE_CXX_COMPILER=$AOMP/bin/${COMPILERNAME_TO_USE}
+    #-D CMAKE_CXX_FLAGS="-mllvm -time-passes -mllvm -openmp-opt-max-iterations=10"
+    -D CMAKE_CXX_FLAGS="-mllvm -time-passes"
+    -D CMAKE_VERBOSE_MAKEFILE=ON
+    -D Kokkos_ARCH_NATIVE=ON
+    -D Kokkos_ARCH_"$KOKKOS_ARCH"=ON
+    -D Kokkos_ENABLE_OPENMP=ON
+    -D Kokkos_ENABLE_OPENMPTARGET=ON
+    -D Kokkos_ENABLE_COMPILER_WARNINGS=ON
+    -D Kokkos_ENABLE_TESTS=ON
+   )
+
+fi
+
+   print_info "Running cmake via"
+   echo "cmake ${ARGS[@]} $KOKKOS_SOURCE_DIR"
+   cmake "${ARGS[@]}" $KOKKOS_SOURCE_DIR
+
+if [ $? != 0 ] ; then
+   echo
+   echo "ERROR in Kokkos cmake"
+   echo "If HWLOC is not found, set environment variable HWLOC_DIR=/path/to/hwloc."
+   echo
+   echo "cmake ${ARGS[@]} $KOKKOS_SOURCE_DIR"
+   exit 1
+fi
+
+echo
+echo "CMAKE done in directory $KOKKOS_BUILD_DIR"
+echo
+print_info "Starting build ..."
+
+print_info make -j$NUM_THREADS
+make --output-sync=recurse -j$NUM_THREADS 2>&1 | tee kokkos-build.log
+
+if [ $? != 0 ] ; then
+   print_error "ERROR in Kokkos build"
+   exit 1
+fi
+
+make install
+if [ $? != 0 ] ; then
+   print_error "ERROR in Kokkos install"
+   exit 1
+fi
+echo
+echo " Kokkos Version $KOKKOS_SHA installed successfully into directory "
+echo " $KOKKOS_INSTALL_DIR"
+echo

--- a/utils/kokkos_run.sh
+++ b/utils/kokkos_run.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+#  kokkos_build.sh: Script to run Kokkos unit tests and get statistics
+#                   This will run kokkos in directory $HOME/kokkos_build.<GPUNAME>
+#
+#  Written by Jan-Patrick Lehr JanPatrick.Lehr@amd.com
+#
+PROGVERSION="X.Y-Z"
+#
+
+function print_info() {
+  toPrint="$1"
+
+  echo "[Info]: $toPrint"
+}
+function print_error() {
+  toPrint="$1"
+
+  echo "[Error]: $toPrint"
+}
+
+function charexists() {
+  char="$1"; shift
+  case "$*" in *"$char"*) return;; esac; return 1
+}
+
+SCRIPT_REALPATH=`realpath $0`
+TOOLDIR=`dirname $SCRIPT_REALPATH`
+
+## To get consistent GPU names for building and running we rely on AOMP here as well
+echo "$AOMP"
+AOMP="${AOMP:-_AOMP_INSTALL_DIR_}"
+echo "$AOMP"
+if [ ! -d $AOMP ] ; then
+   print_error "AOMP is not installed in ${AOMP}. Please set the environment variable."
+   exit 1
+fi
+
+if [[ "$AOMP" =~ "opt" ]]; then
+  # xargs trims the string off whitespaces
+  export DETECTED_GPU=$($AOMP/../bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
+  print_info "Set AOMP_GPU with rocminfo: $DETECTED_GPU"
+else
+  if [ -a $AOMP/bin/rocminfo ]; then
+    print_info "Set AOMP_GPU with rocminfo"
+    export DETECTED_GPU=$($AOMP/bin/rocminfo | grep -m 1 -E gfx[^0]{1}.{2} | awk '{print $2}')
+  else
+    print_info "Set AOMP_GPU with offload-arch."
+    export DETECTED_GPU=$($AOMP/bin/offload-arch | grep -m 1 -E gfx[^0]{1}.{2})
+  fi
+fi
+
+COMPILERNAME_TO_USE=${_COMPILER_TO_USE_:-clang++}
+AOMP_VERSION=$($AOMP/bin/${COMPILERNAME_TO_USE} --version | head -n 1)
+
+AOMP_GPU=${AOMP_GPU:-$DETECTED_GPU}
+
+GIT_DIR=${GIT_DIR:-$HOME/git}
+KOKKOS_BUILD_PREFIX=${KOKKOS_BUILD_PREFIX:-$HOME}
+KOKKOS_TAG=${_KOKKOS_TAG_:-'NA'}
+
+if [ "$1" == "hip" ] ; then
+   kokkos_backend="hip"
+   KOKKOS_BUILD_DIR=${KOKKOS_BUILD_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_build_hip.$AOMP_GPU}
+   KOKKOS_INSTALL_DIR=${KOKKOS_INSTALL_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_hip.$AOMP_GPU}
+else
+   kokkos_backend="openmp"
+   KOKKOS_BUILD_DIR=${KOKKOS_BUILD_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_build_omp.$AOMP_GPU}
+   KOKKOS_INSTALL_DIR=${KOKKOS_INSTALL_DIR:-$KOKKOS_BUILD_PREFIX/kokkos-${KOKKOS_TAG}_omp.$AOMP_GPU}
+fi
+
+KOKKOS_EXAMPLES_SOURCE_DIR=${KOKKOS_EXAMPLES_SOURCE_DIR:-$GIT_DIR/kokkos-openmptarget-examples}
+
+## We want to process the command line arguments
+# The script accepts the arguments 'unittest' and 'cgsolve' for now
+# It sets corresponding variables to 'yes' that indicate if these tests should
+# be executed or not
+KOKKOS_RUN_UNIT_TEST='no'
+KOKKOS_RUN_CGSOVLE='no'
+
+# We support summary and detail execution
+KOKKOS_RUN_TYPE=${KOKKOS_RUN_TYPE:-summary}
+
+# For the CI runs we want to move the summary to the CI folder
+KOKKOS_EXTRACT_FILE_LOCATION=${KOKKOS_EXTRACT_DIRECTORY:-$AOMP_OPENMP_CI}
+
+if [ "$#" -eq 0 ]; then
+  print_error "Please indicate what to run 'unittest', 'cgsolve'"
+  exit 1
+fi
+
+while (( "$#" )); do
+  if [ "$1" == 'unittest' ]; then
+    KOKKOS_RUN_UNIT_TEST='yes'
+  elif [ "$1" == 'cgsolve' ]; then
+    KOKKOS_RUN_CGSOVLE='yes'
+  fi
+  shift
+done
+
+print_info "Selecting what to run unit-test ($KOKKOS_RUN_UNIT_TEST) or cgsolve ($KOKKOS_RUN_CGSOVLE)"
+
+
+if [ $KOKKOS_RUN_UNIT_TEST == 'yes' ]; then
+  if [ -z $KOKKOS_EXTRACT_FILE_LOCATION ]; then
+    initialDir=$PWD
+  else
+    initialDir=$KOKKOS_EXTRACT_FILE_LOCATION
+  fi
+
+  cd $KOKKOS_BUILD_DIR || exit 1
+  
+  cd core/unit_test || exit 1
+  
+  # Run the top-level summary version of the tests
+  if [ "$KOKKOS_RUN_TYPE" == "summary" ]; then
+    OMP_NUM_THREADS=2 ctest --timeout 240 -j 4
+    print_info "For more details, please set KOKKOS_RUN_TYPE to 'detail'"
+ 
+  elif [ "$KOKKOS_RUN_TYPE" == "detail" ]; then
+    # For a detail run, we follow the procedure
+    # 1. Search for all executables in the unit_test directory.
+    # 2. Query each executable for its testsuites and the contained test cases.
+    # 3. Run an executable separately for each testsuite.testcase to detect and cover individual hangs (and still generate results).
+    #    Put each individual result into its own file to merge them back afterwards. 
+
+    # Start with capturing a list of all executables.
+    declare -a EXE_FILES
+    for EXE in $(find . -maxdepth 1 -perm -111 -type f); do
+      echo "AOMPCI LOG: $PWD / $EXE"
+      EXE_FILES+=("$EXE")
+    done
+
+    # Rmove previous test results
+    find . -iname "RESULT_*" -delete
+
+    # 2. Query each executable for all contained test cases
+    for UT in "${EXE_FILES[@]}"; do
+      echo "Executable $UT"
+      # Have gtest list all available test suites and the test cases therein.
+      # A test suite name ends with a '.', so filter for that to differentiate between them.
+      # Run each test case individually under time limit to detect potential hang and report as test failure, while continue to run
+      # all the other test cases normally.
+      for TC in $(python3 $TOOLDIR/extractTestsFromGTest.py $UT); do
+        echo "Running ${UT} TC: $TC"
+        fName=${UT/KokkosCore/RESULT}_${TC/\//_}
+        OMP_PROC_BIND=spread OMP_NUM_THREADS=2 timeout 2m ${UT} --gtest_filter="$TC" --gtest_output=json:$PWD/${fName}.json
+        # Check for return code of command, 124 indicating timeout (interpreted as hang)
+        if [ "$?" == "124" ]; then
+          echo "Command timed out. Need to handle"
+        fi
+      done
+    done
+
+    # The AOMP_CI_ACCUMULATOR is a Python script to read the resulting GTest json files and transform them into extract-format files
+    if [ ! -z "$AOMP_CI_ACCUMULATOR" ]; then
+      tmpResFile=accuResult
+      # Collect everything in the KOKKOS_INTERMEDIATE_FILE ${tmpResFile} is not touched during this command
+      # I know that this looks a bit clumsy and it can sure be improved later.
+      find . -iname "RESULT_*" -exec python3 ${AOMP_CI_ACCUMULATOR} --snapshot ${KOKKOS_FAILS_SNAPSHOT} --failfile ${KOKKOS_FAIL_FILE} --intermediate-file ${KOKKOS_INTERMEDIATE_FILE} {} ${tmpResFile} \;
+      # Generate the extract from the KOKKOS_INTERMEDIATE_FILE
+      python3 ${AOMP_CI_ACCUMULATOR} --snapshot ${KOKKOS_FAILS_SNAPSHOT} --failfile ${KOKKOS_FAIL_FILE} ${KOKKOS_INTERMEDIATE_FILE} ${tmpResFile}
+      cp ${tmpResFile}-perf.ext ${initialDir}/accumulatedResults-pass-rate-${KOKKOS_TAG}.ext
+      cp ${tmpResFile}-corr.ext ${initialDir}/accumulatedResults-corr-${KOKKOS_TAG}.ext
+      rm ${tmpResFile}-corr.ext ${tmpResFile}-perf.ext ${KOKKOS_INTERMEDIATE_FILE}
+    fi
+
+  else
+    print_error "Please set KOKKOS_RUN_TYPE to summary or detail"
+  fi
+fi
+
+if [ $KOKKOS_RUN_CGSOVLE == 'yes' ]; then
+  print_info "Running performance cgsolve"
+  # Switch to the example directory
+  cd $KOKKOS_EXAMPLES_SOURCE_DIR/cgsolve || exit 1
+
+  # The example runs both an OpenMP target version of cgsolve and a version using the Kokkos library
+  # with the OpenMP target backend
+  # We execute an increased problem size and require higher precision to provoke longer runtimes.
+  print_info "Running default (small) problem"
+  ./cgsolve.ompt
+
+  echo ""
+
+  print_info "Running increased (large) problem"
+  ./cgsolve.ompt 400 300 0.000000001 
+fi

--- a/utils/make_header_from_ll_defines.sh
+++ b/utils/make_header_from_ll_defines.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved.
+# make_header_from_ll_defines.sh:
+#    To use low level hc functions maintained in .ll, we need c/cpp headers so 
+#    we can use them properly in hip device library implementations. 
+#
+# Usage: To build /tmp/hc_atomic_ll.h file run this command
+#
+#    make_header_from_ll_defines.sh $HOME/git/aomp/rocm-device-libs/hc/src/hc_atomic.ll
+#    
+
+llfile=${1:-/home/grodgers/git/aomp/rocm-device-libs/hc/src/hc_atomic.ll}
+outfn=${llfile##*/}
+outfn="${outfn%.*}_ll.h"
+
+outfile=/tmp/$outfn
+if [ -f $outfile ] ; then 
+  echo removing old version of $outfile
+  rm -f $outfile
+fi
+touch $outfile
+
+echo "//" >> $outfile
+echo "// This file $outfn was created by $0 " >> $outfile
+echo "// from input file: $llfile  " >> $outfile
+echo "// on `date` " >> $outfile
+echo "//" >> $outfile
+echo "#ifndef INLINE " >> $outfile
+echo "#define INLINE " >> $outfile
+echo "#endif" >> $outfile
+echo "#ifndef _LL_GLOBAL_" >> $outfile
+echo "#define _LL_GLOBAL_ " >> $outfile
+echo "#endif" >> $outfile
+echo "#ifndef _LL_SHARED_" >> $outfile
+echo "#define _LL_SHARED_ " >> $outfile
+echo "#endif" >> $outfile
+
+# Edits:
+#  i32 -> unsigned int 
+#  i64 -> unsigned long long int
+#  @ f -> ""
+#  addrspace(1) -> _LL_GLOBAL_
+#  addrspace(3) -> _LL_SHARED_
+#  define -> INLINE
+#  { -> ;
+#  #[0-9] -> ""
+#  % -> ""
+#  i8 -> unsigned char
+#  i16  -> unsigned short int
+#  i1 -> bool 
+#  local_unnamed_addr -> ""
+#  FIXME: Add const where necessary
+#  FIXME: convert nocapture to ???
+#  FIXME: if define is not all on a single line 
+#  FIXME: Create data structure externs from globals.  Need to look at more than ll defines. 
+#  FIXME: convert readonly to ???  const ? 
+
+grep define $llfile | grep "{" | sed "s/define/INLINE/" | sed "s/i32/unsigned int/g" | sed "s/i64/unsigned long long int/g" | sed "s/%//g"  | sed "s/{/;/g" | sed "s/#[0-9]//g" | sed "s/addrspace(3)/_LL_SHARED_ /g" | sed "s/addrspace(1)/_LL_GLOBAL_ /g"  | sed "s/@//g" | sed "s/i8/unsigned char/g" |  sed "s/i16/unsigned short int/g" | sed "s/i1/bool/g" | sed "s/local_unnamed_addr//g" | tee -a $outfile
+
+echo 
+echo outfile is $outfile
+echo 

--- a/utils/modulefile
+++ b/utils/modulefile
@@ -1,0 +1,24 @@
+#%Module1.0
+# Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved.
+##
+## aomp@X.Y-Z
+##
+module-whatis "aomp @X.Y-Z"
+
+proc ModulesHelp { } {
+puts stderr "This version of AOMP contains C/C++/Flang."
+}
+
+prepend-path PATH "_AOMP_INSTALL_DIR_/bin"
+prepend-path CMAKE_PREFIX_PATH "_AOMP_INSTALL_DIR_"
+prepend-path LIBRARY_PATH "_AOMP_INSTALL_DIR_/lib"
+prepend-path LD_LIBRARY_PATH "_AOMP_INSTALL_DIR_/lib"
+prepend-path LD_RUN_PATH "_AOMP_INSTALL_DIR_/lib"
+# not sure what to put here: prepend-path PKG_CONFIG_PATH "_AOMP_INSTALL_DIR_/lib/pkgconfig"
+prepend-path MANPATH "_AOMP_INSTALL_DIR_/share/man"
+prepend-path CPATH "_AOMP_INSTALL_DIR_/include"
+setenv AOMP_ROOT "_AOMP_INSTALL_DIR_"
+setenv AOMP "_AOMP_INSTALL_DIR_"
+
+
+

--- a/utils/raja.patch
+++ b/utils/raja.patch
@@ -1,0 +1,47 @@
+# Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved. 
+diff --git a/include/RAJA/policy/atomic_auto.hpp b/include/RAJA/policy/atomic_auto.hpp
+index 934bfc68..02789511 100644
+--- a/include/RAJA/policy/atomic_auto.hpp
++++ b/include/RAJA/policy/atomic_auto.hpp
+@@ -36,7 +36,7 @@
+  * Finally, we fallback on the seq_atomic, which performs non-atomic operations
+  * because we assume there is no thread safety issues (no parallel model)
+  */
+-#if defined(__CUDA_ARCH__)
++#if defined(RAJA_ENABLE_CUDA) && defined(__CUDA_ARCH__)
+ #define RAJA_AUTO_ATOMIC \
+   RAJA::cuda_atomic {}
+ #elif defined(__HIP_DEVICE_COMPILE__)
+diff --git a/include/RAJA/util/macros.hpp b/include/RAJA/util/macros.hpp
+index fffb9188..1a1e6b90 100644
+--- a/include/RAJA/util/macros.hpp
++++ b/include/RAJA/util/macros.hpp
+@@ -126,9 +126,12 @@ RAJA_HOST_DEVICE RAJA_INLINE void RAJA_UNUSED_VAR(T &&...) noexcept
+ RAJA_HOST_DEVICE
+ inline void RAJA_ABORT_OR_THROW(const char *str)
+ {
+-#if defined(__CUDA_ARCH__)
++#if defined(RAJA_ENABLE_CUDA) && defined(__CUDA_ARCH__)
+   asm ("trap;");
+
++#elif defined(RAJA_ENABLE_OPENMP)
++  __builtin_trap();
++
+ #elif defined(__HIP_DEVICE_COMPILE__)
+   abort();
+
+diff --git a/test/unit/workgroup/CMakeLists.txt b/test/unit/workgroup/CMakeLists.txt
+index d3228a9a..50d305c1 100644
+--- a/test/unit/workgroup/CMakeLists.txt
++++ b/test/unit/workgroup/CMakeLists.txt
+@@ -71,8 +71,8 @@ if(RAJA_TEST_EXHAUSTIVE OR NOT RAJA_COMPILER MATCHES "RAJA_COMPILER_Intel")
+   unset(Enqueue_SUBTESTS)
+ endif()
+
+-set(Vtable_SUBTESTS Single)
+-buildunitworkgrouptest(Vtable      "${Vtable_SUBTESTS}"      "${Vtable_BACKENDS}")
++#set(Vtable_SUBTESTS Single)
++#buildunitworkgrouptest(Vtable      "${Vtable_SUBTESTS}"      "${Vtable_BACKENDS}")
+
+ set(WorkStorage_SUBTESTS Constructor Iterator InsertCall Multiple)
+ buildunitworkgrouptest(WorkStorage "${WorkStorage_SUBTESTS}" "${WorkStorage_BACKENDS}")

--- a/utils/raja_build.sh
+++ b/utils/raja_build.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+#
+#  raja_build.sh: Script to clone and build raja for a specific GPU 
+#                 This will build raja in directory $HOME/raja_build.<GPUNAME>
+#
+#
+#  Written by Greg Rodgers  Gregory.Rodgers@amd.com
+#
+PROGVERSION="X.Y-Z"
+#
+# Copyright(C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+# 
+# AMD is granting you permission to use this software and documentation (if any) (collectively, the 
+# Materials) pursuant to the terms and conditions of the Software License Agreement included with the 
+# Materials.  If you do not have a copy of the Software License Agreement, contact your AMD 
+# representative for a copy.
+# 
+# You agree that you will not reverse engineer or decompile the Materials, in whole or in part, except for 
+# example code which is provided in source code form and as allowed by applicable law.
+# 
+# WARRANTY DISCLAIMER: THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY 
+# KIND.  AMD DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED, OR STATUTORY, INCLUDING BUT NOT 
+# LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+# PURPOSE, TITLE, NON-INFRINGEMENT, THAT THE SOFTWARE WILL RUN UNINTERRUPTED OR ERROR-
+# FREE OR WARRANTIES ARISING FROM CUSTOM OF TRADE OR COURSE OF USAGE.  THE ENTIRE RISK 
+# ASSOCIATED WITH THE USE OF THE SOFTWARE IS ASSUMED BY YOU.  Some jurisdictions do not 
+# allow the exclusion of implied warranties, so the above exclusion may not apply to You. 
+# 
+# LIMITATION OF LIABILITY AND INDEMNIFICATION:  AMD AND ITS LICENSORS WILL NOT, 
+# UNDER ANY CIRCUMSTANCES BE LIABLE TO YOU FOR ANY PUNITIVE, DIRECT, INCIDENTAL, 
+# INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING FROM USE OF THE SOFTWARE OR THIS 
+# AGREEMENT EVEN IF AMD AND ITS LICENSORS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH 
+# DAMAGES.  In no event shall AMD's total liability to You for all damages, losses, and 
+# causes of action (whether in contract, tort (including negligence) or otherwise) 
+# exceed the amount of $100 USD.  You agree to defend, indemnify and hold harmless 
+# AMD and its licensors, and any of their directors, officers, employees, affiliates or 
+# agents from and against any and all loss, damage, liability and other expenses 
+# (including reasonable attorneys' fees), resulting from Your use of the Software or 
+# violation of the terms and conditions of this Agreement.  
+# 
+# U.S. GOVERNMENT RESTRICTED RIGHTS: The Materials are provided with "RESTRICTED RIGHTS." 
+# Use, duplication, or disclosure by the Government is subject to the restrictions as set 
+# forth in FAR 52.227-14 and DFAR252.227-7013, et seq., or its successor.  Use of the 
+# Materials by the Government constitutes acknowledgement of AMD's proprietary rights in them.
+# 
+# EXPORT RESTRICTIONS: The Materials may be subject to export restrictions as stated in the 
+# Software License Agreement.
+# 
+
+function getdname(){
+   local __DIRN=`dirname "$1"`
+   if [ "$__DIRN" = "." ] ; then 
+      __DIRN=$PWD; 
+   else
+      if [ ${__DIRN:0:1} != "/" ] ; then 
+         if [ ${__DIRN:0:2} == ".." ] ; then 
+               __DIRN=`dirname $PWD`/${__DIRN:3}
+         else
+            if [ ${__DIRN:0:1} = "." ] ; then 
+               __DIRN=$PWD/${__DIRN:2}
+            else
+               __DIRN=$PWD/$__DIRN
+            fi
+         fi
+      fi
+   fi
+   echo $__DIRN
+}
+
+function patchrepo(){
+   cd $patchdir
+   echo "Testing patch $patchfile to $patchdir"
+   applypatch="yes"
+   patch -p1 -t -N --dry-run <$patchfile >/dev/null
+   if [ $? != 0 ] ; then
+      applypatch="no"
+      # Check to see if reverse patch applies cleanly
+      patch -p1 -R --dry-run -t <$patchfile >/dev/null
+      if [ $? == 0 ] ; then
+         echo "patch $patchfile was already applied to $patchdir"
+      else
+         echo
+         echo "ERROR: Patch $patchfile will not apply"
+         echo "       cleanly to directory $patchdir"
+         echo "       Check if it was already applied."
+         echo
+         exit 1
+      fi
+   fi
+   if [ "$applypatch" == "yes" ] ; then
+      echo "Applying patch $patchfile to $patchdir"
+      patch -p1 <$patchfile
+   fi
+}
+
+thisdir=$(getdname $0)
+AOMP=${AOMP:-_AOMP_INSTALL_DIR_}
+aomp_repos=$HOME/git/aomp
+raja_source_dir=$aomp_repos/raja
+raja_url=https://github.com/llnl/raja
+native_gpu=`$AOMP/bin/amdgpu-arch 2>/dev/null`
+[ -z $native_gpu ] && native_gpu=`$AOMP/bin/nvidia-arch 2>/dev/null`
+AOMP_GPU=${AOMP_GPU:-$native_gpu}
+RAJA_BUILD_PREFIX=${RAJA_BUILD_PREFIX:-$HOME}
+NUM_THREADS=${NUM_THREADS:-8}
+AOMP_CMAKE=${AOMP_CMAKE:-cmake}
+if $AOMP_CMAKE --version > /dev/null 2>&1 ; then
+  $AOMP_CMAKE --version
+else
+  echo Error: cmake not found. Try using AOMP_CMAKE env variable.
+  exit 1
+fi
+
+if [ "$1" == "hip" ] ; then
+    raja_backend="hip"
+    echo "HIP backend enabled"
+else
+    raja_backend="openmp"
+    echo "OpenMP Target backend enabled"
+fi
+
+if [ -z $2 ] ; then
+    RAJA_BUILD_DIR=${RAJA_BUILD_DIR:-$RAJA_BUILD_PREFIX/raja_build_omp.$AOMP_GPU}
+else
+    RAJA_BUILD_DIR=$2
+fi
+
+mkdir -p $aomp_repos
+cd $aomp_repos
+if [ ! -d $raja_source_dir ] ; then 
+  echo git clone --recursive -b develop $raja_url
+  git clone --recursive -b develop $raja_url
+  if [ $? != 0 ] ; then 
+     echo
+     echo "ERROR  could not git clone $raja_url "
+     echo
+     exit 1
+  fi
+fi
+cd $raja_source_dir
+
+# Fix hash to prevent failure to build
+echo git reset --hard dec0568e14e72cdc2157582d65e9974060ce71ca
+git reset --hard dec0568e14e72cdc2157582d65e9974060ce71ca
+
+echo "git submodule update"
+git submodule update
+echo "git pull"
+git pull
+
+echo git reset --hard dec0568e14e72cdc2157582d65e9974060ce71ca
+git reset --hard dec0568e14e72cdc2157582d65e9974060ce71ca
+
+if ! [ "$1" == "hip" ] ; then
+patchdir=$raja_source_dir
+patchfile=$thisdir/raja.patch
+patchrepo
+patchdir=$raja_source_dir/blt
+patchfile=$thisdir/blt.patch
+patchrepo
+fi
+
+mkdir -p $RAJA_BUILD_DIR
+cd $RAJA_BUILD_DIR
+
+UNAMEP=`uname -m`
+AOMP_CPUTARGET="${UNAMEP}-pc-linux-gnu"
+if [ "$UNAMEP" == "ppc64le" ] ; then
+   AOMP_CPUTARGET="ppc64le-linux-gnu"
+fi
+
+if [ "$raja_backend" == "hip" ] ; then
+    $AOMP_CMAKE -DHIP_ROOT_DIR=$AOMP/hip -C $raja_source_dir/host-configs/hip.cmake $raja_source_dir
+else
+    $AOMP_CMAKE -DOpenMP_C_FLAGS="-w;--target=${AOMP_CPUTARGET};-fopenmp;-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa;-march=$AOMP_GPU" \
+      -DOpenMP_CXX_FLAGS="-w;--target=${AOMP_CPUTARGET};-fopenmp;-fopenmp-targets=amdgcn-amd-amdhsa;-Xopenmp-target=amdgcn-amd-amdhsa;-march=$AOMP_GPU" \
+      -DENABLE_TARGET_OPENMP=On \
+      -DENABLE_CUDA=Off \
+      -DENABLE_CLANG_CUDA=Off \
+      -DCMAKE_EXE_LINKER_FLAGS="" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_C_COMPILER=$AOMP/bin/clang \
+      -DCMAKE_CXX_COMPILER=$AOMP/bin/clang++ \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=FALSE \
+      -Wno-dev \
+      -DRAJA_ENABLE_OPENMP=On \
+      $raja_source_dir
+fi
+if [ $? != 0 ] ; then 
+   echo "ERROR in Raja cmake"
+   exit 1
+fi
+
+echo
+echo "CMAKE done in directory $raja_build_dir"
+echo
+echo "Starting build ..."
+
+echo make -j$NUM_THREADS
+make -j$NUM_THREADS
+if [ $? != 0 ] ; then 
+   echo "ERROR in Raja build"
+   exit 1
+fi
+
+echo
+echo "Raja build has successfully completed into directory $raja_build_dir"
+echo
+

--- a/utils/rebundle_hip_lib.sh
+++ b/utils/rebundle_hip_lib.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# rebundle_hip_lib.sh : Utility that takes a static device library
+#                       built with packager and converts it to 
+#                       a static device library built with bundler.
+#
+
+#!/bin/bash
+#   rebundle_hip_lib.sh: Utility to convert a static device library (SDL) built
+#         with clang-offload-packager into a static device library for hip. HIP 
+#         currently expects SDLs to be built with clang-offload-bundler. 
+#
+# Copyright(C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+PROGVERSION=X.Y-Z
+function version(){
+   echo $0 version $PROGVERSION
+   exit 0
+}
+function usage(){
+/bin/cat 2>&1 <<"EOF"
+
+   rebundle_hip_lib.sh: Utility to convert a static device library (SDL) built
+         with clang-offload-packager into a static device library for hip. HIP
+         currently expects SDLs to be built with clang-offload-bundler.  This
+         utility is currently necessary if an SDL is built ith OpenMP target
+         offload and user wants to call the target functions from a HIP kernel.
+
+   Usage:
+      rebundle_hip_lib.sh lib_ompSDL.a                   Convert lib_ompSDL.a to
+                                                            bundled/lib_ompSDL.a
+
+      rebundle_hip_lib.sh lib_ompSDL.a bundled/lib_ompSDL.a       Same as above.
+
+      hipcc ...  -L($PWD/bundled) -l _ompSDL         Use converted SDL with hip.
+
+   Options:
+      -v   Print verbose messages
+      -h   Print this help message and exit
+      --version Print version and exit
+
+   Environment variables:
+      LLVM_INSTALL_DIR    LLVM installation directory, default is /opt/rocm/llvm
+
+   Copyright (c) 2024  ADVANCED MICRO DEVICES, INC.
+
+EOF
+  exit 0
+}
+
+LLVM_INSTALL_DIR=${LLVM_INSTALL_DIR:-_LLVM_INSTALL_DIR_}
+
+case "$1" in
+   -v)          _VERBOSE=true ; shift;;
+   -h)          usage ;;
+   -help)       usage ;;
+   --help)      usage ;;
+   -version)    version ;;
+   --version)   version ;;
+esac
+
+if [ -z $1 ] ; then 
+  echo "ERROR: $0 requires at least one input argument."
+  exit 1
+fi
+if [ ! -f $1 ] ; then 
+  echo "ERROR: INPUT FILE $1 not found"
+  exit 1
+fi
+_packaged_archive=${1}
+_packaged_archive_dir=`dirname $_packaged_archive`
+[ "$_packaged_archive_dir" == "." ] && _packaged_archive_dir=$PWD
+_packaged_archive_file=$(basename ${_packaged_archive})
+_new_bundled_archive=${2:-$_packaged_archive_dir/bundled/$_packaged_archive_file}
+_new_bundled_archive_dir=`dirname $_new_bundled_archive`
+mkdir -p $_new_bundled_archive_dir
+
+if [ -f $_new_bundled_archive ] ; then 
+  echo "WARNING: OUTPUT FILE $_new_bundled_archive exists and will be overwritten"
+  if [ $_new_bundled_archive == $_packaged_archive ] ; then 
+     echo "ERROR: Input packaged_archive $_packaged_archive cannot be same file as OUTPUT _new_bundled_archive"
+     exit 1
+  fi
+fi
+
+curdir=$PWD
+tdir=/tmp/$USER/rebundle$$
+[ $_VERBOSE ] && echo "mkdir -p $tdir/bundled"
+mkdir -p $tdir/bundled
+[ $_VERBOSE ] && echo "cd $tdir"
+cd $tdir
+
+
+num_objs=0
+obj_files=()
+cmd="$LLVM_INSTALL_DIR/bin/llvm-ar t $_packaged_archive_dir/$_packaged_archive_file"
+$cmd > _tfile_list_of_objfiles
+while read -r objfile; do 
+  obj_files+=$objfile
+  num_objs=$(( $num_objs + 1 ))
+done < _tfile_list_of_objfiles
+
+cmd="$LLVM_INSTALL_DIR/bin/llvm-ar x $_packaged_archive_dir/$_packaged_archive_file"
+$cmd
+
+bundled_objects=""
+
+for _objfnum in `seq 0 $(( $num_objs- 1 ))` ; do 
+  #echo "-------------- objfile[$_objfnum]= ${obj_files[$_objfnum]} num_objs=$num_objs"
+  objfile=${obj_files[$_objfnum]} 
+  $LLVM_INSTALL_DIR/bin/llvm-objdump $objfile --offloading >tfile_objdump.stdout
+  grep IMAGE tfile_objdump.stdout > tfile_images
+  if [ $? != 0 ] ; then
+     echo "WARNING: member $objfile of $_packaged_archive has no packaged images"
+     echo "         Check that $_packaged_archive is correct"
+  fi
+  num_images=0
+  image_arch=()
+  image_triple=()
+  image_producer=()
+  while read -r line ; do 
+    grep -A4 ""$line"" tfile_objdump.stdout >tfile_image_fields 2>/dev/null
+    image_arch+=`grep arch tfile_image_fields | awk '{print $2}'` 
+    image_triple+=`grep triple tfile_image_fields | awk '{print $2}'` 
+    image_producer+=`grep producer tfile_image_fields | awk '{print $2}'` 
+    num_images=$(( $num_images + 1 ))
+  done <tfile_images
+
+  bundled_targets=""
+  bundled_inputs=""
+  for _i in `seq 0 $(( $num_images - 1 ))` ; do 
+    _extracted_file="file${_objfnum}_image_${_i}_unpackaged.bc"
+    cmd="${LLVM_INSTALL_DIR}/bin/clang-offload-packager $objfile --image=file=${_extracted_file},triple=${image_triple[$_i]},arch=${image_arch[$_i]},kind=${image_producer[$_i]}"
+    #echo $cmd
+    [ $_VERBOSE ] && echo $cmd
+    $cmd
+    bundled_targets+="${image_producer[$_i]}-${image_triple[$_i]}-${image_arch[$_i]},"
+    bundled_inputs+="-input=${_extracted_file} "
+  done
+  bundled_targets+="host-x86_64-unknown-linux-gnu"
+  bundled_inputs+=" -input=$objfile"
+  bcmd="${LLVM_INSTALL_DIR}/bin/clang-offload-bundler --type=o --targets=$bundled_targets --output=bundled/$objfile $bundled_inputs"
+  bundled_objects+=" bundled/$objfile"
+  [ $_VERBOSE ] && echo $bcmd
+  $bcmd
+done 
+
+cmd="$LLVM_INSTALL_DIR/bin/llvm-ar rcs $_new_bundled_archive $bundled_objects"
+[ $_VERBOSE ] && echo $cmd
+$cmd
+
+cd $curdir
+rm -rf $tdir
+[ $_VERBOSE ] && echo rm -rf $tdir
+rm -rf $tdir

--- a/utils/unbundle.sh
+++ b/utils/unbundle.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright(C) 2019 Advanced Micro Devices, Inc. All rights reserved.
+#
+# unbundle.sh: use clang clang-offload-bundler tool to unbundle files
+#              This script is the companion to bundle.sh.  It will name the 
+#              generated files using the conventions used in the coral compiler. 
+#
+#  Written by Greg Rodgers
+# 
+AOMP=${AOMP:-$HOME/rocm/aomp}
+if [ ! -d $AOMP ] ; then
+   AOMP="/opt/rocm/aomp"
+fi
+if [ ! -d $AOMP ] ; then
+   echo "ERROR: AOMP not found at $AOMP"
+   echo "       Please install AOMP or correctly set env-var AOMP"
+   exit 1
+fi
+EXECBIN=$AOMP/bin/clang-offload-bundler
+if [ ! -f $EXECBIN ] ; then 
+   echo "ERROR: $EXECBIN not found"
+   exit 1
+fi
+
+infilename=${1:-ll}
+if [ -f $infilename ] ; then 
+   ftype=${infilename##*.}
+   tnames="$infilename"
+else
+#  Input was not a file, work on all files in the directory of specified type
+   ftype=$infilename
+   tnames=`ls *.$ftype 2>/dev/null`
+   if [ $? != 0 ] ; then 
+      echo "ERROR: No files of type $ftype found"
+      echo "       Try a filetype other than $ftype"
+      exit 1
+   fi
+fi
+
+ftypeout=$ftype
+
+for tname in $tnames ; do 
+   mname=${tname%.$ftype}
+   if [ "$ftype" == "o" ] ; then 
+      otargets=`strings $tname | grep "openmp-"`
+      for longtarget in $otargets ; do
+         if [ "${longtarget:0:22}" == "__CLANG_OFFLOAD_BUNDLE" ] ; then
+            targets="$targets ${longtarget:24}"
+         else
+            targets="$targets $longtarget"
+         fi
+      done
+      host=`strings $tname | grep "host-"`
+      if [ "${longtarget:0:22}" == "__CLANG_OFFLOAD_BUNDLE" ] ; then
+         host=${host:24}
+      else
+         host=${host%*BC}
+      fi
+      targets="$targets $host"
+   else
+      if [ "$ftype" != "bc" ] ; then 
+         targets=`grep "__CLANG_OFFLOAD_BUNDLE____START__" $tname | cut -d" " -f3`
+      else
+#        Hack to find bc targets from a bundle
+         for t in `strings $tname | grep "openmp-" ` ; do 
+            t=${t%*k}
+            t=${t%*\'>}
+            targets="$targets $t"
+         done 
+         host=`strings $tname | grep "host-" `
+         targets="$targets ${host%*BC}"
+      fi
+   fi
+   targetlist=""
+   sepchar=""
+   fnamelist=""
+   for target in $targets ; do 
+      targetlist=$targetlist$sepchar$target
+      if [ "$ftype" == "o" ] ; then
+         if [ "${target:0:6}" == "openmp" ] && [ "${target:7:6}" == "amdgcn" ] ; then
+            ftypeout="bc"
+         fi
+      fi
+      fnamelist=$fnamelist$sepchar${tname}.$target
+      sepchar=","
+   done
+   if [ "$targetlist" != "" ] ; then 
+      cmd="$EXECBIN -unbundle -type=$ftypeout -inputs=$tname -targets=$targetlist -outputs=$fnamelist"
+      echo $cmd
+      $cmd
+      if [ $? != 0 ] ; then 
+         echo "ERROR: $EXECBIN failed."
+         echo "       The failed command was:"
+         echo $cmd
+         exit 1
+      fi
+   fi
+done


### PR DESCRIPTION
This allows us to stop using the aomp-extras repo. For some time now we have slowly moved things out and these were the last remaining files. The build will still use build_extras.sh and copy these scripts to the AOMP install location.