### PR TITLE
[smoke-fort-fails] Add new identified test causing ICE

### DIFF
--- a/test/smoke-fort-fails/Makefile
+++ b/test/smoke-fort-fails/Makefile
@@ -37,7 +37,8 @@ TESTS_DIR = \
     rocm-issue-251 \
     rocm-issue-253-none \
     rocm-issue-253-device \
-    rocm-issue-253-host
+    rocm-issue-253-host \
+    target-array-element-reduction
 
 all:
 	@for test_dir in $(TESTS_DIR); do \

--- a/test/smoke-fort-fails/target-array-element-reduction/Makefile
+++ b/test/smoke-fort-fails/target-array-element-reduction/Makefile
@@ -1,0 +1,15 @@
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/target-array-element-reduction/test.f90
+++ b/test/smoke-fort-fails/target-array-element-reduction/test.f90
@@ -1,0 +1,20 @@
+program main
+  implicit none
+  integer, parameter :: N = 2
+  integer :: v(N)
+  v(:) = 0
+
+  !$omp target parallel map(tofrom: v(1:N)) num_threads(2) reduction(+:v(1))
+    v(1) = v(1) + 1
+  !$omp end target parallel
+
+  !$omp target map(tofrom: v(1:N))
+    !$omp parallel num_threads(2) reduction(+:v(2))
+      v(2) = v(2) + 1
+    !$omp end parallel
+  !$omp end target
+
+  if (v(1) .ne. 2 .or. v(2) .ne. 2) then
+    stop 1
+  end if
+end program


### PR DESCRIPTION
The flang compiler appears to mishandle reductions within a target region when they refer to a single element of an array.

The `target parallel` combined case results in an MLIR verifier error, whereas the `target` + `parallel` nested case triggers an assertion due to the outlined parallel region having live-out values.