### PR TITLE
[build_srock] Add extra information to -DLLVM_FORCE_VC_REVISION

### DIFF
--- a/srock-bin/build_srock.sh
+++ b/srock-bin/build_srock.sh
@@ -222,7 +222,8 @@ cd $SROCK_THEROCK_DIR
 cd compiler/amd-llvm || exit
 smrev="../.amd-llvm.smrev"
 git config --get remote.origin.url > "$smrev"
-git rev-parse HEAD >> "$smrev"
+smsha=$(git rev-parse HEAD)
+echo "${smsha}${LLVM_SHA_EXTRA}" >> "$smrev"
 )
 
 cd $SROCK_THEROCK_DIR


### PR DESCRIPTION
    - Mechanism for adding +PATCHED when using build_srock.sh
    - Via the .amd-llvm.smrev mechanism currently used by TheRock
    - Setting following env var adds to -DLLVM_FORCE_VC_REVISION:
         LLVM_SHA_EXTRA