### PR TITLE
[smoke-dev][omptest] Fix omptest-based tests

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -375,8 +375,12 @@ else
    RUNENV = env $(SET_DEVICE_DEBUG) $(TKILL) $(CBL_ENV)
 endif
 
-# Header include path + linker flag for libomptest based OMPT tests
-OMPTEST = -I$(AOMP)/lib/omptest/include -lomptest
+# ompTest: Set header include path + linker flag for corresponding OMPT tests
+OMPTEST     = -I$(AOMP)/include/omptest/include -lomptest
+
+# ompTest: Set and export CMake config path
+omptest_DIR = $(AOMP)/lib/cmake/openmp/omptest/
+export omptest_DIR
 
 # Individual tests need to set OVERFLOW_GUARD=1 to enable available memory
 # computation at the runtime and passing it to the test as the first argument.

--- a/test/smoke-dev/omptest-device-emi/CMakeLists.txt
+++ b/test/smoke-dev/omptest-device-emi/CMakeLists.txt
@@ -18,15 +18,6 @@ message(STATUS "AOMP directory: '${AOMP_DIR}'")
 # Retrieve package information from omptest
 find_package(omptest REQUIRED)
 
-# Use default compiler values of omptest.
-set(CMAKE_C_COMPILER   ${omptest_C_COMPILER})
-set(CMAKE_CXX_COMPILER ${omptest_CXX_COMPILER})
-message(STATUS "  CMAKE_C_COMPILER: '${CMAKE_C_COMPILER}'")
-message(STATUS "CMAKE_CXX_COMPILER: '${CMAKE_CXX_COMPILER}'")
-
-# Make sure to include and esp. link directories before 'add_executable'
-include_directories(${omptest_INCLUDE_DIR})
-link_directories(${omptest_LIBRARY_ROOT})
 add_executable(${PROJECT_NAME}
                ${PROJECT_NAME}.cpp)
 
@@ -37,7 +28,8 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # Link
 # Note: omp[target] will be linked automatically because of the offload options
-target_link_libraries(${PROJECT_NAME} PRIVATE ${OFFLOAD_OPTIONS} omptest)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+                      ${OFFLOAD_OPTIONS} omptest::omptest)
 
-# Notify: this test does not use GoogleTest
-message(STATUS "GoogleTest: OFF")
+# Notify: Test either uses GoogleTest-based ompTest or 'standalone'
+message(STATUS "Standalone: ${LIBOMPTEST_BUILD_STANDALONE}")

--- a/test/smoke-dev/omptest-device-emi/omptest-device-emi.cpp
+++ b/test/smoke-dev/omptest-device-emi/omptest-device-emi.cpp
@@ -11,6 +11,32 @@ using namespace internal;
 int c[X];
 #pragma omp end declare target
 
+TEST(InitFiniSuite, DeviceLoad) {
+  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRecordDeallocation);
+
+  int N = 128;
+  int a[N];
+
+  for (int DeviceNum = 0; DeviceNum < omp_get_num_devices(); ++DeviceNum) {
+    // Even on multi-GPU systems, only default-device is immediately initialized
+    OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/DeviceNum);
+
+#pragma omp target parallel for device(DeviceNum)
+    {
+      for (int j = 0; j < N; j++)
+        a[j] = 0;
+    }
+
+    OMPT_ASSERT_SYNC_POINT("After DeviceLoad " + std::to_string(DeviceNum));
+  }
+}
+
 TEST(VeccopyCallbacks, OnDevice_Sequenced) {
   OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
   OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
@@ -966,34 +992,4 @@ TEST(VeccopyTraces, OnDeviceCallbacks_teams_distribute_parallel_for_nowait_w_tim
   }
 }
 
-// FIXME: Leave this suite here, so it gets discovered last and executed first.
-TEST(InitFiniSuite, DeviceLoad) {
-  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRecordDeallocation);
-
-  int N = 128;
-  int a[N];
-
-  for (int DeviceNum = 0; DeviceNum < omp_get_num_devices(); ++DeviceNum) {
-    // Even on multi-GPU systems, only default-device is immediately initialized
-    OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/DeviceNum);
-
-#pragma omp target parallel for device(DeviceNum)
-    {
-      for (int j = 0; j < N; j++)
-        a[j] = 0;
-    }
-
-    OMPT_ASSERT_SYNC_POINT("After DeviceLoad " + std::to_string(DeviceNum));
-  }
-}
-
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-dev/omptest-device-non-emi/CMakeLists.txt
+++ b/test/smoke-dev/omptest-device-non-emi/CMakeLists.txt
@@ -18,15 +18,6 @@ message(STATUS "AOMP directory: '${AOMP_DIR}'")
 # Retrieve package information from omptest
 find_package(omptest REQUIRED)
 
