### PR TITLE
[build] - Updates for using ROCm 7.0 sources

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -241,10 +241,10 @@ function getrocmpackage(){
   _packagename="$2"
   _componentversion="$3"
   _directory=$(echo "$2" | cut -b 1)
-  _version=6.4.2
-  _packageversion=6.4.2
-  _fullversion=60402
-  _buildnumber=120
+  _version=7.0
+  _packageversion=7.0.0
+  _fullversion=70000
+  _buildnumber=38
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname
@@ -448,7 +448,7 @@ function buildcmake(){
 
 function buildrocmsmilib(){
   _cname="rocmsmilib"
-  _version=6.4.x
+  _version=7.0.x
   _installdir=$AOMP_SUPP_INSTALL/rocmsmilib-$_version
   _linkfrom=$AOMP_SUPP/rocmsmilib
   _builddir=$AOMP_SUPP_BUILD/rocmsmilib
@@ -463,7 +463,7 @@ function buildrocmsmilib(){
   fi
   runcmd "mkdir -p $_builddir"
   runcmd "cd $_builddir"
-  runcmd "git clone -b release/rocm-rel-6.4 https://github.com/ROCm/rocm_smi_lib rocmsmilib-$_version"
+  runcmd "git clone -b release/rocm-rel-7.0 https://github.com/ROCm/rocm_smi_lib rocmsmilib-$_version"
   runcmd "cd rocmsmilib-$_version"
   runcmd "mkdir -p build"
   runcmd "cd build"
@@ -575,7 +575,7 @@ for _component in $_components ; do
   elif [ "$_component" == "openclicdloader" ] ; then
     getrocmpackage openclicdloader rocm-opencl-icd-loader 1.2
   elif [ "$_component" == "rocm-core" ] ; then
-    getrocmpackage rocm-core rocm-core 6.4.2
+    getrocmpackage rocm-core rocm-core 7.0.0
   else
     echo "ERROR:  Invalid component name $_component" >>"$CMDLOGFILE"
     echo "ERROR:  Invalid component name $_component"

--- a/bin/patches/clr-findamd-icd.patch
+++ b/bin/patches/clr-findamd-icd.patch
@@ -24,18 +24,3 @@ index 0af9f1eab..b2bcb7904 100644
  
  INSTALL(TARGETS clinfo
    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-diff --git a/hipamd/CMakeLists.txt b/hipamd/CMakeLists.txt
-index 98f37b9d1..0546d7783 100755
---- a/hipamd/CMakeLists.txt
-+++ b/hipamd/CMakeLists.txt
-@@ -415,8 +415,8 @@ if (NOT ${HIPCC_BIN_DIR} STREQUAL "")
-   if(EXISTS ${HIPCC_BIN_DIR})
-     install(PROGRAMS ${HIPCC_BIN_DIR}/${HIPCC_EXECUTABLE} DESTINATION bin)
-     install(PROGRAMS ${HIPCC_BIN_DIR}/${HIPCONFIG_EXECUTABLE} DESTINATION bin)
--    install(PROGRAMS ${HIPCC_BIN_DIR}/hipcc.pl DESTINATION bin)
--    install(PROGRAMS ${HIPCC_BIN_DIR}/hipconfig.pl DESTINATION bin)
-+#    install(PROGRAMS ${HIPCC_BIN_DIR}/hipcc.pl DESTINATION bin)
-+#    install(PROGRAMS ${HIPCC_BIN_DIR}/hipconfig.pl DESTINATION bin)
-     install(PROGRAMS ${HIPCC_BIN_DIR}/hipvars.pm DESTINATION bin)
- 
-     if(NOT UNIX)

--- a/bin/patches/patch-control-file_22.0.txt
+++ b/bin/patches/patch-control-file_22.0.txt
@@ -5,7 +5,7 @@ GenASis: genasis.patch
 GenASiS_Basics: genasis_basics.patch
 hipamd: hipamd-rpath.patch
 bolt: bolt.patch
-rocr-runtime: rocr-runtime-combined-numa-remove-gfx940-gfx941.patch
+rocr-runtime: rocr-runtime-numa.patch
 clr: clr-findamd-icd.patch
 rocprofiler: rocprofiler-combined-no-aql-ok-fix-cov6.patch
 babelstream: babelstream-usm.patch

--- a/docs/SOURCEINSTALL.md
+++ b/docs/SOURCEINSTALL.md
@@ -82,15 +82,15 @@ The above command will produce output like this showing you the location and bra
        emu  amd-staging   SPIRV-LLVM-Translator  SPIRV-LLVM-Translator 0659e45216b2 2024-12-04            AlexVlx            AlexVlx
        roc     aomp-dev                flang                     flang 88b81b0a8ead 2023-11-30             GitHub    Emma Pilkington
        roc     aomp-dev                 aomp                      aomp df5b5d8ddffa 2023-12-05 Dhruva Chakrabarti Dhruva Chakrabarti
-       roc   release/rocm-rel-6.4 rocprofiler               rocprofiler 4e190a02e60e 2023-10-30             GitHub      Ammar ELWazir
-       roc   release/rocm-rel-6.4   roctracer                 roctracer 6fbf7673aa7f 2023-07-13 Ranjith Ramakrishnan Ranjith Ramakrishnan
-       roc   release/rocm-rel-6.4   ROCdbgapi                 ROCdbgapi df1a8df2be08 2023-07-28       Lancelot SIX       Lancelot SIX
-       roc   release/rocm-rel-6.4      ROCgdb                    ROCgdb 157eed788288 2023-07-28       Lancelot SIX       Lancelot SIX
-       roc   release/rocm-rel-6.4         hip                       hip 80681169ae20 2023-08-15        Julia Jiang        Julia Jiang
-       roc   release/rocm-rel-6.4         clr                       clr 1949b1621a80 2023-09-21        Julia Jiang        Julia Jiang
-       roc   release/rocm-rel-6.4    rocminfo                  rocminfo c8db38ede264 2023-06-02       Mark Searles       Mark Searles
-       roc   release/rocm-rel-6.4  rocm-cmake                rocm-cmake 15cbb2e47f0b 2023-07-11   Lauren Wrubleski   Lauren Wrubleski
-       roc   release/rocm-rel-6.4 rocr-runtime              ROCR-Runtime b2b6811571bf 2023-09-15      David Yat Sin      David Yat Sin
-       roc   release/rocm-rel-6.4      hipfort                   hipfort 41f33eeaa3f7 2023-09-07             Sam Wu    dependabot[bot]
+       roc   release/rocm-rel-7.0 rocprofiler               rocprofiler 4e190a02e60e 2023-10-30             GitHub      Ammar ELWazir
+       roc   release/rocm-rel-7.0   roctracer                 roctracer 6fbf7673aa7f 2023-07-13 Ranjith Ramakrishnan Ranjith Ramakrishnan
+       roc   release/rocm-rel-7.0   ROCdbgapi                 ROCdbgapi df1a8df2be08 2023-07-28       Lancelot SIX       Lancelot SIX
+       roc   release/rocm-rel-7.0      ROCgdb                    ROCgdb 157eed788288 2023-07-28       Lancelot SIX       Lancelot SIX
+       roc   release/rocm-rel-7.0         hip                       hip 80681169ae20 2023-08-15        Julia Jiang        Julia Jiang
+       roc   release/rocm-rel-7.0         clr                       clr 1949b1621a80 2023-09-21        Julia Jiang        Julia Jiang
+       roc   release/rocm-rel-7.0    rocminfo                  rocminfo c8db38ede264 2023-06-02       Mark Searles       Mark Searles
+       roc   release/rocm-rel-7.0  rocm-cmake                rocm-cmake 15cbb2e47f0b 2023-07-11   Lauren Wrubleski   Lauren Wrubleski
+       roc   release/rocm-rel-7.0 rocr-runtime              ROCR-Runtime b2b6811571bf 2023-09-15      David Yat Sin      David Yat Sin
+       roc   release/rocm-rel-7.0      hipfort                   hipfort 41f33eeaa3f7 2023-09-07             Sam Wu    dependabot[bot]
 ```
 For more information, or if you are interested in joining the development of AOMP, please read the AOMP developers README file located here [README](../bin/README.md).

--- a/docs/SOURCEINSTALL_PREREQUISITE.md
+++ b/docs/SOURCEINSTALL_PREREQUISITE.md
@@ -5,7 +5,7 @@
 #### Debian or Ubuntu Packages
 
 ```
-  sudo apt-get install wget gcc g++ pkg-config libpci-dev libnuma-dev libffi-dev git python3 libopenmpi-dev gawk mesa-common-dev libtool libdrm-amdgpu1 libdrm-dev ccache libdw-dev libgtest-dev libsystemd-dev cmake openssl libssl-dev libgmp-dev libmpfr-dev libelf-dev patchelf pciutils python3.10-dev libudev-dev libgtest-dev libstdc++-12-dev python3-lxml ocl-icd-opencl-dev libsystemd-dev
+  sudo apt-get install wget gcc g++ pkg-config libpci-dev libnuma-dev libffi-dev git python3 libopenmpi-dev gawk mesa-common-dev libtool libdrm-amdgpu1 libdrm-dev ccache libdw-dev libgtest-dev libsystemd-dev cmake openssl libssl-dev libgmp-dev libmpfr-dev libelf-dev patchelf pciutils python3.10-dev libudev-dev libgtest-dev libstdc++-12-dev python3-lxml ocl-icd-opencl-dev libsystemd-dev libsqlite3-dev
 
   # Additional packages used by rocgdb
   sudo apt-get install texinfo libbison-dev bison flex libbabeltrace-dev python3-pip libncurses5-dev liblzma-dev python3-setuptools python3-dev libudev-dev libgmp-dev libmpfr-dev libdw-dev
@@ -29,7 +29,7 @@ Ubuntu 24.04 Only
 
 #### SLES-15-SP6 Packages
 ```
-  sudo zypper install wget libopenssl-devel elfutils libelf-devel git pciutils-devel libffi-devel gcc gcc-c++ libnuma-devel openmpi4-devel Mesa-libGL-devel libquadmath0 libtool libX11-devel systemd-devel hwdata unzip mpfr-devel ocl-icd-devel gcc7-fortran ncurses-devel
+  sudo zypper install wget libopenssl-devel elfutils libelf-devel git pciutils-devel libffi-devel gcc gcc-c++ libnuma-devel openmpi4-devel Mesa-libGL-devel libquadmath0 libtool libX11-devel systemd-devel hwdata unzip mpfr-devel ocl-icd-devel gcc7-fortran ncurses-devel sqlite-devel
 
   A symbolic link may be required at /usr/lib64: /usr/lib64/libquadmath.so -> /usr/lib64/libquadmath.so.0.
 
@@ -53,7 +53,7 @@ Ubuntu 24.04 Only
 #### RHEL Packages
 RHEL 8
 ```
-  sudo yum install dnf-plugins-core gcc-c++ git wget openssl-devel elfutils-libelf-devel elfutils-devel ccache pciutils-devel numactl-devel libffi-devel mesa-libGL-devel libtool libdrm libdrm-devel gmp-devel rpm-build gcc-gfortran libdw-devel libgtest-devel systemd-devel mpfr-devel python38 python38-devel ocl-icd-devel libatomic libquadmath-devel
+  sudo yum install dnf-plugins-core gcc-c++ git wget openssl-devel elfutils-libelf-devel elfutils-devel ccache pciutils-devel numactl-devel libffi-devel mesa-libGL-devel libtool libdrm libdrm-devel gmp-devel rpm-build gcc-gfortran libdw-devel libgtest-devel systemd-devel mpfr-devel python38 python38-devel ocl-icd-devel libatomic libquadmath-devel sqlite-devel
 
   # Additional packages used by rocgdb and roctracer
   sudo yum install texinfo bison flex ncurses-devel expat-devel xz-devel libbabeltrace-devel libatomic libdwarf-devel gtest-devel
@@ -67,7 +67,7 @@ RHEL 8
 
 RHEL 9
 ```
-  sudo dnf install dnf-plugins-core gcc-c++ git wget openssl-devel elfutils-libelf-devel elfutils-devel ccache pciutils-devel numactl-devel libffi-devel mesa-libGL-devel libtool libdrm libdrm-devel gmp-devel rpm-build gcc-gfortran libdw-devel libgtest-devel systemd-devel mpfr-devel python3-devel ocl-icd-devel libatomic libquadmath-devel
+  sudo dnf install dnf-plugins-core gcc-c++ git wget openssl-devel elfutils-libelf-devel elfutils-devel ccache pciutils-devel numactl-devel libffi-devel mesa-libGL-devel libtool libdrm libdrm-devel gmp-devel rpm-build gcc-gfortran libdw-devel libgtest-devel systemd-devel mpfr-devel python3-devel ocl-icd-devel libatomic libquadmath-devel sqlite-devel
 
   # Additional packages used by rocgdb and roctracer
   sudo dnf install texinfo bison flex ncurses-devel expat-devel xz-devel libbabeltrace-devel libatomic libdwarf-devel gtest-devel

--- a/manifests/aomp_22.0.xml
+++ b/manifests/aomp_22.0.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- Manifest for AOMP 22.0-x which uses ROCM 6.4 release branches of external repositories -->
+  <!-- Manifest for AOMP 22.0-x which uses ROCM 7.0 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-6.4" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-7.0" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
     <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
-<!-- These first 4 repos are NOT rocm 6.4. They are compiler developer branches -->
+<!-- These first 4 repos are NOT rocm 7.0. They are compiler developer branches -->
     <project remote="roc" path="llvm-project" name="llvm-project"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="SPIRV-LLVM-Translator" name="SPIRV-LLVM-Translator"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="hipify" name="hipify"    revision="amd-staging" groups="unlocked" />
@@ -16,16 +16,16 @@
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-6.4" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.0" groups="unlocked" />
 </manifest>

--- a/manifests/aompi_22.0.xml
+++ b/manifests/aompi_22.0.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- Manifest for AOMP 22.0-x which uses ROCM 6.4 release branches of external repositories -->
+  <!-- Manifest for AOMP 22.0-x which uses ROCM 7.0 release branches of external repositories -->
 
-    <default revision="release/rocm-rel-6.4" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-7.0" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
     <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
-<!-- These first 4 repos are NOT rocm 6.4. They are compiler developer branches -->
+<!-- These first 4 repos are NOT rocm 7.0. They are compiler developer branches -->
     <project remote="githubemu-lightning" path="llvm-project" name="llvm-project.git" revision="amd-staging" groups="unlocked" />
     <project remote="githubemu-lightning" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
     <project remote="githubemu-lightning" path="hipify" name="hipify.git" revision="amd-staging" groups="unlocked" />
@@ -15,16 +15,16 @@
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-6.4" groups="unlocked" />
-    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-6.4" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.0" groups="unlocked" />
 </manifest>


### PR DESCRIPTION
This move to 7.0 sources requires a new system package:
Ubuntu: libsqlite3-dev
SLES/RHEL: sqlite-devel

- Updated rocr patch to no longer need the removal of gfx940/1
- Updated clr patch to remove the commenting of install commands
