### PR TITLE
[BuildBot] Bump rocm version in dockerfiles

### DIFF
--- a/upstream-buildbots/Ubu22-HIP-TPL/rocm.list
+++ b/upstream-buildbots/Ubu22-HIP-TPL/rocm.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3.3 jammy main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0.2 jammy main

--- a/upstream-buildbots/Ubu22/rocm.list
+++ b/upstream-buildbots/Ubu22/rocm.list
@@ -1,1 +1,1 @@
-deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3 jammy main
+deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.0.2 jammy main


### PR DESCRIPTION
We have HIP bot running ROCm 7.0.2 in production now. Updated the Dockerfiles so that users will be using the correct version for reproducing issues. 