### PR TITLE
Adding reproducer test from ontrack-internal.amd.com/browse/SWDEV-508560

### DIFF
--- a/test/smoke-fort-fails/flang-508560/Makefile
+++ b/test/smoke-fort-fails/flang-508560/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = decl_tgt_allocatable
+TESTSRC_MAIN = decl_tgt_allocatable.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang-new
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-508560/decl_tgt_allocatable.f90
+++ b/test/smoke-fort-fails/flang-508560/decl_tgt_allocatable.f90
@@ -1,0 +1,20 @@
+program test
+   integer, dimension(:), allocatable :: xs
+   integer :: i, acc
+   !$omp declare target (xs)
+
+   allocate (xs(500))
+   !$omp target enter data map(alloc:xs)
+   xs = 1
+   acc = 0
+   !$omp target update to(xs)
+
+   !$omp target map(acc)
+   do i = 1, 500
+      acc = acc + xs(i)
+   end do
+   !$omp end target
+
+   !Expected output acc 500
+   print *, "acc", acc
+end program


### PR DESCRIPTION
Program intermittently fails on amd-staging.