### PR TITLE
[build_supp] Switch to cmake 4.1.2

### DIFF
--- a/bin/build_hipfort.sh
+++ b/bin/build_hipfort.sh
@@ -76,6 +76,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
   MYCMAKEOPTS=(-DCMAKE_INSTALL_PREFIX="$HIPFORT_INSTALL_DIR"
                -DCMAKE_BUILD_TYPE=Release
+               -DCMAKE_POLICY_VERSION_MINIMUM=3.5
                -DHIPFORT_COMPILER="$LLVM_INSTALL_LOC/bin/flang"
                -DHIPFORT_COMPILER_FLAGS="-cpp"
                -DCMAKE_Fortran_FLAGS_DEBUG=""

--- a/bin/build_rocprofiler-register.sh
+++ b/bin/build_rocprofiler-register.sh
@@ -57,6 +57,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo " -----Running $AOMP_PROF_REGISTER_REPO_NAME cmake ---- " 
    echo "${AOMP_CMAKE}" "-DCMAKE_INSTALL_LIBDIR=lib" \
                         "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
+                        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" \
                         "-DROCM_PATH=$AOMP_INSTALL_DIR" \
                         "-DCMAKE_INSTALL_PREFIX=$INSTALL_ROCPROF_REGISTER" \
                         "-DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH" \

--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -415,7 +415,7 @@ function buildfftw(){
 
 function buildcmake(){
   _cname="cmake"
-  _version=3.25.2
+  _version=4.1.2
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname 


### PR DESCRIPTION
We need newer cmake version for the Flang GPU runtime.

Co-authored-by: Dan Palermo dan.palermo@amd.com