### PR TITLE
[smoke-limbo] - Default to AOMP clang instead of GCC for cmake invoca…

### DIFF
--- a/test/smoke-limbo/omptest-device-emi/Makefile
+++ b/test/smoke-limbo/omptest-device-emi/Makefile
@@ -23,4 +23,4 @@ CC           = $(DUMMYSRC) | $(OMP_BIN) $(DUMMYOPT)
 include ../Makefile.rules
 
 clean::
-	git clean -dfx ./build
+	rm -rf ./build

--- a/test/smoke-limbo/omptest-device-emi/performBuildRun.sh
+++ b/test/smoke-limbo/omptest-device-emi/performBuildRun.sh
@@ -40,12 +40,14 @@ if [ ! -d ${AOMP_DIR} ]; then
 fi
 
 echo " >>> Clean ..."
-git clean -fdx ./${BUILD_DIR}
+rm -rf ./${BUILD_DIR}
 
 echo " >>> Configure ..."
 cmake -B ${BUILD_DIR} -S .                                                     \
 -DAOMP_DIR=${AOMP_DIR}                                                         \
--DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH}
+-DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH} \
+-DCMAKE_C_COMPILER=${AOMP_DIR}/bin/clang \
+-DCMAKE_CXX_COMPILER=${AOMP_DIR}/bin/clang++
 
 echo " >>> Build ..."
 cmake --build ${BUILD_DIR} --clean-first --parallel || exit 1

--- a/test/smoke-limbo/omptest-device-non-emi/Makefile
+++ b/test/smoke-limbo/omptest-device-non-emi/Makefile
@@ -22,4 +22,4 @@ CC           = $(DUMMYSRC) | $(OMP_BIN) $(DUMMYOPT)
 include ../Makefile.rules
 
 clean::
-	git clean -dfx ./build
+	rm -rf ./build

--- a/test/smoke-limbo/omptest-device-non-emi/performBuildRun.sh
+++ b/test/smoke-limbo/omptest-device-non-emi/performBuildRun.sh
@@ -40,12 +40,14 @@ if [ ! -d ${AOMP_DIR} ]; then
 fi
 
 echo " >>> Clean ..."
-git clean -fdx ./${BUILD_DIR}
+rm -rf ./${BUILD_DIR}
 
 echo " >>> Configure ..."
 cmake -B ${BUILD_DIR} -S .                                                     \
 -DAOMP_DIR=${AOMP_DIR}                                                         \
--DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH}
+-DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH} \
+-DCMAKE_C_COMPILER=${AOMP_DIR}/bin/clang \
+-DCMAKE_CXX_COMPILER=${AOMP_DIR}/bin/clang++
 
 echo " >>> Build ..."
 cmake --build ${BUILD_DIR} --clean-first --parallel || exit 1

--- a/test/smoke-limbo/veccopy-ompt-target-cmake/Makefile
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/Makefile
@@ -21,4 +21,4 @@ CC           = $(DUMMYSRC) | $(OMP_BIN) $(DUMMYOPT)
 include ../Makefile.rules
 
 clean::
-	git clean -dfx ./build
+	rm -rf ./build

--- a/test/smoke-limbo/veccopy-ompt-target-cmake/performBuildRun.sh
+++ b/test/smoke-limbo/veccopy-ompt-target-cmake/performBuildRun.sh
@@ -40,12 +40,14 @@ if [ ! -d ${AOMP_DIR} ]; then
 fi
 
 echo " >>> Clean ..."
-git clean -fdx ./${BUILD_DIR}
+rm -rf ./${BUILD_DIR}
 
 echo " >>> Configure ..."
 cmake -B ${BUILD_DIR} -S .                                                     \
 -DAOMP_DIR=${AOMP_DIR}                                                         \
--DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH}
+-DTGT_OFFLOAD_ARCH=${TGT_OFFLOAD_ARCH} \
+-DCMAKE_C_COMPILER=${AOMP_DIR}/bin/clang \
+-DCMAKE_CXX_COMPILER=${AOMP_DIR}/bin/clang++
 
 echo " >>> Build ..."
 cmake --build ${BUILD_DIR} --clean-first --parallel || exit 1


### PR DESCRIPTION
…tion

Running into an issue where the gcc on some testers seems incomplete or ccache is misconfigured. Also fix the clean target to remove build dir and not use 'git clean' because the tests are not always in a git repo when tested.