### PR TITLE
[Flang][Test] Add new test-case to use_dev_addr_fort.f90

### DIFF
--- a/test/smoke-fort-dev/flang-325095-2/use_dev_addr_fort.f90
+++ b/test/smoke-fort-dev/flang-325095-2/use_dev_addr_fort.f90
@@ -6,6 +6,15 @@ program omp_subroutine
     allocate(c(N))
     c = -42.0
 
+    call test0(c)
+    if (c(3) .ne. 1.0) then
+       write (*,*) "FAIL : test0:", c
+       stop 2
+    endif
+
+    print *, c
+    c(3) = -42.0
+
     ! Expected output c(3) = 1
     call test1(c)
     if (c(3) .ne. 1.0) then
@@ -46,6 +55,13 @@ program omp_subroutine
     print *, "PASS"
     return
 contains
+    subroutine test0(c)
+        double precision, intent(inout) :: c(:)
+        !$omp target data use_device_ptr(c) map(tofrom: c)
+            c(3) = 1.0
+        !$omp end target data
+    end subroutine
+
     subroutine test1(c)
         double precision, intent(inout) :: c(:)
         !$omp target enter data map(to:c)
@@ -69,7 +85,7 @@ contains
        !$omp target data use_device_ptr(c)
             c(3) = 1.0
        !$omp end target data
-        !$omp target update from(c)
+       !$omp target update from(c)
         write (*,*) "test3:", c
     end subroutine
 


### PR DESCRIPTION
Adding a new test case I found doesn't work in amd-staging at the moment, but should soon when I land a new PR. But effectively we crash when we have a map and use_device_addr/ptr to the same list item on a target at the moment. New patch should allow this.