### PR TITLE
[build] - Move llvm-project, SPIRV, hipify repos to clone from github

### DIFF
--- a/manifests/aompi_22.0.xml
+++ b/manifests/aompi_22.0.xml
@@ -7,9 +7,9 @@
     <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
 <!-- These first 4 repos are NOT rocm 7.0. They are compiler developer branches -->
-    <project remote="githubemu-lightning" path="llvm-project" name="llvm-project.git" revision="amd-staging" groups="unlocked" />
-    <project remote="githubemu-lightning" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
-    <project remote="githubemu-lightning" path="hipify" name="hipify.git" revision="amd-staging" groups="unlocked" />
+    <project remote="roc" path="llvm-project" name="llvm-project.git" revision="amd-staging" groups="unlocked" />
+    <project remote="roc" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
+    <project remote="roc" path="hipify" name="hipify.git" revision="amd-staging" groups="unlocked" />
     <project remote="simde" path="simde" name="simde" revision="master" groups="unlocked" />
 
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />


### PR DESCRIPTION
Preemptive patch that we can land once the move has been completed.
