### PR TITLE
[tr_aomp] Generate .amd-llvm.smrev with latest llvm-project SHA

### DIFF
--- a/tr_aomp/tr_build_aomp.sh
+++ b/tr_aomp/tr_build_aomp.sh
@@ -26,9 +26,8 @@ fi
 # reconstruct .amd-llvm.smrev using the current SHA
 cd compiler/amd-llvm
 smrev="../.amd-llvm.smrev"
-head -1 $smrev     >  "${smrev}.new"
-git rev-parse HEAD >> "${smrev}.new"
-cp "${smrev}.new" $smrev
+git config --get remote.origin.url > "$smrev"
+git rev-parse HEAD >> "$smrev"
 )
 
 [ -d build ] && rm -rf build


### PR DESCRIPTION
Updated version of https://github.com/ROCm/aomp/pull/1560
In case someone does a reset/clean, don't rely on an existing .amd-llvm.smrev being present