### PR TITLE
[Flang] Switch flang-rt build to runtimes-based build

### DIFF
--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -73,7 +73,7 @@ fi
 if [ "$AOMP_LEGACY_OPENMP" != 0 ]; then
   LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;compiler-rt"
 else
-  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;openmp;offload;compiler-rt"
+  LLVM_RUNTIMES="libcxx;libcxxabi;libunwind;openmp;offload;compiler-rt;flang-rt"
 fi
 
 rocmdevicelib_loc_new=lib/llvm/lib/clang/$AOMP_MAJOR_VERSION/lib/amdgcn


### PR DESCRIPTION
This PR switches the build system from the in-tree build of the Fortran runtime to the new runtimes-style build.