### PR TITLE
[smoke] Adds valgrind `make` target

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -103,6 +103,8 @@ og11run: $(TESTNAME)_og11
 	$(OG11ENV) ./$(TESTNAME)_og11
 gpurun: $(TESTNAME)
 	$(AOMP)/bin/gpurun $(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
+valgrind: $(TESTNAME)
+	valgrind $(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
 
 # Just verify output
 verify: run


### PR DESCRIPTION
This adds a new target `valgrind` to enable execution of a testcase under valgrind control.

Only tested with a couple of simple examples: helloworld and some OMPT test cases.

## Motivation

Enable developer for quick use of the tool.

## Technical Details

Adds Makefile rule to execute the target binary under valgrind control

## Test Plan

Some manual testing

## Test Result

Worked

## Submission Checklist

- [x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
