### PR TITLE
Updated OMPT tests that check for trace buffer flush.

### DIFF
--- a/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-api-use/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-api-use/veccopy-ompt-target-emi-tracing.cpp
@@ -3,7 +3,7 @@
  * LIBOMPTARGET_OMPT_FLUSH_ON_BUFFER_FULL=false while doing explicit flushing
  * using ompt_flush_trace. The intention is to check whether trace records are
  * properly flushed when the program/tool uses the ompt_flush_trace API. There
- * should be 22 trace records returned to the tool.
+ * should be 23 trace records returned to the tool.
  */
 #include <assert.h>
 #include <omp.h>
@@ -85,9 +85,13 @@ int main() {
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
+/// CHECK-DAG: rec=
 /// CHECK-NOT: rec=
 
 /// CHECK-DAG: Success
+
+/// The user calls flush before printing success, so 
+/// no more records should be returned here.
 
 /// CHECK-NOT: rec=
 /// CHECK-NOT: host_op_id=0x0

--- a/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-buffer-full/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-buffer-full/veccopy-ompt-target-emi-tracing.cpp
@@ -3,9 +3,8 @@
  * ompt_flush_trace is not invoked by the user/tool. The intention is to check
  * whether trace records are properly flushed as a buffer fills up. Currently,
  * the buffer size in callbacks.h implies that every buffer holds 2 trace
- * records. With this assumption, there should be 20 trace records. The last 2
- * trace records are not flushed because the runtime does not know yet that the
- * last buffer is full.
+ * records. With this assumption, there should be 22 trace records. The last
+ * trace record is not flushed because the last buffer is not yet full.
  */
 #include <assert.h>
 #include <omp.h>
@@ -79,9 +78,7 @@ int main() {
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
-/// CHECK-NOT: rec=
-
-/// CHECK-DAG: Success
-
+/// CHECK-DAG: rec=
+/// CHECK-DAG: rec=
 /// CHECK-NOT: rec=
 /// CHECK-NOT: host_op_id=0x0

--- a/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-shutdown/veccopy-ompt-target-emi-tracing.cpp
+++ b/test/smoke-dev/veccopy-ompt-target-tracing-flush-only-on-shutdown/veccopy-ompt-target-emi-tracing.cpp
@@ -1,7 +1,7 @@
 /*
  * This test is run with LIBOMPTARGET_OMPT_FLUSH_ON_BUFFER_FULL=false and
  * ompt_flush_trace is not invoked by the user/tool. The intention is to check
- * whether trace records are properly flushed on shutdown. 22 trace records
+ * whether trace records are properly flushed on shutdown. 23 trace records
  * should be flushed during shutdown.
  */
 #include <assert.h>
@@ -56,6 +56,7 @@ int main() {
 
 /// CHECK-NOT: host_op_id=0x0
 
+/// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=
 /// CHECK-DAG: rec=


### PR DESCRIPTION
Account for 1 more flush because of recent change of handling of __omp_rtl_data_environment.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
