### PR TITLE
[smoke-fort-fails] Add test for a parallel reduction in a generic kernel

### DIFF
--- a/test/smoke-fort-fails/tgt-generic-parallel-reduction/Makefile
+++ b/test/smoke-fort-fails/tgt-generic-parallel-reduction/Makefile
@@ -1,0 +1,12 @@
+include ../../Makefile.defs
+
+TESTNAME     = tgt-generic-parallel-reduction
+TESTSRC_MAIN = tgt-generic-parallel-reduction.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/tgt-generic-parallel-reduction/tgt-generic-parallel-reduction.f90
+++ b/test/smoke-fort-fails/tgt-generic-parallel-reduction/tgt-generic-parallel-reduction.f90
@@ -1,0 +1,29 @@
+subroutine generic_parallel_reduction(output_var)
+  implicit none
+  integer, intent(out) :: output_var
+
+  integer :: i
+  integer :: private_var
+
+  !$omp target private(private_var) map(from: output_var)
+    private_var = 0
+
+    !$omp parallel do reduction(+:private_var)
+    do i = 1, 32
+      private_var = private_var + 1
+    end do
+
+    output_var = private_var
+  !$omp end target
+end subroutine
+
+program main
+  implicit none
+  integer :: val
+
+  call generic_parallel_reduction(val)
+  if ( val .ne. 32 ) then
+    print *, 'Unexpected result:', val
+    stop 1
+  end if
+end program


### PR DESCRIPTION
This test triggers a known issue where certain generic kernels are misidentified as SPMD, resulting in wrong results.

For this problem to be addressed, the execution of parallel regions in generic target regions must be fixed and also the detection of the kernel type must be updated to avoid detecting such target regions, holding sequential code, as SPMD.