### PR TITLE
Added test for occupancy-based num_teams for generic spmd kernels.

### DIFF
--- a/test/smoke-dev/occupancy-based-opt-big-jump-loop/occupancy_based_opt_big_jump_loop.c
+++ b/test/smoke-dev/occupancy-based-opt-big-jump-loop/occupancy_based_opt_big_jump_loop.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 
 int main() {
-  int N = 10;
+  int N = 1000000;
 
   int a[N];
   int b[N];

--- a/test/smoke-dev/occupancy-based-opt-generic-spmd/Makefile
+++ b/test/smoke-dev/occupancy-based-opt-generic-spmd/Makefile
@@ -1,0 +1,18 @@
+include ../../Makefile.defs
+
+TESTNAME     = occupancy_based_opt_generic_spmd
+TESTSRC_MAIN = occupancy_based_opt_generic_spmd.c
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RUNENV      += LIBOMPTARGET_KERNEL_TRACE=1
+RUNENV 	    += OMPX_GENERIC_SPMD_OCCUPANCY_BASED_OPT=1
+
+RUNCMD      = ./$(TESTNAME) 2>&1 | $(FILECHECK) $(TESTSRC_MAIN)
+
+CLANG        ?= clang
+OMP_BIN      = $(AOMP)/bin/$(CLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-dev/occupancy-based-opt-generic-spmd/occupancy_based_opt_generic_spmd.c
+++ b/test/smoke-dev/occupancy-based-opt-generic-spmd/occupancy_based_opt_generic_spmd.c
@@ -1,0 +1,30 @@
+// Copyright © Advanced Micro Devices, Inc., or its affiliates.
+//
+// SPDX-License-Identifier:  MIT
+
+#define N 1048576
+#define NUM_THREADS 256
+#define NUM_DISTR (N / NUM_THREADS)
+
+#include <stdio.h>
+
+int main() {
+  int a[N];
+  int i, j;
+
+#pragma omp target teams distribute
+  for (i = 0; i < NUM_DISTR; i++)
+#pragma omp parallel for
+    for (j = 0; j < NUM_THREADS; j++)
+      a[i * NUM_THREADS + j] = (i * NUM_THREADS + j);
+
+  for (i = 0; i < N; i++)
+    if (a[i] != i) {
+      printf("wrong value: a[%d]=%d\n", i, a[i]);
+      return 1;
+    }
+  printf("Success\n");
+  return 0;
+}
+
+/// CHECK: Achieved Occupancy: 100%

--- a/test/smoke-dev/occupancy-based-opt/occupancy_based_opt.c
+++ b/test/smoke-dev/occupancy-based-opt/occupancy_based_opt.c
@@ -7,7 +7,7 @@
 
 int main()
 {
-  int N = 10;
+  int N = 1000000;
 
   int a[N];
   int b[N];


### PR DESCRIPTION
Modified existing tests based on occupancy.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
