### PR TITLE
[tests] - Do not depend on LLVMConfig.cmake to determine CLANG_HOST_T…

### DIFF
--- a/examples/inc/find_gpu_and_install_dir.mk
+++ b/examples/inc/find_gpu_and_install_dir.mk
@@ -43,7 +43,7 @@ ifeq ("$(wildcard $(LLVM_INSTALL_DIR))","")
 endif
 
 # Determine clang host target
-CLANG_HOST_TARGET=$(shell awk '/LLVM_HOST_TRIPLE/ {print substr($$2,1,length($$2)-1)}' $(LLVM_INSTALL_DIR)/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+CLANG_HOST_TARGET=$(shell $(LLVM_INSTALL_DIR)/bin/clang --version | grep Target: | cut -d" " -f2)
 
 # Determine COMPILER_NAME (AMD, AOMP, or clang)
 LLVM_COMPILER_NAME := $(shell $(LLVM_INSTALL_DIR)/bin/clang --version | head -n1 | cut -d" " -f1  | cut -d"_" -f1 )

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -66,7 +66,7 @@ ifeq ("$(wildcard $(AOMP)/bin/clang)","")
 endif
 # --- End Standard Makefile check for AOMP installation ---
 
-CLANG_HOST_TARGET=$(shell awk '/LLVM_TARGET_TRIPLE/ {print substr($$2,1,length($$2)-1)}' $(AOMP)/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+CLANG_HOST_TARGET=$(shell $(AOMP)/bin/clang --version | grep Target: | cut -d" " -f2)
 
 ifeq ($(CLANG_HOST_TARGET),)
   $(error Error Could not determine LLVM_TARGET_TRIPLE from $(AOMP)/lib/cmake/llvm/LLVMConfig.cmake)

--- a/test/smoke/flags/run_options.sh
+++ b/test/smoke/flags/run_options.sh
@@ -72,7 +72,7 @@ while read -r line; do
       march_match=${BASH_REMATCH[1]}
       # Remove march from command and replace with correct version
       line=${line/"-$march_match"}
-      CLANG_HOST_TARGET_DIR=$(awk '/LLVM_TARGET_TRIPLE/ {print substr($2,1,length($2)-1)}' "$AOMP"/lib/cmake/llvm/LLVMConfig.cmake | tr -d \")
+      CLANG_HOST_TARGET_DIR=$("$AOMP"/bin/clang --version | grep Target: | cut -d" " -f2)
       host_target_str="-fopenmp-targets=$CLANG_HOST_TARGET_DIR"
     fi
 


### PR DESCRIPTION
…ARGET

This cmake file exists in rocm-llvm-dev, but some ROCm installs do not have that package installed. Instead, use clang --version to get the target.