### PR TITLE
[build] - Add BUILD_ICD=On to build_hipamd.sh

### DIFF
--- a/bin/build_hipamd.sh
+++ b/bin/build_hipamd.sh
@@ -92,7 +92,8 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
                -DCMAKE_HIP_ARCHITECTURES=OFF
                -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=ON
                -DHIPCC_BIN_DIR="$BUILD_DIR/build/hipcc"
-               -DROCM_PATH="$ROCM_PATH")
+               -DROCM_PATH="$ROCM_PATH"
+               -DBUILD_ICD=ON)
 
   # If this machine does not have an actvie amd GPU, tell hipamd
   # to use first in GFXLIST or gfx90a if no GFXLIST
@@ -110,7 +111,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   if [ "$AOMP_BUILD_SANITIZER" == 1 ]; then
      ASAN_FLAGS=("${ASAN_FLAGS[@]}" -I"$SANITIZER_COMGR_INCLUDE_PATH" -Wno-error=deprecated-declarations)
      ASAN_CMAKE_OPTS=("${MYCMAKEOPTS[@]}" "${AOMP_ASAN_ORIGIN_RPATH[@]}"
-                      -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR/lib/asan/cmake;$AOMP_INSTALL_DIR;$HOME/local/openclicdloader"
+                      -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR/lib/asan/cmake;$AOMP_INSTALL_DIR;$HOME/local/openclicdloader;$BUILD_DIR/build/hipamd/opencl/khronos/icd"
                       -DCMAKE_INSTALL_LIBDIR=lib/asan
                       -DCMAKE_C_COMPILER="$LLVM_INSTALL_LOC/bin/clang"
                       -DCMAKE_CXX_COMPILER="$LLVM_INSTALL_LOC/bin/clang++"
@@ -121,7 +122,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
      HIPAMD_DEBUG_CMAKE_OPTS=("${MYCMAKEOPTS[@]}"
                               "${AOMP_DEBUG_ORIGIN_RPATH[@]}"
                               -DCMAKE_BUILD_TYPE=DEBUG
-                              -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR;$HOME/local/openclicdloader"
+                              -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR;$HOME/local/openclicdloader;$BUILD_DIR/build/hipamd/opencl/khronos/icd"
                               -DCMAKE_INSTALL_LIBDIR=lib-debug
                               -DCMAKE_C_COMPILER="$LLVM_INSTALL_LOC/bin/clang"
                               -DCMAKE_CXX_COMPILER="$LLVM_INSTALL_LOC/bin/clang++"
@@ -129,7 +130,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
   fi
 
   HIPAMD_CMAKE_OPTS=("${MYCMAKEOPTS[@]}"
-                     -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR;$HOME/local/openclicdloader"
+                     -DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR;$HOME/local/openclicdloader;$BUILD_DIR/build/hipamd/opencl/khronos/icd"
                      -DCMAKE_INSTALL_LIBDIR=lib
                      -DCMAKE_CXX_FLAGS=-I"${AOMP_INSTALL_DIR}/include/amd_comgr"
                      -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-declarations

--- a/bin/patches/clr-findamd-icd.patch
+++ b/bin/patches/clr-findamd-icd.patch
@@ -1,0 +1,26 @@
+diff --git a/opencl/tools/clinfo/CMakeLists.txt b/opencl/tools/clinfo/CMakeLists.txt
+index 0af9f1eab..b2bcb7904 100644
+--- a/opencl/tools/clinfo/CMakeLists.txt
++++ b/opencl/tools/clinfo/CMakeLists.txt
+@@ -3,13 +3,18 @@ add_executable(clinfo clinfo.cpp)
+ target_compile_definitions(clinfo PRIVATE CL_TARGET_OPENCL_VERSION=220 HAVE_CL2_HPP)
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake")
+-find_package(AMD_ICD)
+ 
+ #todo: to be updated to use header files from other repos
+ target_include_directories(clinfo PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../khronos/headers/opencl2.2")
+ 
+-find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
+-target_link_libraries(clinfo PRIVATE ${AMD_ICD_LIBRARY})
++if(BUILD_ICD)
++  add_dependencies(clinfo OpenCL)
++  target_link_libraries(clinfo PRIVATE OpenCL)
++else()
++  find_package(AMD_ICD)
++  find_library(AMD_ICD_LIBRARY OpenCL HINTS "${AMD_ICD_LIBRARY_DIR}")
++  target_link_libraries(clinfo PRIVATE ${AMD_ICD_LIBRARY})
++endif()
+ 
+ INSTALL(TARGETS clinfo
+   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bin/patches/patch-control-file_21.0.txt
+++ b/bin/patches/patch-control-file_21.0.txt
@@ -6,6 +6,7 @@ GenASiS_Basics: genasis_basics.patch
 hipamd: hipamd-rpath.patch
 bolt: bolt.patch
 rocr-runtime: rocr-runtime-combined-numa-remove-gfx940-gfx941.patch
+clr: clr-findamd-icd.patch
 rocprofiler: rocprofiler-combined-no-aql-ok-fix-cov6.patch
 babelstream: babelstream-usm.patch
 llvm-project: ATD_ASO_full.patch


### PR DESCRIPTION
This allows libOpenCL.so to be picked up from AOMP build tree instead of relying on system package.