### PR TITLE
[build] - Move to ROCm 7.1 sources

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -241,10 +241,10 @@ function getrocmpackage(){
   _packagename="$2"
   _componentversion="$3"
   _directory=$(echo "$2" | cut -b 1)
-  _version=7.0
-  _packageversion=7.0.0
-  _fullversion=70000
-  _buildnumber=38
+  _version=7.1
+  _packageversion=7.1.0
+  _fullversion=70100
+  _buildnumber=20
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname
@@ -449,7 +449,7 @@ function buildcmake(){
 
 function buildrocmsmilib(){
   _cname="rocmsmilib"
-  _version=7.0.x
+  _version=7.1.x
   _installdir=$AOMP_SUPP_INSTALL/rocmsmilib-$_version
   _linkfrom=$AOMP_SUPP/rocmsmilib
   _builddir=$AOMP_SUPP_BUILD/rocmsmilib
@@ -464,7 +464,7 @@ function buildrocmsmilib(){
   fi
   runcmd "mkdir -p $_builddir"
   runcmd "cd $_builddir"
-  runcmd "git clone -b release/rocm-rel-7.0 https://github.com/ROCm/rocm_smi_lib rocmsmilib-$_version"
+  runcmd "git clone -b release/rocm-rel-7.1 https://github.com/ROCm/rocm_smi_lib rocmsmilib-$_version"
   runcmd "cd rocmsmilib-$_version"
   runcmd "mkdir -p build"
   runcmd "cd build"
@@ -576,7 +576,7 @@ for _component in $_components ; do
   elif [ "$_component" == "openclicdloader" ] ; then
     getrocmpackage openclicdloader rocm-opencl-icd-loader 1.2
   elif [ "$_component" == "rocm-core" ] ; then
-    getrocmpackage rocm-core rocm-core 7.0.0
+    getrocmpackage rocm-core rocm-core 7.1.0
   else
     echo "ERROR:  Invalid component name $_component" >>"$CMDLOGFILE"
     echo "ERROR:  Invalid component name $_component"

--- a/bin/clone_aomp.sh
+++ b/bin/clone_aomp.sh
@@ -156,7 +156,15 @@ function list_repo_from_manifest(){
       REPO_REMOTE="emu"
    fi
    if [[ "$REPO_REMOTE" == "roc" ]] ; then
-        manifest_project=$(echo ROCm/$REPO_PROJECT | tr '[:upper:]' '[:lower:]')
+	repo_git_list="llvm-project hipify spirv-llvm-translator"
+	if echo "$repo_git_list" | grep -w "$REPO_PROJECT"; then
+          url=$(grep url .git/config)
+          nogit=${url%*.git}
+          project_name=${nogit##*/}
+          manifest_project=$(echo $REPO_PROJECT | tr '[:upper:]' '[:lower:]' | cut -d"." -f1)
+	else
+          manifest_project=$(echo ROCm/$REPO_PROJECT | tr '[:upper:]' '[:lower:]')
+	fi
    elif [[ "$REPO_REMOTE" == "emu" ]] ; then
         url=$(grep url .git/config)
         nogit=${url%*.git}

--- a/bin/rocmlibs/build_rocBLAS.sh
+++ b/bin/rocmlibs/build_rocBLAS.sh
@@ -142,7 +142,8 @@ if [ "$1" != "install" ] ; then
      -DTensile_LAZY_LIBRARY_LOADING=ON
      -DTensile_LIBRARY_FORMAT=msgpack
      -DBUILD_WITH_HIPBLASLT=OFF
-     -DAMDGPU_TARGETS="""$ROCMLIBS_GFXLIST"""
+     -DROCTX_PATH=$AOMP_INSTALL_DIR
+     -DGPU_TARGETS="""$ROCMLIBS_GFXLIST"""
     "
    echo "Beginning cmake for rocblas..."
    cd $BUILD_DIR/build/rocmlibs/rocBLAS

--- a/bin/rocmlibs/patches/hipblas.patch
+++ b/bin/rocmlibs/patches/hipblas.patch
@@ -13,17 +13,6 @@ index a575664..d27a35f 100644
      else if(deviceString.find("gfx942") != std::string::npos)
      {
          return hipblasClientProcessor::gfx942;
-@@ -495,6 +499,10 @@ hipblasClientProcessor getArch()
-     {
-         return hipblasClientProcessor::gfx1102;
-     }
-+    else if(deviceString.find("gfx1103") != std::string::npos)
-+    {
-+        return hipblasClientProcessor::gfx1103;
-+    }
-     else if(deviceString.find("gfx1150") != std::string::npos)
-     {
-         return hipblasClientProcessor::gfx1150;
 diff --git a/clients/include/utility.h b/clients/include/utility.h
 index bb9e362..3a50954 100644
 --- a/clients/include/utility.h
@@ -36,11 +25,3 @@ index bb9e362..3a50954 100644
      gfx942  = 942,
      gfx950  = 950,
      gfx1010 = 1010,
-@@ -507,6 +508,7 @@ typedef enum hipblasClientProcessor
-     gfx1100 = 1100,
-     gfx1101 = 1101,
-     gfx1102 = 1102,
-+    gfx1103 = 1103,
-     gfx1150 = 1150,
-     gfx1151 = 1151,
-     gfx1200 = 1200,

--- a/bin/rocmlibs/patches/rocblas.patch
+++ b/bin/rocmlibs/patches/rocblas.patch
@@ -1,21 +1,43 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9ea8cd03..95b5bbb8 100644
+index 2e5638682..6d3a067cb 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -85,7 +85,7 @@ if (NOT BUILD_ADDRESS_SANITIZER)
-   set( TARGET_LIST_ROCM_5.7 "gfx803;gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102")
    set( TARGET_LIST_ROCM_6.0 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102")
    set( TARGET_LIST_ROCM_6.3 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201")
--  set( TARGET_LIST_ROCM_7.0 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201")
-+  set( TARGET_LIST_ROCM_7.0 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx90c;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201")
+   set( TARGET_LIST_ROCM_7.0 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1150;gfx1151;gfx1200;gfx1201")
+-  set( TARGET_LIST_ROCM_7.1 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201")
++  set( TARGET_LIST_ROCM_7.1 "gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a;gfx90c;gfx942;gfx950;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201")
  else()
    set( TARGET_LIST_ROCM_5.6 "gfx908:xnack+;gfx90a:xnack+")
    set( TARGET_LIST_ROCM_5.7 "gfx908:xnack+;gfx90a:xnack+;gfx942:xnack+")
+diff --git a/library/CMakeLists.txt b/library/CMakeLists.txt
+index e39c61926..c48ba9b0d 100644
+--- a/library/CMakeLists.txt
++++ b/library/CMakeLists.txt
+@@ -87,7 +87,7 @@ function( rocblas_library_settings lib_target_ )
+       set(ROCTX_PATH "" CACHE STRING "Path to the roctx library (directory containing libroctx64.so)")
+ 
+       find_path(ROCTRACER_INCLUDE_DIR
+-        NAMES roctracer/roctx.h
++        NAMES rocprofiler-sdk-roctx/roctx.h
+         HINTS
+         ${ROCTX_PATH}
+         ${ROCTX_PATH}/include
+@@ -96,7 +96,7 @@ function( rocblas_library_settings lib_target_ )
+         DOC "Path to the roctracer include directory containing roctx.h")
+ 
+       find_library(ROCTX_LIBRARY
+-        NAMES roctx64
++        NAMES rocprofiler-sdk-roctx
+         HINTS
+         ${ROCTX_PATH} # User-provided path
+         ${ROCTX_PATH}/lib
 diff --git a/library/src/handle.cpp b/library/src/handle.cpp
-index dcf0469c..a8b11ddc 100644
+index 7731691ff..4585a58ea 100644
 --- a/library/src/handle.cpp
 +++ b/library/src/handle.cpp
-@@ -354,6 +354,10 @@ Processor _rocblas_handle::getActiveArch()
+@@ -255,6 +255,10 @@ Processor _rocblas_handle::getActiveArch()
      {
          return Processor::gfx90a;
      }
@@ -27,10 +49,10 @@ index dcf0469c..a8b11ddc 100644
      {
          return Processor::gfx942;
 diff --git a/library/src/include/handle.hpp b/library/src/include/handle.hpp
-index c3a0fb52..608bdd20 100644
+index f0668632f..a8fe57e75 100644
 --- a/library/src/include/handle.hpp
 +++ b/library/src/include/handle.hpp
-@@ -82,6 +82,7 @@ enum class Processor : int
+@@ -75,6 +75,7 @@ enum class Processor : int
      gfx906  = 906,
      gfx908  = 908,
      gfx90a  = 910,
@@ -38,8 +60,21 @@ index c3a0fb52..608bdd20 100644
      gfx942  = 942,
      gfx950  = 950,
      gfx1010 = 1010,
+diff --git a/library/src/logging.cpp b/library/src/logging.cpp
+index 20b5d244c..d673bd93e 100644
+--- a/library/src/logging.cpp
++++ b/library/src/logging.cpp
+@@ -24,7 +24,7 @@
+ 
+ #ifndef DISABLE_ROCTX
+ #if !defined(ROCBLAS_STATIC_LIB) && !defined(WIN32)
+-#include <roctracer/roctx.h>
++#include <rocprofiler-sdk-roctx/roctx.h>
+ #endif
+ #endif
+ 
 diff --git a/library/src/tensile_host.cpp b/library/src/tensile_host.cpp
-index a87bace8..a3c2dfdf 100644
+index b0e72cc3d..f1b5ed8d3 100644
 --- a/library/src/tensile_host.cpp
 +++ b/library/src/tensile_host.cpp
 @@ -257,6 +257,10 @@ namespace

--- a/bin/rocmlibs/patches/rocprim.patch
+++ b/bin/rocmlibs/patches/rocprim.patch
@@ -1,13 +1,13 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 36b033a2..18b583eb 100644
+index 20999f18..f59df162 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -149,7 +149,7 @@ else()
+@@ -162,7 +162,7 @@ else()
        )
      else()
        rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
--        TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
-+        TARGETS "gfx803;gfx900:xnack-;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201"
+-        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201"
++        TARGETS "gfx906:xnack-;gfx908:xnack-;gfx90a:xnack-;gfx90a:xnack+;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201"
        )
      endif()
      set(GPU_TARGETS "${DEFAULT_AMDGPU_TARGETS}" CACHE STRING "GPU architectures to compile for" FORCE)

--- a/bin/rocmlibs/patches/tensile.patch
+++ b/bin/rocmlibs/patches/tensile.patch
@@ -1,72 +1,8 @@
-diff --git a/Tensile/AsmCaps.py b/Tensile/AsmCaps.py
-index 26f6a98b..643c3d7f 100644
---- a/Tensile/AsmCaps.py
-+++ b/Tensile/AsmCaps.py
-@@ -741,6 +741,50 @@ def getCapabilitiesCache(rocmVersion: NamedTuple) -> dict:
-                   'v_mov_b64': False,
-                   'v_pk_fma_f16': True,
-                   'v_pk_fmac_f16': False},
-+   (11, 0, 3): {'HasAddLshl': True,
-+                  'HasAtomicAdd': True,
-+                  'HasDirectToLdsDest': False,
-+                  'HasDirectToLdsNoDest': False,
-+                  'HasExplicitCO': True,
-+                  'HasExplicitNC': True,
-+                  'HasGLCModifier': True,
-+                  'HasNTModifier': False,
-+                  'HasLshlOr': True,
-+                  'HasMFMA': False,
-+                  'HasMFMA_b8': False,
-+                  'HasMFMA_bf16_1k': False,
-+                  'HasMFMA_bf16_original': False,
-+                  'HasMFMA_constSrc': False,
-+                  'HasMFMA_f64': False,
-+                  'HasMFMA_f8': False,
-+                  'HasMFMA_i8_908': False,
-+                  'HasMFMA_i8_940': False,
-+                  'HasMFMA_vgpr': False,
-+                  'HasMFMA_xf32': False,
-+                  'HasSMulHi': True,
-+                  'HasWMMA': True,
-+                  'KernargPreloading': False,
-+                  'MaxLgkmcnt': 15,
-+                  'MaxVmcnt': 63,
-+                  'SupportedISA': True,
-+                  'SupportedSource': True,
-+                  'VOP3v_dot4_i32_i8': False,
-+                  'v_dot2_f32_f16': True,
-+                  'v_dot2c_f32_f16': True,
-+                  'v_dot4_i32_i8': False,
-+                  'v_dot4c_i32_i8': False,
-+                  'v_fma_f16': True,
-+                  'v_fma_f32': True,
-+                  'v_fma_f64': True,
-+                  'v_fma_mix_f32': True,
-+                  'v_fmac_f16': False,
-+                  'v_fmac_f32': True,
-+                  'v_mac_f16': False,
-+                  'v_mac_f32': False,
-+                  'v_mad_mix_f32': False,
-+                  'v_mov_b64': False,
-+                  'v_pk_fma_f16': True,
-+                  'v_pk_fmac_f16': False},
-      (11, 5, 0): {'HasAddLshl': True,
-                   'HasAtomicAdd': True,
-                   'HasDirectToLdsDest': False,
 diff --git a/Tensile/Common.py b/Tensile/Common.py
-index 9537b770..3f82448b 100644
+index 86c6c577..376afc47 100644
 --- a/Tensile/Common.py
 +++ b/Tensile/Common.py
-@@ -249,7 +249,7 @@ globalParameters["SupportedISA"] = [(8,0,3),
-                                     (9,0,0), (9,0,6), (9,0,8), (9,0,10),
-                                     (9,4,2), (9,5,0),
-                                     (10,1,0), (10,1,1), (10,1,2), (10,3,0), (10,3,1),
--                                    (11,0,0), (11,0,1), (11,0,2),
-+                                    (11,0,0), (11,0,1), (11,0,2), (11,0,3),
-                                     (11,5,0), (11,5,1),
-                                     (12,0,0), (12,0,1)] # assembly kernels writer supports these architectures
- 
-@@ -308,7 +308,7 @@ globalParameters["SeparateArchitectures"] = False # write Tensile library metada
+@@ -307,7 +307,7 @@ globalParameters["SeparateArchitectures"] = False # write Tensile library metada
  
  globalParameters["LazyLibraryLoading"] = False # Load library and code object files when needed instead of at startup
  
@@ -75,33 +11,8 @@ index 9537b770..3f82448b 100644
  
  globalParameters["ExperimentalLogicDir"] = "/experimental/"
  
-@@ -325,7 +325,7 @@ architectureMap = {
-   'gfx950':'gfx950', 'gfx950:xnack+':'gfx950', 'gfx950:xnack-':'gfx950',
-   'gfx1010':'navi10', 'gfx1011':'navi12', 'gfx1012':'navi14',
-   'gfx1030':'navi21', 'gfx1031':'navi22', 'gfx1032':'navi23', 'gfx1034':'navi24', 'gfx1035':'rembrandt',
--  'gfx1100':'navi31', 'gfx1101':'navi32', 'gfx1102':'navi33',
-+  'gfx1100':'navi31', 'gfx1101':'navi32', 'gfx1102':'navi33', 'gfx1103':'phoenix',
-   'gfx1150':'strixpoint', 'gfx1151':'strixhalo',
-   'gfx1200':'gfx1200',
-   'gfx1201':'gfx1201'
-diff --git a/Tensile/Source/CMakeLists.txt b/Tensile/Source/CMakeLists.txt
-index 8279cfb0..7735220a 100644
---- a/Tensile/Source/CMakeLists.txt
-+++ b/Tensile/Source/CMakeLists.txt
-@@ -51,9 +51,9 @@ if(CMAKE_CXX_COMPILER MATCHES ".*/hipcc$" OR CMAKE_CXX_COMPILER MATCHES ".*clang
- endif()
- 
- if(CMAKE_CXX_COMPILER STREQUAL "hipcc")
--  set(TENSILE_GPU_ARCHS gfx803 gfx900 gfx906:xnack- gfx908:xnack- gfx90a:xnack- gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1034 gfx1035 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 CACHE STRING "GPU architectures")
-+  set(TENSILE_GPU_ARCHS gfx803 gfx900 gfx906:xnack- gfx908:xnack- gfx90a:xnack- gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1034 gfx1035 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 CACHE STRING "GPU architectures")
- else()
--  set(TENSILE_GPU_ARCHS gfx803 gfx900 gfx906 gfx908 gfx90a gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1034 gfx1035 gfx1100 gfx1101 gfx1102 gfx1150 gfx1151 CACHE STRING "GPU architectures")
-+  set(TENSILE_GPU_ARCHS gfx803 gfx900 gfx906 gfx908 gfx90a gfx1010 gfx1011 gfx1012 gfx1030 gfx1031 gfx1032 gfx1034 gfx1035 gfx1100 gfx1101 gfx1102 gfx1103 gfx1150 gfx1151 CACHE STRING "GPU architectures")
- endif()
- 
- include(CMakeDependentOption)
 diff --git a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
-index 0a1f9e67..19930a3c 100644
+index 317250db..66eb5336 100644
 --- a/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
 +++ b/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
 @@ -60,6 +60,7 @@ namespace Tensile
@@ -112,15 +23,7 @@ index 0a1f9e67..19930a3c 100644
              gfx942  = 942,
              gfx950  = 950,
              gfx1010 = 1010,
-@@ -73,6 +74,7 @@ namespace Tensile
-             gfx1100 = 1100,
-             gfx1101 = 1101,
-             gfx1102 = 1102,
-+            gfx1103 = 1103,
-             gfx1150 = 1150,
-             gfx1151 = 1151
-         };
-@@ -91,6 +93,8 @@ namespace Tensile
+@@ -94,6 +95,8 @@ namespace Tensile
                  return "gfx908";
              case AMDGPU::Processor::gfx90a:
                  return "gfx90a";
@@ -129,16 +32,7 @@ index 0a1f9e67..19930a3c 100644
              case AMDGPU::Processor::gfx942:
                  return "gfx942";
              case AMDGPU::Processor::gfx950:
-@@ -117,6 +121,8 @@ namespace Tensile
-                 return "gfx1101";
-             case AMDGPU::Processor::gfx1102:
-                 return "gfx1102";
-+            case AMDGPU::Processor::gfx1103:
-+                return "gfx1103";
-             case AMDGPU::Processor::gfx1150:
-                 return "gfx1150";
-             case AMDGPU::Processor::gfx1151:
-@@ -147,6 +153,10 @@ namespace Tensile
+@@ -156,6 +159,10 @@ namespace Tensile
              {
                  return AMDGPU::Processor::gfx90a;
              }
@@ -149,19 +43,8 @@ index 0a1f9e67..19930a3c 100644
              else if(deviceString.find("gfx942") != std::string::npos)
              {
                  return AMDGPU::Processor::gfx942;
-@@ -183,6 +193,10 @@ namespace Tensile
-             {
-                 return AMDGPU::Processor::gfx1102;
-             }
-+            else if(deviceString.find("gfx1103") != std::string::npos)
-+            {
-+                return AMDGPU::Processor::gfx1103;
-+            }
-             else if(deviceString.find("gfx1150") != std::string::npos)
-             {
-                 return AMDGPU::Processor::gfx1150;
 diff --git a/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp b/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
-index a7687315..4f0107d6 100644
+index a21e584d..c941f831 100644
 --- a/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
 +++ b/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
 @@ -44,6 +44,7 @@ namespace Tensile
@@ -172,15 +55,7 @@ index a7687315..4f0107d6 100644
          gfx942,
          gfx950,
          gfx1010,
-@@ -57,6 +58,7 @@ namespace Tensile
-         gfx1100,
-         gfx1101,
-         gfx1102,
-+        gfx1103,
-         gfx1150,
-         gfx1151,
-         All
-@@ -79,6 +81,8 @@ namespace Tensile
+@@ -82,6 +83,8 @@ namespace Tensile
              return "TensileLibrary_*_gfx908";
          case LazyLoadingInit::gfx90a:
              return "TensileLibrary_*_gfx90a";
@@ -189,17 +64,8 @@ index a7687315..4f0107d6 100644
          case LazyLoadingInit::gfx942:
              return "TensileLibrary_*_gfx942";
          case LazyLoadingInit::gfx950:
-@@ -105,6 +109,8 @@ namespace Tensile
-             return "TensileLibrary_*_gfx1101";
-         case LazyLoadingInit::gfx1102:
-             return "TensileLibrary_*_gfx1102";
-+        case LazyLoadingInit::gfx1103:
-+            return "TensileLibrary_*_gfx1103";
-         case LazyLoadingInit::gfx1150:
-             return "TensileLibrary_*_gfx1150";
-         case LazyLoadingInit::gfx1151:
 diff --git a/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp b/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
-index 12d81fc9..c2c32171 100644
+index 361a0e14..b8b41723 100644
 --- a/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
 +++ b/Tensile/Source/lib/include/Tensile/Serialization/Predicates.hpp
 @@ -220,6 +220,7 @@ namespace Tensile
@@ -210,19 +76,11 @@ index 12d81fc9..c2c32171 100644
                  iot::enumCase(io, value, "gfx942", AMDGPU::Processor::gfx942);
                  iot::enumCase(io, value, "gfx950", AMDGPU::Processor::gfx950);
                  iot::enumCase(io, value, "gfx1010", AMDGPU::Processor::gfx1010);
-@@ -233,6 +234,7 @@ namespace Tensile
-                 iot::enumCase(io, value, "gfx1100", AMDGPU::Processor::gfx1100);
-                 iot::enumCase(io, value, "gfx1101", AMDGPU::Processor::gfx1101);
-                 iot::enumCase(io, value, "gfx1102", AMDGPU::Processor::gfx1102);
-+                iot::enumCase(io, value, "gfx1103", AMDGPU::Processor::gfx1103);
-                 iot::enumCase(io, value, "gfx1150", AMDGPU::Processor::gfx1150);
-                 iot::enumCase(io, value, "gfx1151", AMDGPU::Processor::gfx1151);
-             }
 diff --git a/Tensile/TensileCreateLib/ParseArguments.py b/Tensile/TensileCreateLib/ParseArguments.py
-index c95731ba..a41feb7f 100644
+index f19dab13..be76194a 100644
 --- a/Tensile/TensileCreateLib/ParseArguments.py
 +++ b/Tensile/TensileCreateLib/ParseArguments.py
-@@ -265,7 +265,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
+@@ -259,7 +259,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
          "--ignore-asm-cap-cache",
          dest="IgnoreAsmCapCache",
          action="store_true",
@@ -232,23 +90,20 @@ index c95731ba..a41feb7f 100644
      )
      parser.add_argument(
 diff --git a/docs/src/cli-reference/tensile-create-library-cli.rst b/docs/src/cli-reference/tensile-create-library-cli.rst
-index 3fd61f6f..6caad8c8 100644
+index 4826f944..78ec17c5 100644
 --- a/docs/src/cli-reference/tensile-create-library-cli.rst
 +++ b/docs/src/cli-reference/tensile-create-library-cli.rst
-@@ -54,9 +54,9 @@ Here is the list of optional arguments for invoking the ``TensileCreateLibrary``
+@@ -54,7 +54,7 @@ Here is the list of optional arguments for invoking the ``TensileCreateLibrary``
      - Architectures to generate a library for. When specifying multiple options, use quoted and semicolon-delimited
        architectures such as \-\-architecture='gfx908;gfx1012'.
        Supported architectures include: all; gfx000; gfx803; gfx900; gfx900:xnack-; gfx906; gfx906:xnack+; gfx906:xnack-; gfx908; gfx908:xnack+;
 -      gfx908:xnack-; gfx90a; gfx90a:xnack+; gfx90a:xnack-; gfx940; gfx940:xnack+; gfx940:xnack-; gfx941; gfx941:xnack+;
 +      gfx908:xnack-; gfx90a; gfx90a:xnack+; gfx90a:xnack-; gfx90c; gfx940; gfx940:xnack+; gfx940:xnack-; gfx941; gfx941:xnack+;
        gfx941:xnack-; gfx942; gfx942:xnack+; gfx942:xnack-; gfx1010; gfx1011; gfx1012; gfx1030; gfx1031; gfx1032; gfx1034; gfx1035;
--      gfx1100; gfx1101; gfx1102; gfx1150; gfx1151.
-+      gfx1100; gfx1101; gfx1102; gfx1103; gfx1150; gfx1151.
+       gfx1100; gfx1101; gfx1102; gfx1103; gfx1150; gfx1151; gfx1200; gfx1201.
  
-   * - \-\-build-client
-     - Builds Tensile client executable that is used for stand alone benchmarking. This option is set by default.
 diff --git a/pytest.ini b/pytest.ini
-index c0ea3fcd..fe17c9da 100644
+index 93384c4b..13d9e054 100644
 --- a/pytest.ini
 +++ b/pytest.ini
 @@ -92,6 +92,7 @@ markers =
@@ -259,15 +114,7 @@ index c0ea3fcd..fe17c9da 100644
   xfail-gfx940:  architecture
   xfail-gfx941:  architecture
   xfail-gfx942:  architecture
-@@ -107,6 +108,7 @@ markers =
-  xfail-gfx1100: architecture
-  xfail-gfx1101: architecture
-  xfail-gfx1102: architecture
-+ xfail-gfx1103: architecture
-  xfail-gfx1150: architecture
-  xfail-gfx1151: architecture
-  skip-gfx000:  architecture
-@@ -114,6 +116,7 @@ markers =
+@@ -115,6 +116,7 @@ markers =
   skip-gfx906:  architecture
   skip-gfx908:  architecture
   skip-gfx90a:  architecture
@@ -275,10 +122,3 @@ index c0ea3fcd..fe17c9da 100644
   skip-gfx940:  architecture
   skip-gfx941:  architecture
   skip-gfx942:  architecture
-@@ -129,5 +132,6 @@ markers =
-  skip-gfx1100: architecture
-  skip-gfx1101: architecture
-  skip-gfx1102: architecture
-+ skip-gfx1103: architecture
-  skip-gfx1150: architecture 
-  skip-gfx1151: architecture

--- a/bin/rocmlibs/rocmlibs.xml
+++ b/bin/rocmlibs/rocmlibs.xml
@@ -3,31 +3,31 @@
 <!-- Manifest for rocmlibs -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-7.0" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-7.1" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="rocm"  fetch="https://github.com/ROCm" />
     <remote name="SJTU"  fetch="https://github.com/SJTU-IPADS" />
 
-<project remote="rocm" path="half" name="half" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipBLAS-common" name="hipBLAS-common" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipBLAS" name="hipBLAS" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipBLASLt" name="hipBLASLt" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipCUB" name="hipCUB" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipFFT" name="hipFFT" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipRAND" name="hipRAND" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipSOLVER" name="hipSOLVER" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="hipSPARSE" name="hipSPARSE" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rccl" name="rccl" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocBLAS" name="rocBLAS" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocFFT" name="rocFFT" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocPRIM" name="rocPRIM" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocRAND" name="rocRAND" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocSOLVER" name="rocSOLVER" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocSPARSE" name="rocSPARSE" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="rocThrust" name="rocThrust" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="Tensile" name="Tensile" revision="release/rocm-rel-7.0" groups="unlocked"/>
+<project remote="rocm" path="half" name="half" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipBLAS-common" name="hipBLAS-common" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipBLAS" name="hipBLAS" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipBLASLt" name="hipBLASLt" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipCUB" name="hipCUB" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipFFT" name="hipFFT" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipRAND" name="hipRAND" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipSOLVER" name="hipSOLVER" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="hipSPARSE" name="hipSPARSE" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rccl" name="rccl" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocBLAS" name="rocBLAS" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocFFT" name="rocFFT" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocPRIM" name="rocPRIM" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocRAND" name="rocRAND" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocSOLVER" name="rocSOLVER" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocSPARSE" name="rocSPARSE" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="rocThrust" name="rocThrust" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="Tensile" name="Tensile" revision="release/rocm-rel-7.1" groups="unlocked"/>
 
-<project remote="rocm" path="rocMLIR" name="rocMLIR" revision="release/rocm-rel-7.0" groups="unlocked"/>
-<project remote="rocm" path="MIOpen" name="MIOpen" revision="release/rocm-rel-7.0" groups="unlocked"/>
+<project remote="rocm" path="rocMLIR" name="rocMLIR" revision="release/rocm-rel-7.1" groups="unlocked"/>
+<project remote="rocm" path="MIOpen" name="MIOpen" revision="release/rocm-rel-7.1" groups="unlocked"/>
 
     <project remote="SJTU" path="PowerInfer" name="PowerInfer" revision="main" groups="unlocked" />
 </manifest>

--- a/manifests/aomp_22.0.xml
+++ b/manifests/aomp_22.0.xml
@@ -3,11 +3,11 @@
   <!-- Manifest for AOMP 22.0-x which uses ROCM 7.0 release branches of external repositories -->
 
     <remote name="gerritgit" review="git.amd.com:8080" fetch="ssh://gerritgit/" />
-    <default revision="release/rocm-rel-7.0" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-7.1" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
     <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
-<!-- These first 4 repos are NOT rocm 7.0. They are compiler developer branches -->
+<!-- These first 4 repos are NOT rocm 7.1. They are compiler developer branches -->
     <project remote="roc" path="llvm-project" name="llvm-project"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="SPIRV-LLVM-Translator" name="SPIRV-LLVM-Translator"    revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="hipify" name="hipify"    revision="amd-staging" groups="unlocked" />
@@ -16,16 +16,16 @@
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.1" groups="unlocked" />
 </manifest>

--- a/manifests/aompi_22.0.xml
+++ b/manifests/aompi_22.0.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-  <!-- Manifest for AOMP 22.0-x which uses ROCM 7.0 release branches of external repositories -->
+  <!-- Manifest for AOMP 22.0-x which uses ROCM 7.1 release branches of external repositories -->
 
-    <default revision="release/rocm-rel-7.0" remote="gerritgit" sync-j="4" sync-c="true" />
+    <default revision="release/rocm-rel-7.1" remote="gerritgit" sync-j="4" sync-c="true" />
     <remote name="roc"  fetch="https://github.com/ROCm" />
     <remote name="simde"  fetch="https://github.com/simd-everywhere" />
 
-<!-- These first 4 repos are NOT rocm 7.0. They are compiler developer branches -->
+<!-- These first 4 repos are NOT rocm 7.1. They are compiler developer branches -->
     <project remote="roc" path="llvm-project" name="llvm-project.git" revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="SPIRV-LLVM-Translator" name="spirv-llvm-translator.git" revision="amd-staging" groups="unlocked" />
     <project remote="roc" path="hipify" name="hipify.git" revision="amd-staging" groups="unlocked" />
@@ -15,16 +15,16 @@
     <project remote="roc" path="flang" name="flang"               revision="aomp-dev" groups="unlocked" />
     <project remote="roc" path="aomp" name="aomp"                 revision="aomp-dev" groups="unlocked" />
 
-    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.0" groups="unlocked" />
-    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.0" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-sdk" name="rocprofiler-sdk"              revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="ROCdbgapi" name="ROCdbgapi"                  revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="ROCgdb" name="ROCgdb"                        revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="hip"    name="hip"                           revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="clr" name="clr"                        revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocminfo" name="rocminfo"                         revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocm_smi_lib" name="rocm_smi_lib"                 revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="amdsmi" name="amdsmi"                             revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocm-cmake" name="rocm-cmake"                     revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocr-runtime" name="ROCR-Runtime"                 revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="rocprofiler-register" name="rocprofiler-register" revision="release/rocm-rel-7.1" groups="unlocked" />
+    <project remote="roc" path="hipfort" name="hipfort"                 revision="release/rocm-rel-7.1" groups="unlocked" />
 </manifest>


### PR DESCRIPTION
- Fixed 'clone_aomp.sh list' to not report error if .git is used to clone repo
- Updated build_rocBLAS.sh to include -DROCTX_PATH and replaced deprecated -DAMDGPU_TARGETS with -DGPU_TARGETS. ROCTX (roctracer) headers and libraries are built as a part of rocprofiler-sdk. Now the header is found in include/rocprofiler-sdk-roctx and the library is named librocprofiler-sdk-roctx.so.
- Updated various rocmlibs patches to remove gfx1103. 7.1 added support for gfx1103.
