### PR TITLE
add simde repo so I can update the rocr runtime patch that will need it.

### DIFF
--- a/bin/clone_aomp.sh
+++ b/bin/clone_aomp.sh
@@ -170,6 +170,8 @@ function list_repo_from_manifest(){
         manifest_project=$(echo "$REPO_PROJECT" | tr '[:upper:]' '[:lower:]')
    elif [[ "$REPO_REMOTE" == "hwloc" ]] ; then
         manifest_project=$(echo "open-mpi/$REPO_PROJECT" | tr '[:upper:]' '[:lower:]')
+   elif [[ "$REPO_REMOTE" == "simde" ]] ; then
+        manifest_project=$(echo "simd-everywhere/$REPO_PROJECT" | tr '[:upper:]' '[:lower:]')
    else
         manifest_project=$(echo "$REPO_REMOTE/$REPO_PROJECT" | tr '[:upper:]' '[:lower:]')
    fi
@@ -277,6 +279,8 @@ if [[ "$AOMP_VERSION" == "13.1" ]] || [[ $AOMP_MAJOR_VERSION -gt 13 ]] ; then
          repo_web_location=$GITHWLOC
       elif [ "$remote" == "githubemu-lightning" ] ; then
          repo_web_location=$GITLIGHTNINGINTERNAL
+      elif [ "$remote" == "simde" ] ; then
+         repo_web_location="https://github.com/simd-everywhere"
       else
          line_is_good=0
       fi

--- a/manifests/aomp_22.0.xml
+++ b/manifests/aomp_22.0.xml
@@ -5,11 +5,13 @@
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
     <default revision="release/rocm-rel-6.4" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
+    <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
 <!-- These first 4 repos are NOT rocm 6.4. They are compiler developer branches -->
     <project remote="roc" path="llvm-project" name="llvm-project"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="SPIRV-LLVM-Translator" name="SPIRV-LLVM-Translator"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="hipify" name="hipify"    revision="amd-staging" groups="unlocked" />
+    <project remote="simde" path="simde" name="simde" revision="master" groups="unlocked" />
 
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />

--- a/manifests/aompi_22.0.xml
+++ b/manifests/aompi_22.0.xml
@@ -4,11 +4,13 @@
 
     <default revision="release/rocm-rel-6.4" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
+    <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
 <!-- These first 4 repos are NOT rocm 6.4. They are compiler developer branches -->
     <project remote="githubemu-lightning" path="llvm-project" name="llvm-project.git" revision="amd-staging" groups="unlocked" />
     <project remote="githubemu-lightning" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
     <project remote="githubemu-lightning" path="hipify" name="hipify.git" revision="amd-staging" groups="unlocked" />
+    <project remote="simde" path="simde" name="simde" revision="master" groups="unlocked" />
 
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />


### PR DESCRIPTION
simde allows for some portable intrinsics.   Will use this in future rocr-runtime patch. 