### PR TITLE
Fixed smoke-dev reduction failures: use fabs from math library, not abs from stdlib.

### DIFF
--- a/test/smoke-dev/xteam-red-min-max-calls-target-fast/xteam-red-min-max-calls.c
+++ b/test/smoke-dev/xteam-red-min-max-calls-target-fast/xteam-red-min-max-calls.c
@@ -4,7 +4,6 @@
  * Xteam reduction even with calls inside.
 */
 #include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include <omp.h>
 
@@ -12,48 +11,48 @@ int main()
 {
   int N = 10000;
 
-  int a[N];
+  double a[N];
 
   for (int i=0; i<N; i++)
     a[i]=i+11;
 
-  int max1, max2, max3;
+  double max1, max2, max3;
   max1 = max2 = max3 = 0;
-  int min1, min2, min3;
+  double min1, min2, min3;
   min1 = min2 = min3 = 1000000;
 
 #pragma omp target teams distribute parallel for reduction(max : max1)
   for (int j = 0; j < N; j = j + 1)
   {
-    a[j] = abs(a[j]);
+    a[j] = fabs(a[j]);
     max1 = fmax(max1, a[j]);
   }
 
 #pragma omp target teams distribute parallel for reduction(max : max2)
   for (int j = 0; j < N; j = j + 1)
-    max2 = abs((int)fmax(max2, a[j]));
+    max2 = fabs(fmax(max2, a[j]));
 
 #pragma omp target teams distribute parallel for reduction(max : max3)
   for (int j = 1; j < N; j = j + 1)
-    max3 = fmax(max3, abs(a[j]));
+    max3 = fmax(max3, fabs(a[j]));
 
 #pragma omp target teams distribute parallel for reduction(min : min1)
   for (int j = 0; j < N; j = j + 1)
   {
-    a[j] = abs(a[j]);
+    a[j] = fabs(a[j]);
     min1 = fmin(min1, a[j]);
   }
 
 #pragma omp target teams distribute parallel for reduction(min : min2)
   for (int j = 0; j < N; j = j + 1)
-    min2 = abs((int)fmin(min2, a[j]));
+    min2 = fabs(fmin(min2, a[j]));
 
 #pragma omp target teams distribute parallel for reduction(min : min3)
   for (int j = 1; j < N; j = j + 1)
-    min3 = fmin(min3, abs(a[j]));
+    min3 = fmin(min3, fabs(a[j]));
 
-    printf("max1 = %d max2 = %d max3 = %d\n", max1, max2, max3);
-    printf("min1 = %d min2 = %d min3 = %d\n", min1, min2, min3);
+    printf("max1 = %f max2 = %f max3 = %f\n", max1, max2, max3);
+    printf("min1 = %f min2 = %f min3 = %f\n", min1, min2, min3);
 
   int rc = (max1 != 10010) || (max2 != 10010) || (max3 != 10010) || (min1 != 11) || (min2 != 11) || (min3 != 12);
 
@@ -71,3 +70,4 @@ int main()
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:2
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
+

--- a/test/smoke-dev/xteam-red-min-max-calls/xteam-red-min-max-calls.c
+++ b/test/smoke-dev/xteam-red-min-max-calls/xteam-red-min-max-calls.c
@@ -1,12 +1,12 @@
 /*
  * Test min/max reduction using fmin/fmax with unrelated calls in
- * the kernels. Compile using -O3. abs is not yet recognized as a
- * math function and hence treated as a regular function call. In
+ * the kernels. Compile using -O3. fabs is not yet recognized as a
+ * math function by specialized kernel analysis in clang and 
+ * hence treated as a regular function call. In
  * the presence of general function calls, specialized kernels are
  * not generated at this point using vanilla -O2/-O3.
 */
 #include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include <omp.h>
 
@@ -14,48 +14,48 @@ int main()
 {
   int N = 10000;
 
-  int a[N];
+  double a[N];
 
   for (int i=0; i<N; i++)
     a[i]=i+11;
 
-  int max1, max2, max3;
+  double max1, max2, max3;
   max1 = max2 = max3 = 0;
-  int min1, min2, min3;
+  double min1, min2, min3;
   min1 = min2 = min3 = 1000000;
 
 #pragma omp target teams distribute parallel for reduction(max : max1)
   for (int j = 0; j < N; j = j + 1)
   {
-    a[j] = abs(a[j]);
+    a[j] = fabs(a[j]);
     max1 = fmax(max1, a[j]);
   }
 
 #pragma omp target teams distribute parallel for reduction(max : max2)
   for (int j = 0; j < N; j = j + 1)
-    max2 = abs((int)fmax(max2, a[j]));
+    max2 = fabs(fmax(max2, a[j]));
 
 #pragma omp target teams distribute parallel for reduction(max : max3)
   for (int j = 1; j < N; j = j + 1)
-    max3 = fmax(max3, abs(a[j]));
+    max3 = fmax(max3, fabs(a[j]));
 
 #pragma omp target teams distribute parallel for reduction(min : min1)
   for (int j = 0; j < N; j = j + 1)
   {
-    a[j] = abs(a[j]);
+    a[j] = fabs(a[j]);
     min1 = fmin(min1, a[j]);
   }
 
 #pragma omp target teams distribute parallel for reduction(min : min2)
   for (int j = 0; j < N; j = j + 1)
-    min2 = abs((int)fmin(min2, a[j]));
+    min2 = fabs(fmin(min2, a[j]));
 
 #pragma omp target teams distribute parallel for reduction(min : min3)
   for (int j = 1; j < N; j = j + 1)
-    min3 = fmin(min3, abs(a[j]));
+    min3 = fmin(min3, fabs(a[j]));
 
-    printf("max1 = %d max2 = %d max3 = %d\n", max1, max2, max3);
-    printf("min1 = %d min2 = %d min3 = %d\n", min1, min2, min3);
+    printf("max1 = %f max2 = %f max3 = %f\n", max1, max2, max3);
+    printf("min1 = %f min2 = %f min3 = %f\n", min1, min2, min3);
 
   int rc = (max1 != 10010) || (max2 != 10010) || (max3 != 10010) || (min1 != 11) || (min2 != 11) || (min3 != 12);
 


### PR DESCRIPTION
Calls from stdlib may not be supported in target regions. DeviceRTL earlier resolved some of these calls but that cannot be relied on. That behavior has changed with the move of Device RTL.
