### PR TITLE
[CK] Fix GPU index list creation

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -42,7 +42,7 @@ function getIndexListByTargetArch {
   # Finally, we use xargs to format the results into a tidy, single-line list.
   OnlyVisibleDevices=""
   if [ ! -z "${ROCR_VISIBLE_DEVICES}" ]; then
-    OnlyVisibleDevices="-d ${ROCR_VISIBLE_DEVICES}"
+    OnlyVisibleDevices="$(echo "-d ${ROCR_VISIBLE_DEVICES}" | tr ',' ' ')"
   fi
   GPUList="$(rocm-smi --showproductname ${OnlyVisibleDevices})"
   GPURegex="s/^GPU\[([0-9]+)\].*${TargetArch}$/\1/p"


### PR DESCRIPTION
Fix missing handling of commas in `ROCR_VISIBLE_DEVICES`
 - Now `,` is translated to ` `
   Which is the expected separator of `rocm-smi -d`