### PR TITLE
remove -latomic from 3 smoke tests

### DIFF
--- a/test/smoke-dev/xteamr/Makefile
+++ b/test/smoke-dev/xteamr/Makefile
@@ -8,7 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-CFLAGS       = -O3 -std=c++11 -fopenmp-target-fast -latomic
+CFLAGS       = -O3 -std=c++11 -fopenmp-target-fast
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-dev/xteamr_builtins/Makefile
+++ b/test/smoke-dev/xteamr_builtins/Makefile
@@ -8,7 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-CFLAGS       = -O3 -std=c++11 -latomic
+CFLAGS       = -O3 -std=c++11
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke/double_complex_scalar/Makefile
+++ b/test/smoke/double_complex_scalar/Makefile
@@ -6,6 +6,6 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 CLANG        ?= clang++
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
-CC           = $(OMP_BIN) $(VERBOSE) -std=c++11 -latomic
+CC           = $(OMP_BIN) $(VERBOSE) -std=c++11
 
 include ../Makefile.rules


### PR DESCRIPTION
some systems dont have libatomic.so installed, and i am wondering if our distros are new enough to not need this library anymore.