### PR TITLE
[smoke-fails] Update tests to use rocprofv3

### DIFF
--- a/test/smoke-fails/hsa-lazy-queues/Makefile
+++ b/test/smoke-fails/hsa-lazy-queues/Makefile
@@ -6,10 +6,10 @@ TESTSRC_AUX  = empty-sink.c
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 AOMPROCM     ?= $(AOMPHIP)
-ifneq (,$(wildcard $(AOMPROCM)/bin/rocprof))
-	RUNPROF   = $(AOMPROCM)/bin/rocprof
+ifneq (,$(wildcard $(AOMPROCM)/bin/rocprofv3))
+	RUNPROF   = $(AOMPROCM)/bin/rocprofv3
 else
-	RUNPROF   = $(AOMPROCM)/../bin/rocprof
+	RUNPROF   = $(AOMPROCM)/../bin/rocprofv3
 endif
 
 # If 'ROCR_VISIBLE_DEVICES' is empty, default to zero. Otherwise, split on ','
@@ -23,7 +23,7 @@ else
     RUNENV    = ROCR_VISIBLE_DEVICES=$(DEVICE)
 endif
 
-RUNPROF_FLAGS = --hsa-trace
+RUNPROF_FLAGS = -o results.json --output-format json --hsa-trace True --stats True --
 
 RUNENV       += OMP_NUM_THREADS=2 LIBOMPTARGET_AMDGPU_HSA_QUEUE_BUSY_TRACKING=1
 RUNCMD       = ./$(TESTNAME) && python3 countQueueCreateEvents.py 2

--- a/test/smoke-fails/hsa-lazy-queues/countQueueCreateEvents.py
+++ b/test/smoke-fails/hsa-lazy-queues/countQueueCreateEvents.py
@@ -7,26 +7,33 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('num_occurences', type=int, help='How many hsa_queue_create events are expected')
 
-filename = 'results.json'
+filename = 'results.json_results.json'
 hsa_queue_create_name = 'hsa_queue_create'
 
 def searchAndCount(TheJSON, args) -> None:
-  TraceEvents = TheJSON['traceEvents']
+  Data = TheJSON['rocprofiler-sdk-tool']
+  for D in Data:
+    if 'summary' in D:
+      Summary = D['summary']
 
-  ExpectedNumOccurs = args.num_occurences
-  NumOccurs = 0
-  for e in TraceEvents:
-    if len(e) == 0:
+  for E in Summary:
+    if E['domain'] != 'HSA_API':
       continue
 
-    if e['name'] == hsa_queue_create_name:
-      NumOccurs += 1
+    Stats = E['stats']
+    Ops = Stats['operations']
+    for Op in Ops:
+      if Op['key'] == hsa_queue_create_name:
+        NumOccur = Op['value']['count']
+        # Return error if numbers don't match
+        sys.exit(NumOccur - args.num_occurences)
 
-  if NumOccurs != ExpectedNumOccurs:
-      sys.exit(1)
+  # When not found
+  sys.exit(1)
 
 if __name__ == '__main__':
   args = parser.parse_args()
+  print("Reading JSON file:", filename)
   with open(filename, "r") as f:
     J = json.load(f)
     searchAndCount(J, args)


### PR DESCRIPTION
Older rocprof versions are deprecated, hence tests need updating.