### PR TITLE
[AOMP] Use local aqlprofile for rocprofiler-sdk build

### DIFF
--- a/bin/build_rocprofiler-sdk.sh
+++ b/bin/build_rocprofiler-sdk.sh
@@ -63,7 +63,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
    declare -a MYCMAKEOPTS
 
-   MYCMAKEOPTS=(-DCMAKE_PREFIX_PATH="$AOMP_INSTALL_DIR"
+   MYCMAKEOPTS=(-DCMAKE_PREFIX_PATH="$HOME/local/aqlprofile;$AOMP_INSTALL_DIR"
                 -DCMAKE_INSTALL_PREFIX="$INSTALL_ROCPROF_SDK"
 	        -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 	        -DROCM_ROOT_DIR="$AOMP_INSTALL_DIR"


### PR DESCRIPTION
I found that I needed this for the local (`$HOME/local/aqlprofile`) version to be located during `rocprofiler-sdk` compilation instead of (presumably) the system version in `/opt/rocm`.