### PR TITLE
Handle all combinations of GFXLIST and ROCMLIBS_GFXLIST

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -288,7 +288,7 @@ fi
 # Set list of default amdgcn subarchitectures to build
 # Developers may override GFXLIST and ROCMLIBS_GFXLIST variables to shorten build time of aomp and rocmlibs, respectively.
 # | ROCMLIBS_GFXLIST defined | GFXLIST defined | Resulting GFXLIST and ROCMLIBS_GFXLIST |
-# |           Yes            |       Yes       | GFXLIST and ROCMLIBS_GFXLIST are both set to the defined value of GFXLIST |
+# |           Yes            |       Yes       | GFXLIST and ROCMLIBS_GFXLIST are both set to their defined values |
 # |           Yes            |       No        | GFXLIST is set to ROCMLIBS_GFXLIST, ROCMLIBS_GFXLIST remains unchanged |
 # |           No             |       Yes       | ROCMLIBS_GFXLIST is set to GFXLIST, GFXLIST remains unchanged |
 # |           No             |       No        | GFXLIST is set to a default list, ROCMLIBS_GFXLIST is set to a smaller subset of GFXLIST |

--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -286,12 +286,23 @@ else
 fi
 
 # Set list of default amdgcn subarchitectures to build
-# Developers may override GFXLIST to shorten build time.
-GFXLIST=${GFXLIST:-"gfx900 gfx902 gfx906 gfx908 gfx90a gfx90c gfx942 gfx950 gfx1030 gfx1031 gfx1035 gfx1036 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201 gfx9-generic gfx9-4-generic gfx10-1-generic gfx10-3-generic gfx11-generic gfx12-generic"}
-export GFXLIST
+# Developers may override GFXLIST and ROCMLIBS_GFXLIST variables to shorten build time of aomp and rocmlibs, respectively.
+# | ROCMLIBS_GFXLIST defined | GFXLIST defined | Resulting GFXLIST and ROCMLIBS_GFXLIST |
+# |           Yes            |       Yes       | GFXLIST and ROCMLIBS_GFXLIST are both set to the defined value of GFXLIST |
+# |           Yes            |       No        | GFXLIST is set to ROCMLIBS_GFXLIST, ROCMLIBS_GFXLIST remains unchanged |
+# |           No             |       Yes       | ROCMLIBS_GFXLIST is set to GFXLIST, GFXLIST remains unchanged |
+# |           No             |       No        | GFXLIST is set to a default list, ROCMLIBS_GFXLIST is set to a smaller subset of GFXLIST |
+if [ -z "$ROCMLIBS_GFXLIST" ] && [ -n "$GFXLIST" ]; then
+  ROCMLIBS_GFXLIST="$GFXLIST"
+elif [ -n "$ROCMLIBS_GFXLIST" ] && [ -z "$GFXLIST" ]; then
+  GFXLIST="$ROCMLIBS_GFXLIST"
+else
+  GFXLIST=${GFXLIST:-"gfx900 gfx902 gfx906 gfx908 gfx90a gfx90c gfx942 gfx950 gfx1030 gfx1031 gfx1035 gfx1036 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 gfx1152 gfx1153 gfx1200 gfx1201 gfx9-generic gfx9-4-generic gfx10-1-generic gfx10-3-generic gfx11-generic gfx12-generic"}
+  ROCMLIBS_GFXLIST=${ROCMLIBS_GFXLIST:-"gfx90a;gfx942;gfx1103;gfx1150"}
+fi
 
-# Keep a small list of architectures for ROCMLIBS to shorten build time.
-ROCMLIBS_GFXLIST=${ROCMLIBS_GFXLIST:-"gfx90a;gfx942;gfx1103;gfx1150"}
+export GFXLIST
+export ROCMLIBS_GFXLIST
 
 # Do a sanity check for stanalone build that ROCMLIBS_GFXLIST is a subset of GFXLIST
 for arch in ${ROCMLIBS_GFXLIST//;/ }; do


### PR DESCRIPTION
Couple of boundary conditions were missing where only setting GFXLIST was causing an issue with the sanity checking of architecture list.

| ROCMLIBS_GFXLIST defined | GFXLIST defined | Resulting GFXLIST and ROCMLIBS_GFXLIST |
|--------------------------|-----------------|----------------------------------------|
| Yes | Yes | GFXLIST and ROCMLIBS_GFXLIST are both set to their defined values |
| Yes | No | GFXLIST is set to ROCMLIBS_GFXLIST, ROCMLIBS_GFXLIST remains unchanged |
| No | Yes | ROCMLIBS_GFXLIST is set to GFXLIST, GFXLIST remains unchanged |
| No | No | GFXLIST is set to a default list, ROCMLIBS_GFXLIST is set to a smaller subset of GFXLIST |