### PR TITLE
[smoke-fort-dev] Add test for variable size array arguments

### DIFF
--- a/test/smoke-fort-dev/tgt-variable-array-dimension/Makefile
+++ b/test/smoke-fort-dev/tgt-variable-array-dimension/Makefile
@@ -1,0 +1,14 @@
+NOOPT        = 1
+include ../../Makefile.defs
+
+TESTNAME     = tgt-variable-array-dimension
+TESTSRC_MAIN = tgt-variable-array-dimension.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN)
+
+FLANG        ?= flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+CFLAGS       = -O0
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/tgt-variable-array-dimension/tgt-variable-array-dimension.f90
+++ b/test/smoke-fort-dev/tgt-variable-array-dimension/tgt-variable-array-dimension.f90
@@ -1,0 +1,40 @@
+subroutine init_array(ub, v)
+  implicit none
+
+  integer, intent(in) :: ub
+  real, dimension(1:ub+1, 1:ub+1), intent(out) :: v
+
+  integer :: i, j
+
+  !$omp target teams distribute
+  do i=1,6
+    !$omp parallel do
+    do j=1,6
+      v(j, i) = 100.0
+    end do
+  end do
+end subroutine
+
+program main
+  implicit none
+
+  real, dimension(:, :), allocatable :: v
+  integer :: i, j
+
+  allocate(v(1:6, 1:6))
+
+  !$omp target enter data map(alloc: v)
+  call init_array(5, v)
+  !$omp target exit data map(from: v)
+
+  do i=1,6
+    do j=1,6
+      if (v(j, i) /= 100.0) then
+        print *, "Expected values: 100.0. Actual values:", v(:,:)
+        stop 1
+      end if
+    end do
+  end do
+
+  deallocate(v)
+end program


### PR DESCRIPTION
This test, which already works when running in SPMD mode (current behavior) triggers an edge case for Generic mode that causes results to be incorrect.

This is related to the fact that, in that execution mode, a temporary allocated to store the upper bounds prior to entering the parallel region should use device shared memory instead of stack memory.