### PR TITLE
[Fix] Have RUNENV as env not as executable in valgrind

### DIFF
--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -104,7 +104,7 @@ og11run: $(TESTNAME)_og11
 gpurun: $(TESTNAME)
 	$(AOMP)/bin/gpurun $(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
 valgrind: $(TESTNAME)
-	valgrind $(RUNENV) $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
+	$(RUNENV) valgrind $(RUNPROF) ./$(TESTNAME) 2>&1 | tee $@.log
 
 # Just verify output
 verify: run


### PR DESCRIPTION
With the previous location valgrind would complain that it cannot find the executable.
