### PR TITLE
[smoke-fort-fails] Add test for SWDEV-523229 and SWDEV-540611

### DIFF
--- a/test/smoke-fort-fails/flang-523229/Makefile
+++ b/test/smoke-fort-fails/flang-523229/Makefile
@@ -1,0 +1,14 @@
+include ../../Makefile.defs
+
+TESTNAME     = type_bound_proc_target
+TESTSRC_MAIN = type_bound_proc_target.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-523229/type_bound_proc_target.f90
+++ b/test/smoke-fort-fails/flang-523229/type_bound_proc_target.f90
@@ -1,0 +1,31 @@
+! Reproducer for tickets SWDEV-523229 and SWDEV-540611.
+! Compilation would fail while lowering to LLVM IR due to leftover host
+! operations in the device MLIR module.
+
+module mymodule
+  implicit none
+
+  type :: myclass
+  contains
+    procedure :: myfunc => myfunc
+  end type myclass
+
+contains
+  subroutine myfunc(self)
+    class(myclass) :: self
+  end subroutine
+end module
+
+program main
+  use mymodule, only : myclass
+  implicit none
+
+  class(myclass), allocatable :: x
+  allocate(x)
+
+  call x%myfunc()
+  !$omp target
+  !$omp end target
+
+  deallocate(x)
+end program


### PR DESCRIPTION
This minimal reproducer shows the same behavior as the tickets listed in the title.

A fix has already been merged into amd-staging, adding it to smoke-fort-fails first to make sure it works in the nightlies before moving to smoke-fort.