### PR TITLE
[tests] - Update examples/tests for use of LLVM_ENABLE_PER_TARGET_RUN…

### DIFF
--- a/examples/inc/find_gpu_and_install_dir.mk
+++ b/examples/inc/find_gpu_and_install_dir.mk
@@ -42,6 +42,9 @@ ifeq ("$(wildcard $(LLVM_INSTALL_DIR))","")
   endif
 endif
 
+# Determine clang host target
+CLANG_HOST_TARGET=$(shell awk '/LLVM_HOST_TRIPLE/ {print substr($$2,1,length($$2)-1)}' $(LLVM_INSTALL_DIR)/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+
 # Determine COMPILER_NAME (AMD, AOMP, or clang)
 LLVM_COMPILER_NAME := $(shell $(LLVM_INSTALL_DIR)/bin/clang --version | head -n1 | cut -d" " -f1  | cut -d"_" -f1 )
 FLANG ?= flang

--- a/examples/openmp/demo_offload_types/Makefile
+++ b/examples/openmp/demo_offload_types/Makefile
@@ -37,7 +37,7 @@ ifeq ($(LLVM_COMPILER_NAME),clang)
 	@echo "2 Skipping host-offload because this is broken in trunk"
 else
 	@echo "2. Create binary for host offloading:	host-offload"
-	$(CC) $(CFLAGS) -fopenmp-targets=x86_64-pc-linux-gnu -Xopenmp-target=x86_64-pc-linux-gnu --march=znver1 $^ -o host-offload 
+	$(CC) $(CFLAGS) -fopenmp-targets=$(CLANG_HOST_TARGET) -Xopenmp-target=$(CLANG_HOST_TARGET) --march=znver1 $^ -o host-offload
 endif
 	@echo "3. Create binary that does GPU offload:	gpu-offload"
 	$(CC) $(CFLAGS) $(OAFLAG) $^ -o gpu-offload 

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -1,6 +1,5 @@
 SHELL=/bin/bash -o pipefail
 
-
 # Set the value of SKIP_USM to 1 if the system is a VM, else sets SKIP_USM to 0.
 # a system is considered a VM if it has the HyperV or VMWare names present in
 # output of lspci or /usr/sbin/lspci or /sbin/lspci commands.
@@ -66,6 +65,12 @@ ifeq ("$(wildcard $(AOMP)/bin/clang)","")
   endif
 endif
 # --- End Standard Makefile check for AOMP installation ---
+
+CLANG_HOST_TARGET=$(shell awk '/LLVM_TARGET_TRIPLE/ {print substr($$2,1,length($$2)-1)}' $(AOMP)/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+
+ifeq ($(CLANG_HOST_TARGET),)
+  $(error Error Could not determine LLVM_TARGET_TRIPLE from $(AOMP)/lib/cmake/llvm/LLVMConfig.cmake)
+endif
 
 ifneq ($(TIMEOUT),)
   TKILL= timeout $(TIMEOUT)

--- a/test/smoke/clang-host-targ/Makefile
+++ b/test/smoke/clang-host-targ/Makefile
@@ -7,7 +7,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 TARGET       = -fopenmp -O3 
-TARGET       += -fopenmp-targets=x86_64-pc-linux-gnu -Xopenmp-target=x86_64-pc-linux-gnu --march=znver1
+TARGET       += -fopenmp-targets=$(CLANG_HOST_TARGET) -Xopenmp-target=$(CLANG_HOST_TARGET) --march=znver1
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/clang-host-targ2/Makefile
+++ b/test/smoke/clang-host-targ2/Makefile
@@ -11,7 +11,7 @@ $(TESTSRC_AUX): another.c
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 TARGET       = -fopenmp -O3 
-TARGET       += -fopenmp-targets=x86_64-pc-linux-gnu -Xopenmp-target=x86_64-pc-linux-gnu --march=x86
+TARGET       += -fopenmp-targets=$(CLANG_HOST_TARGET) -Xopenmp-target=$(CLANG_HOST_TARGET) --march=x86
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/flags/Makefile
+++ b/test/smoke/flags/Makefile
@@ -15,7 +15,6 @@ all: $(TESTNAME)
 $(TESTNAME): $(TESTSRC_ALL)
 	@./run_options.sh $(AOMP_GPU)
 
-
 compile:
 ifdef nvidia_targets
 	$(CC) $(make_options) $(nvidia_targets) $(march) $(cuda) -o $(TESTNAME)

--- a/test/smoke/flags/options.txt
+++ b/test/smoke/flags/options.txt
@@ -2,7 +2,7 @@ OFFLOAD_DEBUG=1 flags.c -isystem${AOMP}/include  -O2 ${AOMP_CPUTARGET} -fopenmp 
 flags.c -isystem${AOMP}/include  -O2 ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
 flags.c ${AOMP_CPUTARGET} -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
 flags.c -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=AOMP_GPU_or_auto_detect
-flags.c -fopenmp -save-temps ${AOMP_CPUTARGET} -fopenmp-targets=x86_64-pc-linux-gnu
+flags.c -fopenmp -save-temps ${AOMP_CPUTARGET} -fopenmp-targets=HOST_TARGET
 flags.c -fopenmp -save-temps ${AOMP_CPUTARGET}
-flags.c -fopenmp -save-temps -fopenmp-targets=x86_64-pc-linux-gnu
+flags.c -fopenmp -save-temps -fopenmp-targets=HOST_TARGET
 flags.c -fopenmp -save-temps

--- a/test/smoke/flags/run_options.sh
+++ b/test/smoke/flags/run_options.sh
@@ -13,6 +13,7 @@ march_regex="(march=AOMP_GPU_or_auto_detect)"
 debug_regex="(OFFLOAD_DEBUG=([0-9]))"
 # Regex to search for Nvidia cards
 target_regex="(-fopenmp-[a-z]*=[a-z,-]*).*(-Xopenmp-[a-z]*=[a-z,-]*)"
+host_target_regex="(fopenmp-targets=HOST_TARGET)"
 
 UNAMEP=`uname -m`
 if [[ $UNAMEP == "ppc64le" ]] ; then
@@ -67,11 +68,19 @@ while read -r line; do
       echo "$base $test_num: Make Failed" >> ../make-fail.txt
     fi
   else # Host compilation or run, GPU not detected on input line, no need to pass other variables to make
+    if [[ "$line" =~ $host_target_regex ]]; then
+      march_match=${BASH_REMATCH[1]}
+      # Remove march from command and replace with correct version
+      line=${line/"-$march_match"}
+      CLANG_HOST_TARGET_DIR=$(awk '/LLVM_TARGET_TRIPLE/ {print substr($2,1,length($2)-1)}' "$AOMP"/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+      host_target_str="-fopenmp-targets=$CLANG_HOST_TARGET_DIR"
+    fi
+
     if [[ $1 != "run" ]]; then
-      make --no-print-directory make_options="$line" compile
+      make --no-print-directory make_options="$line $host_target_str" compile
     fi
     if [[ $1 == "run" ]]; then
-      make --no-print-directory make_options="$line" test_num=$test_num check
+      make --no-print-directory make_options="$line $host_target_str" test_num=$test_num check
     fi
   fi
   # Host not successfull

--- a/test/smoke/host_targ/Makefile
+++ b/test/smoke/host_targ/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = host_targ.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TARGET 	     = -fopenmp -fopenmp-targets=x86_64-pc-linux-gnu -Xopenmp-target=x86_64-pc-linux-gnu --march=x86 -save-temps
+TARGET 	     = -fopenmp -fopenmp-targets=$(CLANG_HOST_TARGET) -Xopenmp-target=$(CLANG_HOST_TARGET) --march=x86 -save-temps
 
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)

--- a/test/smoke/liba_bundled_cmdline/Makefile
+++ b/test/smoke/liba_bundled_cmdline/Makefile
@@ -13,7 +13,7 @@ EXTRA_OMP_FLAGS =
 
 CC        = $(AOMP)/bin/clang
 UNAMEP    = $(shell uname -m)
-HOST_TARGET = $(UNAMEP)-pc-linux-gnu
+HOST_TARGET = $(CLANG_HOST_TARGET)
 EXTRA_CFLAGS = -target $(HOST_TARGET)
 
 ifeq (sm_,$(findstring sm_,$(AOMP_GPU)))


### PR DESCRIPTION
…TIME_DIR

Some tests hardcode 'x86_64-pc-linux-gnu' which is not always the correct host target. We will instead query the LLVMConfig.cmake to determine the correct LLVM_HOST_TARGET.