### PR TITLE
[build] - Fix issue with hipamd using comgr from /opt/rocm

### DIFF
--- a/bin/patches/clr-amd-comgr-find-package.patch
+++ b/bin/patches/clr-amd-comgr-find-package.patch
@@ -1,0 +1,12 @@
+diff --git a/rocclr/cmake/ROCclrLC.cmake b/rocclr/cmake/ROCclrLC.cmake
+index d8ecf4a..f41d605 100644
+--- a/rocclr/cmake/ROCclrLC.cmake
++++ b/rocclr/cmake/ROCclrLC.cmake
+@@ -20,7 +20,6 @@
+ 
+ find_package(amd_comgr 2.9 CONFIG
+   PATHS
+-    /opt/rocm/
+     ${ROCM_INSTALL_PATH}
+   PATH_SUFFIXES
+     cmake/amd_comgr

--- a/bin/patches/patch-control-file_22.0.txt
+++ b/bin/patches/patch-control-file_22.0.txt
@@ -6,7 +6,7 @@ GenASiS_Basics: genasis_basics.patch
 hipamd: hipamd-rpath.patch
 bolt: bolt.patch
 rocr-runtime: rocr-runtime-numa.patch
-clr: clr-findamd-icd.patch
+clr: clr-findamd-icd.patch clr-amd-comgr-find-package.patch
 rocprofiler: rocprofiler-combined-no-aql-ok-fix-cov6.patch
 babelstream: babelstream-usm.patch
 llvm-project: ATD_ASO_full.patch


### PR DESCRIPTION
Hipamd searches for comgr config version 2.9 first and then 3.0. There is a case where an older ROCm install will satisfy the 2.9 version. This leads to issues when searching for hsa headers due to adding -isystem /opt/rocm/include. The hsa headers from the older ROCm do not build with newer ROCclr sources. For now we will remove /opt/rocm from the find_package search path.
