### PR TITLE
Update versions of build_supp components openmpi, hdf5 and silo

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -155,7 +155,7 @@ function buildopenmpi(){
   fi
 
   _cname="openmpi"
-  _version=5.0.7
+  _version=5.0.8
   _release=v5.0
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
@@ -303,8 +303,8 @@ function getrocmpackage(){
 
 function buildhdf5(){
   _cname="hdf5"
-  _version=1.12.0
-  _release=hdf5-1.12
+  _version=1.14.0
+  _release=hdf5-1.14
   _installdir=$AOMP_SUPP_INSTALL/hdf5-$_version
   _linkfrom=$AOMP_SUPP/hdf5
   _builddir=$AOMP_SUPP_BUILD/hdf5
@@ -339,7 +339,7 @@ function buildhdf5(){
 
 function buildsilo(){
   _cname="silo"
-  _version=4.10.2
+  _version=4.11.1
   _installdir=$AOMP_SUPP_INSTALL/silo-$_version
   _linkfrom=$AOMP_SUPP/silo
   _builddir=$AOMP_SUPP_BUILD/silo
@@ -356,7 +356,8 @@ function buildsilo(){
   runcmd "cd $_builddir"
   # runcmd "wget https://wci.llnl.gov/sites/wci/files/2021-01/silo-$_version.tgz"
   # runcmd "tar -xzf silo-$_version.tgz"
-  runcmd "wget https://software.llnl.gov/Silo/ghpages/releases/silo-$_version.tar.xz"
+  #runcmd "wget https://software.llnl.gov/Silo/ghpages/releases/silo-$_version.tar.xz"
+  runcmd "wget https://github.com/LLNL/Silo/releases/download/$_version/silo-$_version.tar.xz"
   runcmd "tar -x --xz -f silo-$_version.tar.xz"
   runcmd "cd silo-$_version"
   if [ -d "$_installdir" ] ; then

--- a/bin/run_genasis.sh
+++ b/bin/run_genasis.sh
@@ -58,21 +58,21 @@ fi
 export GPU_ID=$($ROCM/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
 currdir=$(pwd)
 if [ -d "$SILO_DIR" ] ; then
-    echo "SILO 4.10.2 exists."
+    echo "SILO 4.11.1 exists."
 else
-    echo "SILO 4.10.2 does not exist. Please run ./build_supp.sh silo in $thisdir"
+    echo "SILO 4.11.1 does not exist. Please run ./build_supp.sh silo in $thisdir"
     exit
 fi
 if [ -d "$HDF5_DIR" ] ; then
-    echo "HDF5-1.12.0 exists."
+    echo "HDF5-1.14.0 exists."
     export INCLUDE_HDF5="-I$HDF5_DIR/include"
     export LIBRARY_HDF5="-L$HDF5_DIR/lib -lhdf5_fortran -lhdf5"
 else
-    echo "HDF5-1.12.0 does not exist. Please run ./build_supp.sh hdf5 in $thisdir"
+    echo "HDF5-1.14.0 does not exist. Please run ./build_supp.sh hdf5 in $thisdir"
     exit
 fi
 if [ -d "$OPENMPI_DIR" ] ; then
-    echo "OpenMPI-4.1.1 exists."
+    echo "OpenMPI-5.0.8 exists."
     export MPI=${OPENMPI_DIR}
 else
     echo "OpenMPI does not exist. Please run ./build_supp.sh openmpi in $thisdir"

--- a/bin/run_genasis_flang_new.sh
+++ b/bin/run_genasis_flang_new.sh
@@ -80,21 +80,21 @@ fi
 export GPU_ID=$($ROCM/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1}.{2})
 currdir=$(pwd)
 if [ -d "$SILO_DIR" ] ; then
-    echo "SILO 4.10.2 exists."
+    echo "SILO 4.11.1 exists."
 else
-    echo "SILO 4.10.2 does not exist. Please run ./build_supp.sh silo in $thisdir"
+    echo "SILO 4.11.1 does not exist. Please run ./build_supp.sh silo in $thisdir"
     exit
 fi
 if [ -d "$HDF5_DIR" ] ; then
-    echo "HDF5-1.12.0 exists."
+    echo "HDF5-1.14.0 exists."
     export INCLUDE_HDF5="-I$HDF5_DIR/include"
     export LIBRARY_HDF5="-L$HDF5_DIR/lib -lhdf5_fortran -lhdf5"
 else
-    echo "HDF5-1.12.0 does not exist. Please run ./build_supp.sh hdf5 in $thisdir"
+    echo "HDF5-1.14.0 does not exist. Please run ./build_supp.sh hdf5 in $thisdir"
     exit
 fi
 if [ -d "$OPENMPI_DIR" ] ; then
-    echo "OpenMPI-4.1.1 exists."
+    echo "OpenMPI-5.0.8 exists."
     export MPI=${OPENMPI_DIR}
 else
     echo "OpenMPI does not exist. Please run ./build_supp.sh openmpi in $thisdir"
@@ -102,11 +102,11 @@ else
 fi
 
 OMP_DEFINES="-DENABLE_OMP_OFFLOAD"
-if [ "$ENABLE_OMP_OFFLOAD" -eq "0" ] ; then
+if [[ "$ENABLE_OMP_OFFLOAD" -eq "0" ]] ; then
     OMP_DEFINES=
 fi
 
-if [ "$USE_OPENMP_RUNTIME" -eq "1" ] ; then
+if [[ "$USE_OPENMP_RUNTIME" -eq "1" ]] ; then
     OMP_DEFINES+=" -DUSE_OPENMP_RUNTIME"
 fi
 


### PR DESCRIPTION
Update versions of build_supp components openmpi(to 5.0.8), hdf5(to 1.14.0) and silo(to 4.11.1) used in GenASiS testing.