### PR TITLE
Fixed smoke-dev clang-ifaces.

### DIFF
--- a/test/smoke-fails/clang-ifaces/Makefile
+++ b/test/smoke-fails/clang-ifaces/Makefile
@@ -8,6 +8,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
+OMP_FLAGS += -O0
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fails/clang-ifaces/clang-ifaces.c
+++ b/test/smoke-fails/clang-ifaces/clang-ifaces.c
@@ -1,0 +1,51 @@
+/* Copyright © Advanced Micro Devices, Inc., or its affiliates.
+
+   SPDX-License-Identifier:  MIT */
+
+#include <stdio.h>
+#include <omp.h>
+
+int main(){
+    int a[256];
+    int b[256];
+    int c;
+    int d;
+    int e[256];
+    int f;
+
+#pragma omp target teams distribute parallel for map(tofrom: a)
+for (int i =0; i <256; i++)
+{
+    a[i] =i;
+}
+
+#pragma omp target teams distribute map(tofrom: b)
+for(int i = 0; i <256; i++)
+{
+    b[i]= i;
+}
+
+#pragma omp target parallel map(tofrom: c)
+{
+    c = 2;
+}
+#pragma omp target teams map(tofrom: d)
+{
+   d = 3;
+}
+
+#pragma omp target parallel for map(tofrom: e)
+for (int i =0; i <256; i++)
+{
+    e[i] =i;
+}
+
+#pragma omp target map(tofrom: f)
+{
+    f = 4;
+}
+if (f != 4) return 1;
+return 0;
+}
+
+


### PR DESCRIPTION
By removing -O0 from the compile line. Replicated the failing -O0 test in smoke-fails.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
