### PR TITLE
[smoke] Fixes potential nullptr deref

### DIFF
--- a/test/smoke/aomp-issue376/aomp-issue376.cpp
+++ b/test/smoke/aomp-issue376/aomp-issue376.cpp
@@ -34,6 +34,9 @@ int main()
       }
   }
 
+  if (!DeviceMapPtr)
+    return 0;
+
   for (auto Dev : *DeviceMapPtr)
     flush_trace(Dev);
 
@@ -42,8 +45,3 @@ int main()
 
 /// CHECK: Callback Target
 /// CHECK-SAME: device_num=0
-
-
-
-
-


### PR DESCRIPTION
When disabling OMPT support this test will crash with a segementation fault.
With this fix the test will still fail but no longer seg fault.