### PR TITLE
[OpenMP][omptest] Adapt smoke-fails to omptest OpenMP move

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -376,7 +376,7 @@ else
 endif
 
 # ompTest: Set header include path + linker flag for corresponding OMPT tests
-OMPTEST     = -I$(AOMP)/include/omptest/include -lomptest
+OMPTEST     = -I$(AOMP)/include/omptest -lomptest
 
 # ompTest: Set and export CMake config path
 omptest_DIR = $(AOMP)/lib/cmake/openmp/omptest/

--- a/test/smoke-fails/omptest-testsuite-emi-tracing/omptest_testsuite_emi_tracing.cpp
+++ b/test/smoke-fails/omptest-testsuite-emi-tracing/omptest_testsuite_emi_tracing.cpp
@@ -15,6 +15,20 @@ ompt_set_result_t libomptarget_ompt_set_trace_ompt(int DeviceId,
 using namespace omptest;
 using namespace internal;
 
+// Place this suite at the top, so it gets discovered and executed first.
+TEST(InitialTestSuite, uut_device_init_load_multi_gpu) {
+  // We only want to assert on DeviceLoads: ignore other events
+  OMPT_ASSERT_SET_MODE_RELAXED()
+
+  for (int i = 0; i < omp_get_num_devices(); ++i) {
+    OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/i)
+#pragma omp target device(i)
+    {
+      ;
+    }
+  }
+}
+
 TEST(MultiGPUTracingSuite, uut_device_set_trace_disabled) {
   int N = 128;
   int a[N];
@@ -251,9 +265,9 @@ TEST(MultiGPUTracingSuite, uut_device_set_trace_target_submit) {
   }
 }
 
-TEST(DisabledSuite, DISABLED_uut_target_disabled) {
-  assert(false && "This test should have been disabled");
-}
+// TEST(DisabledSuite, DISABLED_uut_target_disabled) {
+//   assert(false && "This test should have been disabled");
+// }
 
 TEST(SequenceAssertion, uut_target_sequence) {
   int N = 128;
@@ -532,23 +546,4 @@ TEST(MixedAssertionSuite, uut_target_sequence_and_set) {
     printf("Success\n");
 }
 
-// Leave this suite down here so it gets discovered last and executed first.
-TEST(InitialTestSuite, uut_device_init_load_multi_gpu) {
-  // We only want to assert on DeviceLoads: ignore other events
-  OMPT_ASSERT_SET_MODE_RELAXED()
-
-  for (int i = 0; i < omp_get_num_devices(); ++i) {
-    OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/i)
-#pragma omp target device(i)
-    {
-      ;
-    }
-  }
-}
-
-#ifndef LIBOFFLOAD_LIBOMPTEST_USE_GOOGLETEST
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
-#endif
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
+++ b/test/smoke-fails/omptest-testsuite-emi/omptest_testsuite_emi.cpp
@@ -5,6 +5,25 @@
 using namespace omptest;
 using namespace internal;
 
+// Place this suite at the top, so it gets discovered and executed first.
+TEST(InitialTestSuite, uut_device_init_load) {
+  /* The Test Body */
+  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
+
+  int N = 128;
+  int a[N];
+
+  OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/0)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
 TEST(SequenceSuite, uut_target) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
@@ -111,7 +130,7 @@ TEST(SetSuite, uut_target) {
   }
 }
 
-TEST_XFAIL(SetSuite, uut_target_xfail_banned_begin_end) {
+TEST_XFAIL(SetSuiteFail, uut_target_xfail_banned_begin_end) {
   /* The Test Body */
   int N = 128;
   int a[N];
@@ -382,26 +401,4 @@ TEST(SequenceSuite, veccopy_ompt_target) {
     printf("Success\n");
 }
 
-// Leave this suite down here so it gets discovered last and executed first.
-TEST(InitialTestSuite, uut_device_init_load) {
-  /* The Test Body */
-  OMPT_SUPPRESS_EVENT(EventTy::TargetEmi)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOpEmi)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmitEmi)
-
-  int N = 128;
-  int a[N];
-
-  OMPT_ASSERT_SET(DeviceLoad, /*DeviceNum=*/0)
-
-#pragma omp target parallel for
-  {
-    for (int j = 0; j < N; j++)
-      a[j] = 0;
-  }
-}
-
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
+++ b/test/smoke-fails/omptest-testsuite/omptest_testsuite.cpp
@@ -5,7 +5,26 @@
 using namespace omptest;
 using namespace internal;
 
-TEST_XFAIL(SequenceSuite, uut_target_xfail_wrong_order) {
+// Place this suite at the top, so it gets discovered and executed first.
+TEST(InitialTestSuite, uut_device_init_load) {
+  /* The Test Body */
+  OMPT_SUPPRESS_EVENT(EventTy::Target)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
+  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
+
+  int N = 128;
+  int a[N];
+
+  OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
+
+#pragma omp target parallel for
+  {
+    for (int j = 0; j < N; j++)
+      a[j] = 0;
+  }
+}
+
+TEST_XFAIL(SequenceSuiteFail, uut_target_xfail_wrong_order) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -26,7 +45,7 @@ TEST_XFAIL(SequenceSuite, uut_target_xfail_wrong_order) {
   }
 }
 
