### PR TITLE
Update tgt-firstprivate with tests for lowering !fir.boxchar types

### DIFF
--- a/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
+++ b/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
@@ -45,11 +45,11 @@ program test_firstprivate
   logical :: main_result
   
   main_result = .TRUE.
-  main_result = test_int_non_allocatable()
-  main_result = test_int_allocatable(10)
-  main_result = test_int_allocatable_with_bounds(-5, 5)
-  main_result = test_char_non_allocatable()
-  main_result = test_char_allocatable()
+  main_result = main_result .AND. test_int_non_allocatable()
+  main_result = main_result .AND. test_int_allocatable(10)
+  main_result = main_result .AND. test_int_allocatable_with_bounds(-5, 5)
+  main_result = main_result .AND. test_char_non_allocatable()
+  main_result = main_result .AND. test_char_allocatable()
   if (.not. main_result) then
      print *, "(test_firstprivate): FAIL"
      stop 1
@@ -65,6 +65,7 @@ contains
     
    call memcpy_int(a, b, 10)
    test_result = match_int(a, b, 1, 10)
+   call print_result(test_result, "test_int_non_allocatable")
   end function test_int_non_allocatable
 
   function test_int_allocatable(n) result(test_result)
@@ -84,6 +85,7 @@ contains
 
     deallocate(a)
     deallocate(b)
+    call print_result(test_result, "test_int_allocatable")
   end function test_int_allocatable
 
   function test_int_allocatable_with_bounds(lb, ub) result(test_result)
@@ -103,6 +105,7 @@ contains
 
     deallocate(a)
     deallocate(b)
+    call print_result(test_result, "test_int_allocatable_with_bounds")
   end function test_int_allocatable_with_bounds
 
   function test_char_non_allocatable() result(test_result)
@@ -113,6 +116,7 @@ contains
 
     call memcpy_char(a, b)
     test_result = match_char(a, b)
+    call print_result(test_result, "test_char_non_allocatable")
   end function test_char_non_allocatable
 
   function test_char_allocatable() result(test_result)
@@ -126,6 +130,11 @@ contains
     a = "john"
     call memcpy_char(a, b)
     test_result = match_char(a, b)
+
+    deallocate(a)
+    deallocate(b)
+    call print_result(test_result, "test_char_allocatable")
+
   end function test_char_allocatable
 
   subroutine initialize(arr, lb, ub, val)
@@ -145,6 +154,17 @@ contains
     end if
   end subroutine initialize
 
+  subroutine print_result(res, msg)
+    logical, intent(in) :: res
+    character(len=*), intent(in) :: msg
+
+    if (res) then
+       print *, "PASS: ", msg
+    else
+       print *, "FAIL: ", msg
+    end if
+    
+  end subroutine print_result
   function match_int(a, b, lb, ub) result(check_result)
     integer, intent(in) :: lb, ub
     integer, dimension(lb:ub), intent(in) :: a, b

--- a/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
+++ b/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
@@ -25,6 +25,17 @@ contains
     end do
     !$omp end target
   end subroutine memcpy_int_custom_lbub
+
+  subroutine memcpy_char(src, dst)
+    character(len=*), intent(in) :: src
+    character(len=*), intent(out) :: dst
+
+    !$omp target firstprivate(src) map(from:dst)
+    dst = src
+    !$omp end target
+
+  end subroutine memcpy_char
+
 end module tests
 
 program test_firstprivate
@@ -37,6 +48,8 @@ program test_firstprivate
   main_result = test_int_non_allocatable()
   main_result = test_int_allocatable(10)
   main_result = test_int_allocatable_with_bounds(-5, 5)
+  main_result = test_char_non_allocatable()
+  main_result = test_char_allocatable()
   if (.not. main_result) then
      print *, "(test_firstprivate): FAIL"
      stop 1
@@ -51,7 +64,7 @@ contains
     call initialize(b, 1, 10, val=0)
     
    call memcpy_int(a, b, 10)
-   test_result = match(a, b, 1, 10)
+   test_result = match_int(a, b, 1, 10)
   end function test_int_non_allocatable
 
   function test_int_allocatable(n) result(test_result)
@@ -67,7 +80,7 @@ contains
     call initialize(b, 1, n, val=0)
     
     call memcpy_int(a, b, n)
-    test_result = match(a, b, 1, n)
+    test_result = match_int(a, b, 1, n)
 
     deallocate(a)
     deallocate(b)
@@ -86,11 +99,34 @@ contains
     call initialize(b, lb, ub, 0)
     
     call memcpy_int_custom_lbub(a, b, lb, ub)
-    test_result = match(a, b, lb, ub)
+    test_result = match_int(a, b, lb, ub)
 
     deallocate(a)
     deallocate(b)
   end function test_int_allocatable_with_bounds
+
+  function test_char_non_allocatable() result(test_result)
+    character(len=10) :: a, b
+    logical :: test_result
+
+    a = "john"
+
+    call memcpy_char(a, b)
+    test_result = match_char(a, b)
+  end function test_char_non_allocatable
+
+  function test_char_allocatable() result(test_result)
+    character(len=:), allocatable :: a, b
+    integer :: n
+    logical :: test_result
+    n = 10
+
+    allocate(character(len=n) :: a)
+    allocate(character(len=n) :: b)
+    a = "john"
+    call memcpy_char(a, b)
+    test_result = match_char(a, b)
+  end function test_char_allocatable
 
   subroutine initialize(arr, lb, ub, val)
     integer, optional, intent(in) :: val
@@ -109,7 +145,7 @@ contains
     end if
   end subroutine initialize
 
-  function match(a, b, lb, ub) result(check_result)
+  function match_int(a, b, lb, ub) result(check_result)
     integer, intent(in) :: lb, ub
     integer, dimension(lb:ub), intent(in) :: a, b
     integer :: i
@@ -122,5 +158,16 @@ contains
        end if
     end do
     check_result = .TRUE.
-    end function match
+  end function match_int
+
+  function match_char(a, b) result(check_result)
+    character(len=*), intent(in) :: a
+    character(len=*), intent(in) :: b
+    logical :: check_result
+    if (a .ne. b) then
+       check_result = .FALSE.
+       return
+    end if
+    check_result = .TRUE.
+  end function match_char
 end program test_firstprivate

--- a/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
+++ b/test/smoke-fort-dev/tgt-firstprivate/test_firstprivate.f90
@@ -163,8 +163,8 @@ contains
     else
        print *, "FAIL: ", msg
     end if
-    
   end subroutine print_result
+
   function match_int(a, b, lb, ub) result(check_result)
     integer, intent(in) :: lb, ub
     integer, dimension(lb:ub), intent(in) :: a, b


### PR DESCRIPTION
For now, this is expected to fail with the nightly AOMP build. These tests pass on my local branch and will pass with AOMP once my local branch is accepted upstream and is turned around and merged internally.

Since, smoke-fort-dev doesn't cause PSDB to fail overall, the failing tests here won't block merges trying to merge into amd-staging