### PR TITLE
[CK] Fix build issue on gfx12 after CK 128f5a1e

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -253,6 +253,8 @@ CKCmakeCmd="cmake -GNinja -B ${CK_BUILD} -S ${CK_REPO} -DCMAKE_PREFIX_PATH=${ROC
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ -DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache "
 CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=${CK_GPU_TARGETS}"
+# For some reason, CK on gfx12 wants this set.
+CKCMakeCmd+="-DBUILD_DEV=On"
 
 if [ "${ShouldRebuildCK}" == 'yes' ]; then
   echo "Rebuilding the CK repo w/ ${CKBuildParallelism} parallel jobs."

--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -252,7 +252,7 @@ fi
 CKCmakeCmd="cmake -GNinja -B ${CK_BUILD} -S ${CK_REPO} -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DCMAKE_INSTALL_PREFIX=${CK_INSTALL} "
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ -DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache "
-CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=${CK_GPU_TARGETS}"
+CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=${CK_GPU_TARGETS} "
 # For some reason, CK on gfx12 wants this set.
 CKCMakeCmd+="-DBUILD_DEV=On"
 


### PR DESCRIPTION
After
https://github.com/ROCm/composable_kernel/commit/128f5a1eab330744d10c82a799bfdd9978d4c14b it appears that CK on gfx12 requires this CMake flag to be specified. Otherwise it will bail out with a CMake error.