### PR TITLE
[omptests] Output git log info

### DIFF
--- a/bin/run_omptests.sh
+++ b/bin/run_omptests.sh
@@ -53,6 +53,11 @@ fi
 
 log=$(date --iso-8601=minutes).log
 
+# Show latest git commit
+echo ""
+git show -s
+echo ""
+
 echo "env DEVICE_TYPE=amd DEVICE_TARGET=$DEVICE_TARGET DEVICE_ARCH=$DEVICE_ARCH HOSTRTL=$AOMP/lib/libdevice TARGETRTL=$AOMP/lib GLOMPRTL=$AOMP/lib LLVMBIN=$AOMP/bin make -i"
 
 env DEVICE_TYPE=amd DEVICE_TARGET="$DEVICE_TARGET" DEVICE_ARCH="$DEVICE_ARCH" HOSTRTL="$AOMP/lib/libdevice" \

--- a/bin/run_omptests.sh
+++ b/bin/run_omptests.sh
@@ -54,9 +54,7 @@ fi
 log=$(date --iso-8601=minutes).log
 
 # Show latest git commit
-echo ""
-git show -s
-echo ""
+echo -e "\n$(git show -s)\n"
 
 echo "env DEVICE_TYPE=amd DEVICE_TARGET=$DEVICE_TARGET DEVICE_ARCH=$DEVICE_ARCH HOSTRTL=$AOMP/lib/libdevice TARGETRTL=$AOMP/lib GLOMPRTL=$AOMP/lib LLVMBIN=$AOMP/bin make -i"
 


### PR DESCRIPTION
Show the current commit in the repo. This is mostly such that a log file does contain the info which commit was used in the run.