-# Use default compiler values of omptest.
-set(CMAKE_C_COMPILER   ${omptest_C_COMPILER})
-set(CMAKE_CXX_COMPILER ${omptest_CXX_COMPILER})
-message(STATUS "  CMAKE_C_COMPILER: '${CMAKE_C_COMPILER}'")
-message(STATUS "CMAKE_CXX_COMPILER: '${CMAKE_CXX_COMPILER}'")
-
-# Make sure to include and esp. link directories before 'add_executable'
-include_directories(${omptest_INCLUDE_DIR})
-link_directories(${omptest_LIBRARY_ROOT})
 add_executable(${PROJECT_NAME}
                ${PROJECT_NAME}.cpp)
 
@@ -37,7 +28,8 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # Link
 # Note: omp[target] will be linked automatically because of the offload options
-target_link_libraries(${PROJECT_NAME} PRIVATE ${OFFLOAD_OPTIONS} omptest)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+                      ${OFFLOAD_OPTIONS} omptest::omptest)
 
-# Notify: this test does not use GoogleTest
-message(STATUS "GoogleTest: OFF")
+# Notify: Test either uses GoogleTest-based ompTest or 'standalone'
+message(STATUS "Standalone: ${LIBOMPTEST_BUILD_STANDALONE}")

--- a/test/smoke-dev/omptest-device-non-emi/omptest-device-non-emi.cpp
+++ b/test/smoke-dev/omptest-device-non-emi/omptest-device-non-emi.cpp
@@ -11,6 +11,32 @@ using namespace internal;
 int c[X];
 #pragma omp end declare target
 
+TEST(InitFiniSuite, DeviceLoad) {
+  OMPT_SUPPRESS_EVENT(EventTy::Target)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
+  OMPT_SUPPRESS_EVENT(EventTy::BufferRecordDeallocation);
+
+  int N = 128;
+  int a[N];
+
+  for (int DeviceNum = 0; DeviceNum < omp_get_num_devices(); ++DeviceNum) {
+    // Even on multi-GPU systems, only default-device is immediately initialized
+    OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/DeviceNum);
+
+#pragma omp target parallel for device(DeviceNum)
+    {
+      for (int j = 0; j < N; j++)
+        a[j] = 0;
+    }
+
+    OMPT_ASSERT_SYNC_POINT("After DeviceLoad " + std::to_string(DeviceNum));
+  }
+}
+
 TEST(VeccopyCallbacks, OnDeviceDefaultTeams_Sequenced) {
   OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
   OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
@@ -582,7 +608,7 @@ TEST(DataOpTests, ExplicitAllocationTimeNonZero) {
   OMPT_ASSERT_SYNC_POINT("After de-alloc");
 }
 
-TEST(DataOpTests, ExplicitDeallocationTimeNonZero) {
+TEST(DataOpTestsPass, ExplicitDeallocationTimeNonZero) {
   OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
   OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
   OMPT_SUPPRESS_EVENT(EventTy::BufferRecordDeallocation);
@@ -603,7 +629,7 @@ TEST(DataOpTests, ExplicitDeallocationTimeNonZero) {
   OMPT_ASSERT_SYNC_POINT("After de-alloc");
 }
 
-TEST_XFAIL(DataOpTests, ExplicitAllocatorMultiDevice) {
+TEST_XFAIL(DataOpTestsFail, ExplicitAllocatorMultiDevice) {
   OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
   OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
   OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
@@ -955,34 +981,4 @@ TEST(VeccopyTraces, OnDeviceCallbacks_teams_distribute_parallel_for_nowait_w_tim
   }
 }
 
-// FIXME: Leave this suite here, so it gets discovered last and executed first.
-TEST(InitFiniSuite, DeviceLoad) {
-  OMPT_SUPPRESS_EVENT(EventTy::Target)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRequest);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferComplete);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRecord);
-  OMPT_SUPPRESS_EVENT(EventTy::BufferRecordDeallocation);
-
-  int N = 128;
-  int a[N];
-
-  for (int DeviceNum = 0; DeviceNum < omp_get_num_devices(); ++DeviceNum) {
-    // Even on multi-GPU systems, only default-device is immediately initialized
-    OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/DeviceNum);
-
-#pragma omp target parallel for device(DeviceNum)
-    {
-      for (int j = 0; j < N; j++)
-        a[j] = 0;
-    }
-
-    OMPT_ASSERT_SYNC_POINT("After DeviceLoad " + std::to_string(DeviceNum));
-  }
-}
-
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-dev/veccopy-ompt-target-cmake/CMakeLists.txt
+++ b/test/smoke-dev/veccopy-ompt-target-cmake/CMakeLists.txt
@@ -18,15 +18,6 @@ message(STATUS "AOMP directory: '${AOMP_DIR}'")
 # Retrieve package information from omptest
 find_package(omptest REQUIRED)
 
