### PR TITLE
Fix for aus-smc01 and aus-smc03's launch_latency error.

### DIFF
--- a/test/smoke-dev/launch_latency/Makefile
+++ b/test/smoke-dev/launch_latency/Makefile
@@ -9,7 +9,7 @@ CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 RUNENV       = ulimit -s unlimited;
-RUNCMD       = rocprofv3 --output-format csv --kernel-trace --stats -- ./$(TESTNAME) && python3 printLatency.py
+RUNCMD       = $(AOMPHIP)/bin/rocprofv3 --output-format csv --kernel-trace --stats -- ./$(TESTNAME) && python3 printLatency.py
 
 #-ccc-print-phases
 #"-\#\#\#"


### PR DESCRIPTION
Fix for aus-smc01 and aus-smc03's launch_latency error.  Using the wrong rocprofv3, needed to be from AOMP.