### PR TITLE
Test: FNew-flang-tracekernel, changed rocprof to rocprofv3; rocprof is being deprecated.

### DIFF
--- a/test/smoke-fails/FNew-flang-tracekernel/Makefile
+++ b/test/smoke-fails/FNew-flang-tracekernel/Makefile
@@ -16,8 +16,7 @@ CC           = $(OMP_BIN) $(VERBOSE)
 
 LIBPATH = $(AOMPHIP)/lib:/opt/rocm/lib
 RUNENV += PATH=$(ROCM)/bin:$(PATH) LD_LIBRARY_PATH=$(LIBPATH):$(LD_LIBRARY_PATH) LIBOMPTARGET_KERNEL_TRACE=2
-RUNPROF = $(AOMPHIP)/bin/rocprof
-RUNPROF_FLAGS = --roctx-trace --sys-trace
+RUNPROF = $(AOMPHIP)/bin/rocprofv3 --output-format csv --marker-trace --runtime-trace --stats --
 
 UNSUPPORTED = ASAN_COMPILE
 


### PR DESCRIPTION
The make and make clean work OK.

Test has a syntax error, unable to check:
   make run
   make check
   
