### PR TITLE
[build] - Do not hardcode field in build_supp.sh

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -119,7 +119,7 @@ function checkversion(){
   # inputs: $_linkfrom, $_cname, $CMDLOGFILE, $_version
   # output: $SKIPBUILD
   if [ -L $_linkfrom ] ; then 
-    existing_install_dir=`ls -l $_linkfrom | grep $_cname | awk '{print $11}'`
+    existing_install_dir=`ls -l $_linkfrom | grep $_cname | awk '{print $NF}'`
     if [ -d $existing_install_dir ] ; then 
       existing_version=${existing_install_dir##*-} 
       if [ "$existing_version" == "$_version" ] ; then 


### PR DESCRIPTION
Some systems have additional information returned from 'ls' and thus break the 11th field assumption. Instead use 'NF' which will always have the total number of fields.

Suggested by Hideki Saito.