### PR TITLE
[Bbots] Add libc build dependency

### DIFF
--- a/upstream-buildbots/Ubu22/prerequisites
+++ b/upstream-buildbots/Ubu22/prerequisites
@@ -12,6 +12,7 @@ python3
 python3-dev
 python3-pip
 python3-setuptools
+python3-pyyaml-env-tag
 vim
 wget
 sudo


### PR DESCRIPTION
Libc headergen requires pyyaml to be available.