-# Use default compiler values of omptest.
-set(CMAKE_C_COMPILER   ${omptest_C_COMPILER})
-set(CMAKE_CXX_COMPILER ${omptest_CXX_COMPILER})
-message(STATUS "  CMAKE_C_COMPILER: '${CMAKE_C_COMPILER}'")
-message(STATUS "CMAKE_CXX_COMPILER: '${CMAKE_CXX_COMPILER}'")
-
-# Make sure to include and esp. link directories before 'add_executable'
-include_directories(${omptest_INCLUDE_DIR})
-link_directories(${omptest_LIBRARY_ROOT})
 add_executable(${PROJECT_NAME}
                ${PROJECT_NAME}.cpp)
 
@@ -37,7 +28,8 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 # Link
 # Note: omp[target] will be linked automatically because of the offload options
-target_link_libraries(${PROJECT_NAME} PRIVATE ${OFFLOAD_OPTIONS} omptest)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+                      ${OFFLOAD_OPTIONS} omptest::omptest)
 
-# Notify: this test does not use GoogleTest
-message(STATUS "GoogleTest: OFF")
+# Notify: Test either uses GoogleTest-based ompTest or 'standalone'
+message(STATUS "Standalone: ${LIBOMPTEST_BUILD_STANDALONE}")

--- a/test/smoke-dev/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
+++ b/test/smoke-dev/veccopy-ompt-target-cmake/veccopy-ompt-target-cmake.cpp
@@ -5,6 +5,24 @@
 using namespace omptest;
 using namespace internal;
 
+TEST(InitialTestSuite, uut_device_init_load) {
+  /* The Test Body */
+  OMPT_SUPPRESS_EVENT(EventTy::Target)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
+
+  int N = 128;
+  int a[N];
+
+  OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
 TEST_XFAIL(SequenceSuiteXFail, uut_target_xfail_wrong_order) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
@@ -216,28 +234,4 @@ TEST(SequenceSuite, veccopy_ompt_target) {
     printf("Success\n");
 }
 
-// FIXME: Leave this suite here, so it gets discovered last and executed first.
-TEST(InitialTestSuite, uut_device_init_load) {
-  /* The Test Body */
-  OMPT_SUPPRESS_EVENT(EventTy::Target)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
-
-  int N = 128;
-  int a[N];
-
-  OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
-
-#pragma omp target parallel for
-  {
-    for (int j = 0; j < N; j++)
-      a[j] = 0;
-  }
-}
-
-int main(int argc, char **argv) {
-  Runner R;
-  R.run();
-
-  return 0;
-}
+OMPTEST_TESTSUITE_MAIN()


### PR DESCRIPTION
Fix omptest-based + CMake tests
 - export of omptest_DIR fixes find_package(omptest)

Enhance build steps (header inclusion and linking) due to omptest improvements.

Test names:
 * omptest-device-emi
 * omptest-device-non-emi
 * veccopy-ompt-target-cmake

## Motivation

Changed CMake configuration requires changes and allows for easier build of certain test setups.

## Technical Details

omptest CMake configuration has a different location now.
This needs to be accommodated, e.g. by exporting `omptest_DIR`.

Also, an easier, more robust usage of omptest is now possible due to CMake package config:
`target_link_libraries(${PROJECT_NAME} PRIVATE ${OFFLOAD_OPTIONS} omptest::omptest)`
Which not only links the shared library but also takes care of include and link directory propagation.

## Test Plan

smoke-dev was checked and the three (previous) fails were tested individually.

## Test Result

`omptest-device-emi`, `omptest-device-non-emi` and `veccopy-ompt-target-cmake` now pass.