### PR TITLE
[smoke-fort-dev] Add a slightly more complex version of flang-325095

### DIFF
--- a/test/smoke-fort-dev/Makefile
+++ b/test/smoke-fort-dev/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.defs
 TESTS_DIR = \
     do-concurrent-device \
     do-concurrent-host \
+	flang-325095-2 \
     flang-464660-2 \
     flang-471469 \
     flang-523587 \

--- a/test/smoke-fort-dev/flang-325095-2/Makefile
+++ b/test/smoke-fort-dev/flang-325095-2/Makefile
@@ -1,0 +1,14 @@
+NOOPT        = 1
+include ../../Makefile.defs
+
+TESTNAME     = use_dev_addr_fort
+TESTSRC_MAIN = use_dev_addr_fort.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/flang-325095-2/use_dev_addr_fort.f90
+++ b/test/smoke-fort-dev/flang-325095-2/use_dev_addr_fort.f90
@@ -1,0 +1,88 @@
+program omp_subroutine
+    implicit none
+    integer, parameter :: N = 3
+    double precision, allocatable, dimension(:) :: c
+
+    allocate(c(N))
+    c = -42.0
+
+    ! Expected output c(3) = 1
+    call test1(c)
+    if (c(3) .ne. 1.0) then
+       write (*,*) "FAIL : test1:", c
+       stop 2
+    endif
+
+    print *, c
+    c(3) = -42.0
+
+    !$omp target enter data map(to:c)
+    call test2(c)
+    !$omp target update from(c)
+    if (c(3) .ne. 1.0) then
+       write (*,*) "FAIL : test2:", c
+       stop 2
+    endif
+
+    print *, c
+    c(3) = -42.0
+
+    call test3()
+    if (c(3) .ne. -42.0) then
+       write (*,*) "FAIL : test3:", c
+       stop 2
+    endif
+
+    print *, c
+    c(3) = -42.0
+
+    call test4(c)
+    if (c(3) .ne. 1.0) then
+       write (*,*) "FAIL : test4:", c
+       stop 2
+    endif
+
+    print *, c
+    print *, "PASS"
+    return
+contains
+    subroutine test1(c)
+        double precision, intent(inout) :: c(:)
+        !$omp target enter data map(to:c)
+        !$omp target data use_device_ptr(c)
+        c(3) = 1.0
+        !$omp end target data
+        !$omp target update from(c)
+    end subroutine
+
+    subroutine test2(c)
+        double precision, intent(inout) :: c(:)
+        !$omp target data use_device_ptr(c)
+        c(3) = 1.0
+        !$omp end target data
+    end subroutine
+
+    subroutine test3()
+        double precision, allocatable, dimension(:) :: c
+        allocate(c(N))
+       !$omp target enter data map(to:c)
+       !$omp target data use_device_ptr(c)
+            c(3) = 1.0
+       !$omp end target data
+        !$omp target update from(c)
+        write (*,*) "test3:", c
+    end subroutine
+
+
+    subroutine test4(c)
+        double precision, allocatable, dimension(:), intent(inout) :: c
+        deallocate(c)
+        allocate(c(N))
+        !$omp target enter data map(to:c)
+        !$omp target data use_device_ptr(c)
+        c(3) = 1.0
+        !$omp end target data
+        !$omp target update from(c)
+    end subroutine
+
+end program omp_subroutine


### PR DESCRIPTION
The test makes sure to reset c where neccessary to an initial value to prevent false positives and also utilises a larger allocatable array that doesn't write to the first element, to prevent false positives where we are only able to the first element and nothing else (common false positive case if a descriptor isn't quite correct).