-TEST_XFAIL(SequenceSuite, uut_target_xfail_banned_begin_end) {
+TEST_XFAIL(SequenceSuiteFail, uut_target_xfail_banned_begin_end) {
   /* The Test Body */
   OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
   OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
@@ -216,26 +235,4 @@ TEST(SequenceSuite, veccopy_ompt_target) {
     printf("Success\n");
 }
 
-// Leave this suite down here so it gets discovered last and executed first.
-TEST(InitialTestSuite, uut_device_init_load) {
-  /* The Test Body */
-  OMPT_SUPPRESS_EVENT(EventTy::Target)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetDataOp)
-  OMPT_SUPPRESS_EVENT(EventTy::TargetSubmit)
-
-  int N = 128;
-  int a[N];
-
-  OMPT_ASSERT_SEQUENCE(DeviceLoad, /*DeviceNum=*/0)
-
-#pragma omp target parallel for
-  {
-    for (int j = 0; j < N; j++)
-      a[j] = 0;
-  }
-}
-
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-fails/omptest-unittest/omptest.cpp
+++ b/test/smoke-fails/omptest-unittest/omptest.cpp
@@ -6,13 +6,13 @@ TEST(ManualSuite, ParallelFor) {
   /* The Test Body */
   int arr[10] = {0};
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
-      "User Parallel Begin", "Group", omptest::ObserveState::always,
+      "User Parallel Begin", "Group", omptest::ObserveState::Always,
       /*NumThreads=*/2));
   SequenceAsserter->insert(omptest::OmptAssertEvent::ThreadBegin(
-      "User Thread Begin", "Group", omptest::ObserveState::always,
+      "User Thread Begin", "Group", omptest::ObserveState::Always,
       ompt_thread_initial));
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
-      "User Parallel End", "Group", omptest::ObserveState::always));
+      "User Parallel End", "Group", omptest::ObserveState::Always));
 
   SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelBegin);
   SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelEnd);
@@ -33,18 +33,18 @@ TEST(ManualSuite, ParallelForActivation) {
   /* The Test Body */
   int arr[10] = {0};
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
-      "User Parallel Begin", "Group", omptest::ObserveState::always,
+      "User Parallel Begin", "Group", omptest::ObserveState::Always,
       /*NumThreads=*/2));
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
-      "User Parallel End", "Group", omptest::ObserveState::always));
+      "User Parallel End", "Group", omptest::ObserveState::Always));
 
   // The last sequence we want to observe does not contain
   // another thread begin.
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelBegin(
-      "User Parallel Begin", "Group", omptest::ObserveState::always,
+      "User Parallel Begin", "Group", omptest::ObserveState::Always,
       /*NumThreads=*/2));
   SequenceAsserter->insert(omptest::OmptAssertEvent::ParallelEnd(
-      "User Parallel End", "Group", omptest::ObserveState::always));
+      "User Parallel End", "Group", omptest::ObserveState::Always));
 
   SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelBegin);
   SequenceAsserter->permitEvent(omptest::internal::EventTy::ParallelEnd);
@@ -174,7 +174,4 @@ TEST(ManualSuite, veccopy_ompt_target) {
   OMPT_ASSERT_SEQUENCE_ENABLE();
 }
 
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()

--- a/test/smoke-fails/veccopy-ompTest/veccopy.cpp
+++ b/test/smoke-fails/veccopy-ompTest/veccopy.cpp
@@ -17,45 +17,45 @@ TEST(InitialSuite, veccopy) {
     b[i]=i;
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::DeviceLoad(
-      "User DeviceLoad", "Group", omptest::ObserveState::always,
+      "User DeviceLoad", "Group", omptest::ObserveState::Always,
       /*DeviceNum=*/0));
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::Target(
-      "User Target", "Group", omptest::ObserveState::always, /*Kind=*/TARGET,
+      "User Target", "Group", omptest::ObserveState::Always, /*Kind=*/TARGET,
       /*Endpoint=*/BEGIN));
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/ALLOC, /*Bytes=*/sizeof(a)));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/H2D, /*Bytes=*/sizeof(a)));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/ALLOC, /*Bytes=*/sizeof(a)));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/H2D, /*Bytes=*/sizeof(a)));
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetSubmit(
-      "User Target Submit", "Group", omptest::ObserveState::always,
+      "User Target Submit", "Group", omptest::ObserveState::Always,
       /*RequestedNumTeams=*/1));
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/D2H, /*Bytes=*/sizeof(a)));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/D2H, /*Bytes=*/sizeof(a)));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/DELETE));
   SequenceAsserter->insert(omptest::OmptAssertEvent::TargetDataOp(
-      "User Target DataOp", "Group", omptest::ObserveState::always,
+      "User Target DataOp", "Group", omptest::ObserveState::Always,
       /*OpType=*/DELETE));
 
   SequenceAsserter->insert(omptest::OmptAssertEvent::Target(
-      "User Target", "Group", omptest::ObserveState::always, /*Kind=*/TARGET,
+      "User Target", "Group", omptest::ObserveState::Always, /*Kind=*/TARGET,
       /*Endpoint=*/END));
 
 #pragma omp target parallel for
@@ -75,7 +75,4 @@ TEST(InitialSuite, veccopy) {
     printf("Success\n");
 }
 
-int main(int argc, char **argv) {
-  Runner R;
-  return R.run();
-}
+OMPTEST_TESTSUITE_MAIN()


### PR DESCRIPTION
## Motivation

Changed upstream structure and behavior of `omptest` required changes in our tests.

## Technical Details

Replaced main() with corresponding macro
Reordered test cases since GoogleTest executes in-order
Remove disabled test as this causes a "fail"
Split certain suites into "Suite" and "SuiteFail"
 - Reason: TEST and TEST_XFAIL represent different fixture classes
    But only one fixture class per suite is allowed

## Test Plan

Checked individual tests and performed a full run of the check script.

## Test Result

Tests failing due to the OpenMP move of omptest were fixed by these changes.
Tests that *should* now pass:
 * omptest-testsuite
 * omptest-testsuite-emi
 * omptest-testsuite-emi-tracing
 * omptest-unittest
 * veccopy-ompTest