### PR TITLE
Fixed iteam reduction test by replacing num_threads with thread_limit clause.

### DIFF
--- a/test/smoke-fails/iteam-red-1/iteam_red_1.c
+++ b/test/smoke-fails/iteam-red-1/iteam_red_1.c
@@ -35,11 +35,15 @@ void vmul_omp(double*a, double*b, double*c, int N) {
 }
 
 void vmul_sim(double*a, double*b, double*c, int N) {
-#pragma omp target map(to: a[0:N], b[0:N]) map(from:c[0:N]) 
+// The number of threads launched must match the tripcount of the k-loop.
+// The best way to (almost) guarantee that is to use the thread_limit clause
+// on the target construct. The num_threads clause on the inner parallel construct has
+// no effect since the OpenMP runtime is not fed that information from the inner parallel.
+#pragma omp target map(to: a[0:N], b[0:N]) map(from:c[0:N]) thread_limit(NUM_THREADS)
 #pragma omp teams distribute
   for(int i=0; i<N; i++) {
     double sum = 0;
-#pragma omp parallel for num_threads(NUM_THREADS)
+#pragma omp parallel for 
     for (uint64_t k = 0; k < NUM_THREADS; ++k) {
       double val0 = 0;
       for (int64_t j = k; j < N; j += NUM_THREADS)


### PR DESCRIPTION
After a recent change, generic SPMD kernels may have their blocksize reduced by the runtime. So the user code can no longer assume that the number of threads launched will match the default blocksize. The only way to ensure that is to add a thread_limit clause to the target construct.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
