### PR TITLE
[Offload][Test] Add test for debug info in cross-team reduction code

### DIFF
--- a/test/smoke-dev/xteam-red-debug-info/Makefile
+++ b/test/smoke-dev/xteam-red-debug-info/Makefile
@@ -1,0 +1,16 @@
+include ../../Makefile.defs
+
+TESTNAME     = xteam_red_debug_info
+TESTSRC_MAIN = xteam_red_debug_info.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV       += LIBOMPTARGET_INFO=1
+RUNCMD       = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang -g
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/xteam-red-debug-info/xteam_red_debug_info.c
+++ b/test/smoke-dev/xteam-red-debug-info/xteam_red_debug_info.c
@@ -1,0 +1,25 @@
+#include<omp.h>
+
+// This test checks if the debug infomation were correctly
+// mapped for cross-tream reduction code.
+
+int main()
+{
+  int N = 100000;
+  double x[N];
+  double sum = 0.0;
+
+  #pragma omp target teams distribute parallel for reduction(+: sum)
+  for (int i=0; i<N; i++){
+    sum += x[i];
+  }
+
+  sum = sum/(double)N;
+}
+
+/// CHECK:      firstprivate(N)[4] (implicit)
+/// CHECK-NEXT: tofrom(sum)[8] (implicit)
+/// CHECK-NEXT: firstprivate(unknown)[8] (implicit)
+/// CHECK-NEXT: tofrom(x)[800000] (implicit)
+/// CHECK-NEXT: firstprivate(unknown)[8]
+/// CHECK-NEXT: firstprivate(unknown)[8]


### PR DESCRIPTION
This test is to ensure that the debug information are correctly mapped for cross-team reduction kernel.