### PR TITLE
[tr_aomp] Change default repo & install from tr_aomp to tr-aomp

### DIFF
--- a/tr_aomp/README
+++ b/tr_aomp/README
@@ -39,7 +39,7 @@ ln -sf $TR_AOMP_REPOS/TheRock/build/compiler/amd-llvm/build $TR_AOMP_REPOS/llvm-
 
 Compiler development flow: edit, build, install, test
 EDIT
-  - cd git/tr_aomp/llvm-project ; edit files in the llvm source tree
+  - cd git/tr-aomp/llvm-project ; edit files in the llvm source tree
 
 UPDATE BUILD
   - cd $TR_AOMP_REPOS/llvm-project/build

--- a/tr_aomp/tr_aomp_common_vars
+++ b/tr_aomp/tr_aomp_common_vars
@@ -17,11 +17,11 @@ AOMP_MAJOR_VERSION=${AOMP_VERSION%.*}
 # tr_build_aomp.sh will copy TheRock/build/dist/rocm to $AOMP_INSTALL_DIR
 # and create a link from aomp to $AOMP_INSTALL_DIR.
 # AOMP will be a symbolic link AOMP_INSTALL_DIR is the versioned dir name
-AOMP=${TR_AOMP:-$HOME/rocm/tr_aomp}
+AOMP=${TR_AOMP:-$HOME/rocm/tr-aomp}
 AOMP_INSTALL_DIR=${AOMP}_${AOMP_VERSION_STRING}
 
 # TR_AOMP_REPOS is the parent directory for TheRock and aomp repos.  
-TR_AOMP_REPOS=${TR_AOMP_REPOS:-/work/$USER/git/tr_aomp}
+TR_AOMP_REPOS=${TR_AOMP_REPOS:-/work/$USER/git/tr-aomp}
 if [ ! -d $TR_AOMP_REPOS ] ; then
   mkdir -p $TR_AOMP_REPOS
   [ $? != 0 ] && echo "ERROR: could not create $TR_AOMP_REPOS" && exit 1


### PR DESCRIPTION
   - underscore is otherwise used as the separator between the name and the version (e.g. tr-aomp_22.0-5)