### PR TITLE
Fix UMT build by rebasing and tweaking the currently required patch for 5.9.0

### DIFF
--- a/bin/patches/UMT-5-9-0-amdflang-mods.patch
+++ b/bin/patches/UMT-5-9-0-amdflang-mods.patch
@@ -1,0 +1,456 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b348b26..ff000f1 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -19,7 +19,7 @@ set(TETON_VERSION_PATCH 0)
+ include (cmake/Version.cmake)
+ 
+ # The CUDA Boltzmann Compton solver source file requires C++11.  Conduit requires C++14.
+-set(CMAKE_CXX_STANDARD 14)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CUDA_STANDARD 14)
+ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+@@ -104,7 +104,14 @@ if(ENABLE_OPENMP)
+          message( STATUS "OPENMP - Platform has unified memory, skip OpenMP host<->device maps and updates" )
+          add_compile_definitions( "TETON_OPENMP_HAS_UNIFIED_MEMORY" )
+       endif()
+-
++      
++      # ideally this would be runtime nad not require a recompile, but the
++      # presence of the omp_wrapper.h macros prevents this unfortunately
++      if ($ENV{HSA_XNACK})
++         add_compile_definitions(HSA_XNACK=$ENV{HSA_XNACK})
++      else()
++         add_compile_definitions(HSA_XNACK=0)
++      endif()
+    endif()
+ 
+    find_package(OpenMP REQUIRED COMPONENTS Fortran CXX)
+@@ -201,7 +208,31 @@ if(ENABLE_OPENMP)
+ 
+          target_link_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--rocm-path=${HIP_ROOT_DIR} -target-accel=amd_${CMAKE_HIP_ARCHITECTURES}>)
+          target_compile_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--rocm-path=${HIP_ROOT_DIR} -target-accel=amd_${CMAKE_HIP_ARCHITECTURES}>)
+-         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::amdhip64)
++         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::device)
++         target_include_directories( OpenMP::OpenMP_Fortran INTERFACE ${HIP_ROOT_DIR}/include)
++
++      elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang")
++
++         message( STATUS "Detected Flang Fortran OpenMP offload support requested.  Adding additional flags to pull in HIP backend needed by Cray Fortran compiler.")
++
++         if (DEFINED CMAKE_HIP_ARCHITECTURES)
++            message( STATUS "Setting target gpu architecture to ${CMAKE_HIP_ARCHITECTURES}")
++         else()
++            message( FATAL_ERROR " Must set CMAKE_HIP_ARCHITECTURES when using LLVM Flang compiler openmp offload functionality.")
++         endif()
++
++         if (DEFINED CMAKE_FORTRAN_OFFLOAD_LIB)
++            message( STATUS "Setting Fortran GPU offload library to ${CMAKE_FORTRAN_OFFLOAD_LIB}")
++         else()
++            message( FATAL_ERROR " Must set CMAKE_FORTRAN_OFFLOAD_LIB when using LLVM Flang compiler openmp offload functionality.")
++         endif()
++
++         find_package(hip REQUIRED)
++         add_compile_definitions( "TETON_ENABLE_HIP" )
++
++         target_link_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--offload-arch=${CMAKE_HIP_ARCHITECTURES}>)
++         target_compile_options( OpenMP::OpenMP_Fortran INTERFACE $<$<COMPILE_LANGUAGE:Fortran>:--offload-arch=${CMAKE_HIP_ARCHITECTURES}>)
++         target_link_libraries( OpenMP::OpenMP_Fortran INTERFACE hip::device)
+          target_include_directories( OpenMP::OpenMP_Fortran INTERFACE ${HIP_ROOT_DIR}/include)
+ 
+       endif()
+diff --git a/src/cmake/GetGPUInfo.cmake b/src/cmake/GetGPUInfo.cmake
+index 2a337a9..fac34e0 100644
+--- a/src/cmake/GetGPUInfo.cmake
++++ b/src/cmake/GetGPUInfo.cmake
+@@ -14,28 +14,40 @@ if (ENABLE_OPENMP_OFFLOAD)
+   message(STATUS "Checking for GPU...")
+   if (CMAKE_CUDA_ARCHITECTURES STREQUAL 70)
+     message(STATUS "-- Detected NVIDIA Volta, setting device num processors to 80")
++    set(OMP_DEVICE_NUM_PROCESSORS 80)
++    add_compile_definitions(OMP_DEVICE_NUM_PROCESSORS=80)
+     set(GSET_MIN_SIZE 16)
+     set(MAX_NUM_SWEEP_HYPER_DOMAINS 1)
+     set(MAX_NUM_GTA_HYPER_DOMAINS 80)
+     set(OMP_DEVICE_TEAM_THREAD_LIMIT 1024)
+-
++    set(IS_AMDGPU FALSE)
++    add_compile_definitions(IS_AMDGPU=0)
++    set(OPENMP_UNIFIED_MEMORY FALSE)
+   elseif (CMAKE_HIP_ARCHITECTURES STREQUAL gfx90a)
+ # AMD MI250X - 110 CUs
+     message(STATUS "-- Detected AMD MI250, setting device num processors to 110")
++    set(OMP_DEVICE_NUM_PROCESSORS 110)
++    add_compile_definitions(OMP_DEVICE_NUM_PROCESSORS=110)
+     set(GSET_MIN_SIZE 16)
+     set(MAX_NUM_SWEEP_HYPER_DOMAINS 1)
+     set(MAX_NUM_GTA_HYPER_DOMAINS 110)
+     set(OMP_DEVICE_TEAM_THREAD_LIMIT 1024)
+-
++    set(IS_AMDGPU TRUE)
++    add_compile_definitions(IS_AMDGPU=1)
++    set(OPENMP_UNIFIED_MEMORY TRUE)
+ # AMD MI300 - 228 CUs
+   elseif (CMAKE_HIP_ARCHITECTURES STREQUAL gfx942)
+     message(STATUS "-- Detected AMD MI300, setting device num processors to 228")
++    set(OMP_DEVICE_NUM_PROCESSORS 228)
++    add_compile_definitions(OMP_DEVICE_NUM_PROCESSORS=228)
+     set(OPENMP_UNIFIED_MEMORY TRUE)
+     set(GSET_MIN_SIZE 4)
+     set(MAX_NUM_SWEEP_HYPER_DOMAINS 1)
++    set(MAX_NUM_HYPER_DOMAINS 40)
+     set(MAX_NUM_GTA_HYPER_DOMAINS 228)
++    set(IS_AMDGPU TRUE)
++    add_compile_definitions(IS_AMDGPU=1)
+     set(OMP_DEVICE_TEAM_THREAD_LIMIT 1024)
+-
+   else()
+     message(ERROR "-- Unrecogized or unset value for CUDA or HIP architecture.")
+   endif()
+@@ -43,11 +55,16 @@ if (ENABLE_OPENMP_OFFLOAD)
+ else()
+   message(STATUS "-- No GPU detected.")
+   # These are only used if running the GPU kernels on the CPU for testing purposes.
++  set(OMP_DEVICE_NUM_PROCESSORS 1)
++  add_compile_definitions(OMP_DEVICE_NUM_PROCESSORS=1)
+   set(OMP_DEVICE_TEAM_THREAD_LIMIT 1)
+   set(GSET_MIN_SIZE 1)
+   set(MAX_NUM_SWEEP_HYPER_DOMAINS 1)
+   set(MAX_NUM_GTA_HYPER_DOMAINS 1)
+   set(OMP_DEVICE_TEAM_THREAD_LIMIT 1)
++  set(IS_AMDGPU FALSE)
++  add_compile_definitions(IS_AMDGPU=0)
++  set(OPENMP_UNIFIED_MEMORY FALSE)
+ endif()
+ 
+ mark_as_advanced(OMP_DEVICE_NUM_PROCESSORS OMP_DEVICE_TEAM_THREAD_LIMIT)
+diff --git a/src/teton/CMakeLists.txt b/src/teton/CMakeLists.txt
+index 805e3e5..940776a 100644
+--- a/src/teton/CMakeLists.txt
++++ b/src/teton/CMakeLists.txt
+@@ -234,8 +234,10 @@ if(ENABLE_TESTS)
+                               ${CONDUIT_INCLUDE_DIR}/conduit
+                             )
+ 
++if ( ENABLE_OPENMP AND CMAKE_Fortran_COMPILER_ID STREQUAL LLVMFlang)
+   target_link_libraries( test_driver PUBLIC
+-                         teton
++                         $<LINK_LIBRARY:WHOLE_ARCHIVE,teton>
++                         -Wl,--no-nvptx-whole-archive
+                          ${CONDUIT_LIBRARIES}
+                          ${CONDUITRELAY_LIBRARIES}
+                          ${CONDUITBLUEPRINT_LIBRARIES}
+@@ -243,9 +245,25 @@ if(ENABLE_TESTS)
+                          ${CONDUITRELAYMPI_LIBRARIES}
+                          ${CONDUITRELAYMPIIO_LIBRARIES}
+                        )
++else()
++  target_link_libraries( test_driver PUBLIC
++                        teton
++                        ${CONDUIT_LIBRARIES}
++                        ${CONDUITRELAY_LIBRARIES}
++                        ${CONDUITBLUEPRINT_LIBRARIES}
++                        ${CONDUITBLUEPRINTMPI_LIBRARIES}
++                        ${CONDUITRELAYMPI_LIBRARIES}
++                        ${CONDUITRELAYMPIIO_LIBRARIES}
++                      )
++endif()
+ 
+   if( ENABLE_OPENMP )
+-    target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran)
++    if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "LLVMFlang")
++      target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran
++                             ${CMAKE_FORTRAN_OFFLOAD_LIB})
++    else()
++      target_link_libraries( test_driver PUBLIC OpenMP::OpenMP_Fortran)
++    endif()
+ 
+     # The target_link_options command has trouble with adding flags if there is
+     # a space, it keeps putting quotes around the whole line.  Use the older
+@@ -280,7 +298,7 @@ if(ENABLE_TESTS)
+   if (ENABLE_UMPIRE)
+     target_include_directories( test_driver PUBLIC ${UMPIRE_INCLUDE_DIR} 
+                                                    ${UMPIRE_FORTRAN_MODULES_DIR})
+-    target_link_libraries( test_driver PUBLIC ${UMPIRE_LIBRARIES})
++    target_link_libraries( test_driver PUBLIC ${UMPIRE_LIBRARIES} rt)
+ 
+     if (FMT_ROOT)
+       target_include_directories( test_driver PUBLIC ${FMT_INCLUDE_DIR})
+diff --git a/src/teton/driver/test_driver.cc b/src/teton/driver/test_driver.cc
+index 68e96c9..b736171 100644
+--- a/src/teton/driver/test_driver.cc
++++ b/src/teton/driver/test_driver.cc
+@@ -650,7 +650,10 @@ int TetonDriver::execute()
+                << std::endl;
+          }
+          options["iteration/incidentFluxMaxIt"] = 99;
+-         options["iteration/outerMaxIt"] = 1;
++         // A default of 1 outerMaxIt for LLVM Flang AMDGPU doesn't work, it
++         // currently requiress more outer iterations to converge. So set to 50
++         // which was the default in v5.5.0.
++         options["iteration/outerMaxIt"] = 50;
+ #endif
+          if (cycles == 0 && goalTime <= 0.0)
+          {
+@@ -663,6 +666,16 @@ int TetonDriver::execute()
+             numAzimuthalUser = 3;
+             if (numGroupsUser <= 0)
+                numGroupsUser = 128;
++            // Setting any of the above to be equivelant to benchmark problem 2
++            // works for mi300, but having them as the current default doesn't
++            // allow the correct group partitioning (perfectly even, and UMT
++            // doesn't support uneven group partitions at the moment), for the
++            // moment I've selected 32 as numGroupUser to be a little different
++            // to benchmark problem 2 while still allowing even group paritions
++            // with no remainder work. However, the original LLNL authors will
++            // know best what the appropriate thing to do here is.
++            if (OMP_DEVICE_NUM_PROCESSORS == 228) // MI300 processor count
++              numGroupsUser = 32;
+          }
+          else if (benchmarkProblem == 2)
+          {
+@@ -1187,14 +1200,16 @@ void TetonDriver::setOptions()
+          }
+          else if (useUmpire == 3)
+          {
+-#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
+-            if (myRank == 0)
+-            {
+-               std::cerr
+-                  << "Teton driver: Detected user selection of single Umpire device memory pool.  This is only supported on single memory architecture platforms."
+-                  << std::endl;
+-            }
+-            exit(1);
++#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) ||                               \
++    defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) &&          \
++        HSA_XNACK == 0
++           if (myRank == 0) {
++             std::cerr << "Teton driver: Detected user selection of single "
++                          "Umpire device memory pool.  This is only supported "
++                          "on single memory architecture platforms."
++                       << std::endl;
++           }
++           exit(1);
+ #endif
+             if (myRank == 0)
+             {
+diff --git a/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90 b/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
+index d132b25..0765c66 100644
+--- a/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
++++ b/src/teton/gpu/CornerSweepUCBrz_OMPOL.F90
+@@ -144,7 +144,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets,Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle))
++   TOMPC(private(ASet, angle, setID))
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+ 
+@@ -176,7 +176,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nAngleSets, Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2))
++   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/gpu/SetSweep_OMPOL.F90 b/src/teton/gpu/SetSweep_OMPOL.F90
+index bed14e4..0bad379 100644
+--- a/src/teton/gpu/SetSweep_OMPOL.F90
++++ b/src/teton/gpu/SetSweep_OMPOL.F90
+@@ -97,7 +97,7 @@
+ !  If the CUDA solver is used the source needs to be mapped to the GPU
+ 
+ #if !defined(TETON_ENABLE_MINIAPP_BUILD)
+-#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) || defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) && HSA_XNACK == 0
+    if ( useBoltzmannCompton .and. Size% useCUDASolver .and. Size% ngr >= 16) then
+    START_RANGE("Teton_OpenMP_data_movement")
+      do setID=1,nGroupSets
+@@ -184,7 +184,7 @@
+ 
+ !  Map the latest boundary values
+ 
+-#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) || defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) && HSA_XNACK == 0
+          START_RANGE("Teton_OpenMP_data_movement")
+          TOMP_UPDATE(target update to( Set%PsiB(:,:,Angle) ) )
+          END_RANGE("Teton_OpenMP_data_movement")
+@@ -239,7 +239,7 @@
+          Set   => getSetData(Quad, setID)
+          Angle =  Set% AngleOrder(sendIndex)
+ 
+-#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) || defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) && HSA_XNACK == 0
+          START_RANGE("Teton_OpenMP_Updates")
+          TOMP_UPDATE(target update from( Set%PsiB(:,:,Angle) ))
+          END_RANGE("Teton_OpenMP_Updates")
+diff --git a/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90 b/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
+index 3548de8..0927dea 100644
+--- a/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
++++ b/src/teton/gpu/SweepGreyUCBrz_OMPOL.F90
+@@ -145,7 +145,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets,nGTASets,Geom,nSets,Quad )&)
+-   TOMPC(private(Set))
++   TOMPC(private(Set, SetID))
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+ 
+@@ -411,7 +411,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nGTASets, Geom, GTA, Quad, angleList, nSets)&)
+-   TOMPC(private(Set, ASet, angle, angle0, quadwt, quadTauW1, quadTauW2))
++   TOMPC(private(Set, ASet, angle, angle0, quadwt, quadTauW1, quadTauW2, setID))
+ 
+    ZoneSetLoop2: do zSetID=1,nZoneSets
+      do setID=1,nGTASets
+diff --git a/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90 b/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
+index 44e9098..ae35ab9 100644
+--- a/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
++++ b/src/teton/gpu/SweepGreyUCBxyz_OMPOL.F90
+@@ -572,7 +572,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nGTASets, nSets, GTA, angleList, Quad, Geom)&)
+-   TOMPC(private(Set, ASet, angle, quadwt)) 
++   TOMPC(private(Set, ASet, angle, quadwt, setID))
+ 
+    ZoneSetLoop3: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/gpu/SweepUCBrz_OMPOL.F90 b/src/teton/gpu/SweepUCBrz_OMPOL.F90
+index bcfbbdb..1f540b2 100644
+--- a/src/teton/gpu/SweepUCBrz_OMPOL.F90
++++ b/src/teton/gpu/SweepUCBrz_OMPOL.F90
+@@ -139,7 +139,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets,Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle))
++   TOMPC(private(ASet, angle, setID))
+ 
+    ZoneSetLoop: do zSetID=1,nZoneSets
+ 
+@@ -171,7 +171,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none)&)
+    TOMPC(shared(nZoneSets, nAngleSets, Geom, angleList, Quad)&)
+-   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2))
++   TOMPC(private(ASet, angle, fac, R_afp, R_afp2, R, R2, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+@@ -254,7 +254,6 @@
+ 
+ 
+    if ( nHyperDomains > 1 ) then
+-
+      TOMP(target teams distribute collapse(2) num_teams(nZoneSets*nSets) &)
+      TOMPC(thread_limit(omp_device_team_thread_limit) default(none) &)
+      TOMPC(shared(sendIndex, Quad, nZoneSets, nSets) &)
+diff --git a/src/teton/gpu/SweepUCBxyz_OMPOL.F90 b/src/teton/gpu/SweepUCBxyz_OMPOL.F90
+index 350ffcc..9c9c0dc 100644
+--- a/src/teton/gpu/SweepUCBxyz_OMPOL.F90
++++ b/src/teton/gpu/SweepUCBxyz_OMPOL.F90
+@@ -138,7 +138,7 @@
+    TOMP_MAP(target enter data map(to: tau, sendIndex, angleList))
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+-   TOMPC(private(ASet, angle) &)
++   TOMPC(private(ASet, angle, setID) &)
+    TOMPC(shared(nZoneSets, angleList, Quad, Geom, nAngleSets) )
+ 
+    ZoneSetLoop0: do zSetID=1,nZoneSets
+@@ -186,7 +186,7 @@
+ 
+    TOMP(target teams distribute num_teams(nZoneSets) thread_limit(omp_device_team_thread_limit) default(none) &)
+    TOMPC(shared(nZoneSets, nAngleSets, Quad, Geom) &)
+-   TOMPC(private(ASet))
++   TOMPC(private(ASet, setID))
+ 
+    ZoneSetLoop1: do zSetID=1,nZoneSets
+ 
+diff --git a/src/teton/include/omp_wrappers.h b/src/teton/include/omp_wrappers.h
+index 519bc26..07b86d5 100644
+--- a/src/teton/include/omp_wrappers.h
++++ b/src/teton/include/omp_wrappers.h
+@@ -19,7 +19,10 @@
+ #endif
+ 
+ ! Enable openmp data map and update pragmas, if openmp offloading enabled and not using unified cpu and gpu memory.
+-#if defined(TETON_ENABLE_OPENMP_OFFLOAD) && !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if defined(TETON_ENABLE_OPENMP_OFFLOAD) &&                                    \
++        !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) ||                           \
++    defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) &&          \
++        HSA_XNACK == 0
+ #  define TOMP_MAP(source) !$omp source
+ #  define TOMP_UPDATE(source) !$omp source
+ #else
+@@ -28,7 +31,10 @@
+ #endif
+ 
+ ! Enable Umpire integration for host and device pools, if openmp offloading enabled and not using unified cpu and gpu memory.
+-#if defined(TETON_ENABLE_UMPIRE) && defined(TETON_ENABLE_OPENMP_OFFLOAD) && !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if defined(TETON_ENABLE_UMPIRE) && defined(TETON_ENABLE_OPENMP_OFFLOAD) &&    \
++        !defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) ||                           \
++    defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) &&          \
++        HSA_XNACK == 0
+ #  define UMPIRE_DEVICE_POOL_ALLOC(source) call target_alloc_and_pair_ptrs(source)
+ #  define UMPIRE_DEVICE_POOL_FREE(source) call target_free_and_unpair_ptrs(source)
+ #else
+diff --git a/src/teton/mods/Datastore_mod.F90 b/src/teton/mods/Datastore_mod.F90
+index b530955..64abf0a 100644
+--- a/src/teton/mods/Datastore_mod.F90
++++ b/src/teton/mods/Datastore_mod.F90
+@@ -146,7 +146,7 @@ contains
+       endif
+     endif
+     ! Get the value from the environment
+-    call getenv("TETON_PARTITION", str)
++    call get_environment_variable("TETON_PARTITION", str)
+     if (str .ne. " ") then
+       value = 0
+       read (str,*) value
+diff --git a/src/teton/mods/MemoryAllocator_mod.F90 b/src/teton/mods/MemoryAllocator_mod.F90
+index 1931b4b..90765ca 100644
+--- a/src/teton/mods/MemoryAllocator_mod.F90
++++ b/src/teton/mods/MemoryAllocator_mod.F90
+@@ -82,7 +82,7 @@ contains
+       endif
+ 
+       if (umpire_device_allocator_id >= 0) then
+-#if defined(TETON_OPENMP_HAS_UNIFIED_MEMORY)
++#if defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) || defined(TETON_OPENMP_HAS_UNIFIED_MEMORY) && defined(IS_AMDGPU) && HSA_XNACK == 1
+          if (Options%isRankVerbose() > 0 ) then
+             print *, "Teton: An umpire host allocator and device allocator were both provided.  Teton only requires one allocator on single memory architecture platforms.  The device allocator will be used."
+          endif
+diff --git a/src/teton/mods/cmake_defines_mod.F90.in b/src/teton/mods/cmake_defines_mod.F90.in
+index fd6db7c..138f8bc 100644
+--- a/src/teton/mods/cmake_defines_mod.F90.in
++++ b/src/teton/mods/cmake_defines_mod.F90.in
+@@ -15,5 +15,6 @@ implicit none
+    integer, parameter :: min_groupset_size = @GSET_MIN_SIZE@
+    integer, parameter :: max_num_sweep_hyperdomains = @MAX_NUM_SWEEP_HYPER_DOMAINS@
+    integer, parameter :: max_num_gta_hyperdomains = @MAX_NUM_GTA_HYPER_DOMAINS@
+-
++   logical, parameter :: omp_unified_memory = .@OPENMP_UNIFIED_MEMORY@.
++   logical, parameter :: omp_is_amdgpu = .@IS_AMDGPU@.
+ end module cmake_defines_mod
+diff --git a/src/teton/rt/addGreyCorrections_OMPOL.F90 b/src/teton/rt/addGreyCorrections_OMPOL.F90
+index 4592199..a13d3aa 100644
+--- a/src/teton/rt/addGreyCorrections_OMPOL.F90
++++ b/src/teton/rt/addGreyCorrections_OMPOL.F90
+@@ -142,7 +142,7 @@
+      TOMP(target teams distribute collapse(2) num_teams(nZoneSets*nSets) &)
+      TOMPC(thread_limit(omp_device_team_thread_limit) default(none) &)
+      TOMPC(shared(nZoneSets, nSets, Quad, GTA, wtiso)&)
+-     TOMPC(private(Set, ASet, HypPlanePtr, Groups, NumAngles, c, g0))
++     TOMPC(private(Set, ASet, HypPlanePtr, Groups, NumAngles, c, g0, angle))
+ 
+      ZoneSetLoop1: do zSetID=1,nZoneSets
+        SetLoop1: do setID=1,nSets

--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -125,7 +125,7 @@ if [ "$1" == "build_umt" ]; then
     # This applies specific tweaks to UMT required for Flang, we can likely
     # remove this in the near future once it's incorporated into UMT and
     # one or two smaller flang bugs are squashed
-    git apply $thisdir/patches/UMT-amdflang-mods.patch
+    git apply $thisdir/patches/UMT-5-9-0-amdflang-mods.patch
 
     rm -rf build
     mkdir build


### PR DESCRIPTION
Updating the UMT patch to support 5.9.0, primarily a rebase with several small tweaks like setting the C++ standard to 17 to have access to the template type trait UMTs now using.

Notably, I kept the old patch around and made a new one for 5.9.0 (that's now invoked by the script), just incase we need the backwards compatibility.
