### PR TITLE
Changed rocprof to rocprofv3 because rocprof is being deprecated.

### DIFF
--- a/test/smoke-fort-dev/hipfort/f2003/roctx/Makefile
+++ b/test/smoke-fort-dev/hipfort/f2003/roctx/Makefile
@@ -6,7 +6,7 @@ main: main.f03 hip_implementation.cpp
 	hipfc $(CFLAGS) main.f03 hip_implementation.cpp -o main -lroctx64
 
 run: main
-	rocprof -d rocprof_out -o rocprof_out/results.csv --hip-trace --roctx-trace ./main
+	$(AOMPHIP)/bin/rocprofv3 --output-format csv --marker-trace --runtime-trace --stats -- ./main
 
 clean:
-	rm -rf main *.o *.mod rocprof_out
+	rm -rf main *.o *.mod rocprof_out `hostname`


### PR DESCRIPTION
More changes to replace rocprof with rocprofv3.
