### PR TITLE
[BBots] Add missing deps for offload unit tests

### DIFF
--- a/upstream-buildbots/Ubu22/prerequisites
+++ b/upstream-buildbots/Ubu22/prerequisites
@@ -5,12 +5,15 @@ ninja-build
 g++
 gcc
 git
+libc6-dev
+libc6-dev-i386
 libffi-dev
 libgtest-dev
 libpython3.10-dev
 python3
 python3-dev
 python3-pip
+python3-psutil
 python3-setuptools
 vim
 wget


### PR DESCRIPTION
It seems that the offload unit tests did complain about some headers missing when running on the bare ubuntu image.
This adds the missing deps.