### PR TITLE
[smoke-fort-dev] Add multi-generic-exe

### DIFF
--- a/test/smoke-fort-dev/Makefile
+++ b/test/smoke-fort-dev/Makefile
@@ -10,6 +10,7 @@ TESTS_DIR = \
     flang-529628 \
     hipfort \
     multi-generic \
+    multi-generic-exe \
     rocm-issue-201 \
     tgt-abort-lhostdev \
     tgt-firstprivate \

--- a/test/smoke-fort-dev/multi-generic-exe/Makefile
+++ b/test/smoke-fort-dev/multi-generic-exe/Makefile
@@ -30,7 +30,7 @@ GENERIC ?= gfx9-generic,gfx9-4-generic,gfx10-1-generic,gfx10-3-generic,gfx11-gen
 OFFLOAD = -fopenmp --offload-arch
 
 test:
-	${OMP_BIN} -c ${OFFLOAD}=${AOMP_GPU} vadd.f90
+	${OMP_BIN} -c ${OFFLOAD}=${GENERIC} vadd.f90
 	${OMP_BIN} -c ${OFFLOAD}=${AOMP_GPU},${GENERIC} vmul.f90
 	${OMP_BIN} -c main.f90
 	${OMP_BIN} -o test ${OFFLOAD}=${GENERIC} main.o ${LDFLAGS} vadd.o vmul.o

--- a/test/smoke-fort-dev/multi-generic-exe/main.f90
+++ b/test/smoke-fort-dev/multi-generic-exe/main.f90
@@ -1,0 +1,42 @@
+program vadddemo
+    implicit none
+    integer, parameter :: N = 100000
+    real a(N), b(N), c(N), validate(N)
+    integer i, num, flag, size;
+    num = N
+    
+    size = sizeof(a(1))
+    print *, "type: real"
+    print *, "bytes: ", size
+
+    flag = -1
+
+!$omp target map(from: a,b,validate)
+!$omp teams distribute parallel do 
+    do i = 1, N
+        a(i) = i+1;
+        b(i) = i+2;
+        validate(i) = a(i) + b(i);
+    enddo
+!$omp end target
+
+    call vadd(a, b, c, N)
+
+    do i = 1, num
+        if (c(i) .ne. validate(i)) then
+            ! print 1st bad index
+            if ( flag .eq. -1 ) then
+                print *, "First fail: c(", i, "):", c(i), " != validate(", i, "):", validate(i)
+            endif
+            flag = i;
+        endif
+    enddo
+    if (flag .eq. -1) then
+        print *, "Success"
+        call exit(0)
+    else
+        print *, "Last fail:  c(", flag, "):", c(flag), " != validate(", flag, "):", validate(flag)
+        print *, "FAILED"
+        call exit(1)
+    endif
+end program

--- a/test/smoke-fort-dev/multi-generic-exe/vadd.f90
+++ b/test/smoke-fort-dev/multi-generic-exe/vadd.f90
@@ -1,0 +1,12 @@
+subroutine vadd(a, b, c, N)
+    implicit none
+    real :: a(N), b(N), c(N)
+    integer :: N, i
+
+!$omp target map(to: a,b) map(from: c)
+!$omp teams distribute parallel do 
+    do i=1,N
+        c(i) = a(i) + b(i)
+    end do
+!$omp end target
+end subroutine

--- a/test/smoke-fort-dev/multi-generic-exe/vmul.f90
+++ b/test/smoke-fort-dev/multi-generic-exe/vmul.f90
@@ -1,0 +1,12 @@
+subroutine vmul(a, b, c, N)
+    implicit none
+    real :: a(N), b(N), c(N)
+    integer :: N, i
+
+!$omp target map(to: a,b) map(from: c)
+!$omp teams distribute parallel do 
+    do i=1,N
+        c(i) = a(i) * b(i)
+    end do
+!$omp end target
+end subroutine

--- a/test/smoke-fort-dev/whole-archive/Makefile
+++ b/test/smoke-fort-dev/whole-archive/Makefile
@@ -3,8 +3,6 @@
 #NOLINK       = 1
 include ../../Makefile.defs
 
-.PHONY: modules
-
 TESTNAME     = test
 TESTSRC_MAIN = main.f90
 TESTSRC_AUX  = vadd.f90
@@ -22,7 +20,6 @@ include ../Makefile.rules
 #LDFLAGS=-Wl,--whole-archive -Wl,--allow-multiple-definition -Wl,--no-nvptx-whole-archive
 LDFLAGS=-Wl,--whole-archive -Wl,--allow-multiple-definition
 
-# 446005 "works" version
 test:
 	${OMP_BIN} -c ${OMP_FLAGS} vadd.f90
 	rm -f vadd.a


### PR DESCRIPTION
    - version that tries to create a generic executable in the presence of an object (library standin) that has also contains the native arch