### PR TITLE
[smoke-fort][OpenMP] Add tests for GPU reductions on allocatables and static arrays

### DIFF
--- a/test/smoke-fort-dev/byref-reduction-scalar-allocatable/Makefile
+++ b/test/smoke-fort-dev/byref-reduction-scalar-allocatable/Makefile
@@ -1,0 +1,16 @@
+NOOPT        = 1
+include ../../Makefile.defs
+
+TESTNAME     = byref_reduction_scalar_allocatable
+TESTSRC_MAIN = byref_reduction_scalar_allocatable.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN)
+
+FLANG        ?= flang
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/byref-reduction-scalar-allocatable/byref_reduction_scalar_allocatable.f90
+++ b/test/smoke-fort-dev/byref-reduction-scalar-allocatable/byref_reduction_scalar_allocatable.f90
@@ -1,0 +1,35 @@
+program main
+  implicit none
+
+  real, allocatable :: scalar_alloc
+  integer :: i
+  real, parameter :: num_iters = 1000000
+
+  allocate(scalar_alloc)
+  scalar_alloc = 0
+
+  !$omp target map(tofrom: scalar_alloc)
+  call foo(scalar_alloc)
+  !$omp end target
+
+  print *, "result: ", scalar_alloc
+
+  if (scalar_alloc /= num_iters) then
+    print *, "Incorrect result! (actual): ", scalar_alloc, " vs. (expected): ", num_iters
+    stop 1
+  end if
+
+contains
+subroutine foo(scalar_alloc)
+  implicit none
+  integer :: i
+  real, allocatable, intent(inout) :: scalar_alloc
+
+  !$omp parallel do reduction(+: scalar_alloc)
+  do i = 1, num_iters
+    scalar_alloc = scalar_alloc + 1
+  end do
+end subroutine
+
+
+end program

--- a/test/smoke-fort-dev/byref-reduction-scalar-allocatable/byref_reduction_scalar_allocatable.f90
+++ b/test/smoke-fort-dev/byref-reduction-scalar-allocatable/byref_reduction_scalar_allocatable.f90
@@ -20,16 +20,14 @@ program main
   end if
 
 contains
-subroutine foo(scalar_alloc)
-  implicit none
-  integer :: i
-  real, allocatable, intent(inout) :: scalar_alloc
+  subroutine foo(scalar_alloc)
+    implicit none
+    integer :: i
+    real, allocatable, intent(inout) :: scalar_alloc
 
-  !$omp parallel do reduction(+: scalar_alloc)
-  do i = 1, num_iters
-    scalar_alloc = scalar_alloc + 1
-  end do
-end subroutine
-
-
+    !$omp parallel do reduction(+: scalar_alloc)
+    do i = 1, num_iters
+      scalar_alloc = scalar_alloc + 1
+    end do
+  end subroutine
 end program

--- a/test/smoke-fort-dev/byref-reduction-static-array/Makefile
+++ b/test/smoke-fort-dev/byref-reduction-static-array/Makefile
@@ -1,0 +1,16 @@
+NOOPT        = 1
+include ../../Makefile.defs
+
+TESTNAME     = byref_reduction_static_array
+TESTSRC_MAIN = byref_reduction_static_array.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN)
+
+FLANG        ?= flang
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/byref-reduction-static-array/byref_reduction_static_array.f90
+++ b/test/smoke-fort-dev/byref-reduction-static-array/byref_reduction_static_array.f90
@@ -1,0 +1,39 @@
+program main
+  implicit none
+
+  real, parameter :: num_iters = 1000000
+  integer, parameter :: arr_size = 10
+  real :: arr(arr_size)
+  real :: expected_arr(arr_size)
+  integer :: i
+
+  do i = 1, arr_size
+    arr(i) = i
+    expected_arr(i) = i + num_iters
+  end do
+
+  !$omp target map(tofrom: arr)
+  call foo(arr)
+  !$omp end target
+
+  print *, "result: ", arr
+
+  if (any(arr /= expected_arr)) then
+    print *, "Incorrect result! (actual): ", arr, " vs. (expected): ", expected_arr
+    stop 1
+  end if
+
+contains
+subroutine foo(arr)
+  implicit none
+  integer :: i
+  real, intent(inout) :: arr(arr_size)
+
+  !$omp parallel do reduction(+: arr)
+  do i = 1, num_iters
+    arr = arr + 1
+  end do
+end subroutine
+
+
+end program

--- a/test/smoke-fort-dev/byref-reduction-static-array/byref_reduction_static_array.f90
+++ b/test/smoke-fort-dev/byref-reduction-static-array/byref_reduction_static_array.f90
@@ -24,16 +24,14 @@ program main
   end if
 
 contains
-subroutine foo(arr)
-  implicit none
-  integer :: i
-  real, intent(inout) :: arr(arr_size)
+  subroutine foo(arr)
+    implicit none
+    integer :: i
+    real, intent(inout) :: arr(arr_size)
 
-  !$omp parallel do reduction(+: arr)
-  do i = 1, num_iters
-    arr = arr + 1
-  end do
-end subroutine
-
-
+    !$omp parallel do reduction(+: arr)
+    do i = 1, num_iters
+      arr = arr + 1
+    end do
+  end subroutine
 end program


### PR DESCRIPTION
Adds smoke tests for the changes introduced in upstream PR: https://github.com/llvm/llvm-project/pull/165714. These tests cannot be added as offloading tests upstream (yet) since they need to link wit h flang's device RT lib.