### PR TITLE
[NFC][testing] Prepare tests for implicit Flang GPU runtime

### DIFF
--- a/bin/run_genasis_flang_new.sh
+++ b/bin/run_genasis_flang_new.sh
@@ -110,10 +110,16 @@ if [[ "$USE_OPENMP_RUNTIME" -eq "1" ]] ; then
     OMP_DEFINES+=" -DUSE_OPENMP_RUNTIME"
 fi
 
+if [[ "$IMPLICIT_GPU_FLANG_RT" -eq "1" ]]; then
+    FORTRAN_OFFLOAD_LIB=
+else
+    FORTRAN_OFFLOAD_LIB=-lflang_rt.hostdevice
+fi
+
 export LD_LIBRARY_PATH=$AOMP/lib:$AOMPHIP/lib:$OPENMPI_DIR/lib:$LD_LIBRARY_PATH
 export FORTRAN_COMPILE="$AOMP/bin/$FLANG -c -fopenmp --offload-arch=$GPU_ID -fPIC -I$OPENMPI_DIR/lib -cpp $OMP_DEFINES -fstack-arrays"
 export CC_COMPILE="$AOMP/bin/clang -fPIC"
-export FORTDEV_LIBS=${FORTDEV_LIBS:-"-lflang_rt.hostdevice"}
+export FORTDEV_LIBS=${FORTDEV_LIBS:-"$FORTRAN_OFFLOAD_LIB"}
 export FORTHOST_LIBS=${FORTHOST_LIBS:-"-lflang_rt.runtime"}
 export OTHER_LIBS="-lm -L$AOMP/lib $FORTHOST_LIBS $FORTDEV_LIBS -lomp -lomptarget -z muldefs "
 export FORTRAN_LINK="$AOMP/bin/clang $OTHER_LIBS"

--- a/bin/run_umt.sh
+++ b/bin/run_umt.sh
@@ -152,6 +152,12 @@ if [ "$1" == "build_umt" ]; then
         exit $mystat
     fi
 
+    if [[ $IMPLICIT_GPU_FLANG_RT -eq 1 ]]; then
+        FORTRAN_OFFLOAD_LIB=
+    else
+        FORTRAN_OFFLOAD_LIB=$AOMP/lib/libflang_rt.hostdevice.a
+    fi
+
     rm -rf build
     mkdir build
     pushd build
@@ -162,7 +168,7 @@ if [ "$1" == "build_umt" ]; then
     -DUMPIRE_ROOT=$AOMP_REPOS_TEST/$UMPIRE_SRC_DIR/install \
     -DCAMP_ROOT=$AOMP_REPOS_TEST/$CAMP_SRC_DIR/install \
     -DCMAKE_C_COMPILER=$CC -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_Fortran_COMPILER=$FC \
-    -DCMAKE_FORTRAN_OFFLOAD_LIB=$AOMP/lib/libflang_rt.hostdevice.a \
+    -DCMAKE_FORTRAN_OFFLOAD_LIB=$FORTRAN_OFFLOAD_LIB \
     -DCMAKE_Fortran_LINKER_WRAPPER_FLAG="-Wl," \
     -DENABLE_CUDA=OFF \
     -DENABLE_OPENMP=ON -DOPENMP_HAS_FORTRAN_INTERFACE=ON \

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -353,6 +353,12 @@ ifeq ($(TEMPS),1)
   VERBOSE += -save-temps 
 endif
 
+ifeq ($(IMPLICIT_GPU_FLANG_RT),1)
+  FLANG_GPU_LINK_FLAGS =
+else
+  FLANG_GPU_LINK_FLAGS = -lflang_rt.hostdevice
+endif
+
 ifeq ($(NOOPT),1)
 CFLAGS =
 else

--- a/test/smoke-fort-dev/device_aassign/Makefile
+++ b/test/smoke-fort-dev/device_aassign/Makefile
@@ -6,7 +6,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/device_intrinsics/Makefile
+++ b/test/smoke-fort-dev/device_intrinsics/Makefile
@@ -11,7 +11,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fort-dev/flang-315421/Makefile
+++ b/test/smoke-fort-dev/flang-315421/Makefile
@@ -8,7 +8,7 @@ TESTSRC_ALL  =  $(TESTSRC_AUX) $(TESTSRC_MAIN)
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_FLAGS   += -DFAIL
 
 include ../Makefile.rules

--- a/test/smoke-fort-dev/flang-464660-2/Makefile
+++ b/test/smoke-fort-dev/flang-464660-2/Makefile
@@ -9,7 +9,7 @@ TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-OMP_FLAGS   += -lflang_rt.hostdevice
+OMP_FLAGS   += $(FLANG_GPU_LINK_FLAGS)
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fort-dev/flang-523626/Makefile
+++ b/test/smoke-fort-dev/flang-523626/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/flang-529628/Makefile
+++ b/test/smoke-fort-dev/flang-529628/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/rocm-issue-201/Makefile
+++ b/test/smoke-fort-dev/rocm-issue-201/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/target-cmplx4-div/Makefile
+++ b/test/smoke-fort-dev/target-cmplx4-div/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/target-cmplx8-div/Makefile
+++ b/test/smoke-fort-dev/target-cmplx8-div/Makefile
@@ -9,10 +9,9 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
-CFLAGS       = -lflang_rt.hostdevice
 #-ccc-print-phases
 #"-\#\#\#"
 

--- a/test/smoke-fort-dev/tgt-abort-lhostdev/Makefile
+++ b/test/smoke-fort-dev/tgt-abort-lhostdev/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/tgt-firstprivate/Makefile
+++ b/test/smoke-fort-dev/tgt-firstprivate/Makefile
@@ -7,7 +7,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/tgt-print-hello-lhostdev/Makefile
+++ b/test/smoke-fort-dev/tgt-print-hello-lhostdev/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/tgt-print-val-lhostdev/Makefile
+++ b/test/smoke-fort-dev/tgt-print-val-lhostdev/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/tgt-stop-lhostdev/Makefile
+++ b/test/smoke-fort-dev/tgt-stop-lhostdev/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-dev/tgt-write-lhostdev/Makefile
+++ b/test/smoke-fort-dev/tgt-write-lhostdev/Makefile
@@ -8,7 +8,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        ?= flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535320/Makefile
+++ b/test/smoke-fort-fails/flang-535320/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535416-O0/Makefile
+++ b/test/smoke-fort-fails/flang-535416-O0/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -O0 -lflang_rt.hostdevice
+CFLAGS       = -O0 $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535416-O2/Makefile
+++ b/test/smoke-fort-fails/flang-535416-O2/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -O2 -lflang_rt.hostdevice
+CFLAGS       = -O2 $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-537499/Makefile
+++ b/test/smoke-fort-fails/flang-537499/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -lflang_rt.hostdevice
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases


### PR DESCRIPTION
## Motivation

Add one switch which can control if we want to test AOMP Flang compiler with implicitly linked Flang GPU runtime.
Do not add -lflang_rt.hostdevice flag if IMPLICIT_GPU_FLANG_RT is set to 1.
