### PR TITLE
[CK] Replace client-examples compiler 'hipcc' with 'clang++'

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -372,10 +372,10 @@ fi
 # Handle CK client examples
 if [ "${SelectedSuite}" == 'client-examples' ]; then
   # Configure and build the client examples
-  # Note: client_example needs hipcc, otherwise there may be assertion failures.
   CKCmakeCmd="cmake -G Ninja "
   CKCmakeCmd+="-B ${CK_CLIENT_EXAMPLES_BUILD} -S ${CK_CLIENT_EXAMPLES_SOURCE} "
-  CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/../../bin/hipcc "
+  CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ "
+  CKCmakeCmd+="-DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "
   CKCmakeCmd+="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache "
   CKCmakeCmd+="-DCMAKE_PREFIX_PATH=${AOMP_LIB_PATH}/cmake;${CK_INSTALL} "
   CKCmakeCmd+="-DGPU_TARGETS=${CK_GPU_TARGETS} "


### PR DESCRIPTION
Bring the CMake configuration in-line with the remaining script.
Using hipcc was necessary only for client-examples.
Meanwhile, clang++ has been fixed and may be used.