### PR TITLE
[build] - Disable building tests for rocprofiler-sdk

### DIFF
--- a/bin/build_rocprofiler-sdk.sh
+++ b/bin/build_rocprofiler-sdk.sh
@@ -70,7 +70,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 	        -DBUILD_SHARED_LIBS=On
 	        -DGPU_TARGETS="$GFXSEMICOLONS"
 	        -DROCPROFILER_BUILD_SAMPLES=ON
-		-DROCPROFILER_BUILD_TESTS=ON)
+		-DROCPROFILER_BUILD_TESTS=OFF)
 
    echo " -----Running rocprofiler-sdk cmake ---- "
    echo "${AOMP_CMAKE}" "${MYCMAKEOPTS[@]}" "$AOMP_REPOS/$AOMP_PROF_SDK_REPO_NAME"


### PR DESCRIPTION
A recent commit came into the 7.0 branch which seems to be dependent on another commit and is causing a build failure. For now we can just disable the tests to avoid the issue.
