### PR TITLE
Test: vmulsum-hsa-stats, changed from rocprof to rocprofv3 because rocprof is deprecated.

### DIFF
--- a/test/smoke-dev/vmulsum-hsa-stats/Makefile
+++ b/test/smoke-dev/vmulsum-hsa-stats/Makefile
@@ -8,8 +8,7 @@ TESTSRC_ALL    = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG          ?= clang
 OMP_BIN        = $(AOMP)/bin/$(CLANG)
 CC             = $(OMP_BIN) $(VERBOSE)
-RUNPROF = $(AOMPHIP)/bin/rocprof
-RUNPROF_FLAGS = --hsa-trace
+RUNPROF = $(AOMPHIP)/bin/rocprofv3 --output-format csv --hsa-trace --stats -- 
 
 #-ccc-print-phases
 #"-\#\#\#"


### PR DESCRIPTION
The following work OK.
   make
   make run
   make check
   make clean
