### PR TITLE
Fixes OpenMP examples to correctly determine XNACK capable GPUs

### DIFF
--- a/examples/inc/find_gpu_and_install_dir.mk
+++ b/examples/inc/find_gpu_and_install_dir.mk
@@ -70,6 +70,23 @@ else
   LLVM_GPU_TRIPLE = amdgcn-amd-amdhsa
 endif
 
+_supports_xnack= gfx90a, gfx90a:xnack+,\
+              gfx90c, gfx90c:xnack+,\
+              gfx940, gfx940:xnack+,\
+              gfx941, gfx941:xnack+,\
+              gfx942, gfx942:xnack+,\
+              gfx950, gfx950:xnack+,\
+              gfx1010, gfx1010:xnack+\
+              gfx1011, gfx1011:xnack+\
+              gfx1012, gfx1012:xnack+\
+              gfx1013, gfx1013:xnack+
+
+ifeq ($(findstring $(LLVM_GPU_ARCH), $(_supports_xnack)),)
+  LLVM_GPU_IS_XNACKABLE=0
+else
+  LLVM_GPU_IS_XNACKABLE=1
+endif
+
 # Find where HIP is installed and set HIPDIR and HIPCC
 HIPDIR ?= $(LLVM_INSTALL_DIR)
 ifeq ("$(wildcard $(HIPDIR)/bin/hipcc)","")

--- a/examples/openmp/demo_offload_types/Makefile
+++ b/examples/openmp/demo_offload_types/Makefile
@@ -41,7 +41,7 @@ else
 endif
 	@echo "3. Create binary that does GPU offload:	gpu-offload"
 	$(CC) $(CFLAGS) $(OAFLAG) $^ -o gpu-offload 
-ifneq (sm_,$(findstring sm_,$(LLVM_GPU_ARCH)))
+ifeq ($(LLVM_GPU_IS_XNACKABLE),1)
 	@echo "4. Create binary for GPU offload compiled with :xnack+"
 	@echo "   The image will require HSA_XNACK=1 at runtime."
 	$(CC) $(CFLAGS) $(OAQFLAG) $^ -o $(TESTNAME)
@@ -61,7 +61,7 @@ else
 endif
 	@echo "3. gpu-offload"
 	./gpu-offload
-ifneq (sm_,$(findstring sm_,$(LLVM_GPU_ARCH)))
+ifeq ($(LLVM_GPU_IS_XNACKABLE),1)
 	@echo "4. GPU offload compiled with :xnack+,  Runtime fail will disable offloading."
 ifeq ($(LLVM_COMPILER_NAME),AMD)
 	@echo "   SKIPPING SINCE ROCm 6.1 has runtime fail here:  env HSA_XNACK=0 ./$(TESTNAME) "
@@ -84,7 +84,7 @@ ifneq ($(LLVM_COMPILER_NAME),clang)
 endif
 	@echo "3. gpu-offload"
 	env OMP_TARGET_OFFLOAD=DISABLED ./gpu-offload
-ifneq (sm_,$(findstring sm_,$(LLVM_GPU_ARCH)))
+ifeq ($(LLVM_GPU_IS_XNACKABLE),1)
 	@echo "4. GPU offload compiled with :xnack+ but run with HSA_XNACK=0"
 	env OMP_TARGET_OFFLOAD=DISABLED HSA_XNACK=0 ./$(TESTNAME) 
 	@echo "5. GPU offload compiled with :xnack+"
@@ -99,7 +99,7 @@ ifneq ($(LLVM_COMPILER_NAME),clang)
 endif
 	@echo "3. GPU offload"
 	env OMP_TARGET_OFFLOAD=MANDATORY ./gpu-offload
-ifneq (sm_,$(findstring sm_,$(LLVM_GPU_ARCH)))
+ifeq ($(LLVM_GPU_IS_XNACKABLE),1)
 	@echo "4. SKIPPING execution of binary compiled with xnack+ with OMP_TARGET_OFFLOAD=MANDATORY"
 	@echo "   and run with HSA_XNACK=0 because this always creates expected fatal runtime error."
 	@echo "5. GPU offload compiled with :xnack+ and run with HSA_XNACK=1"


### PR DESCRIPTION
Adds logic to find_gpu_and_install_dir to set new environment variable LLVM_GPU_IS_XNACKABLE. Changes logic in demo_offload_types test to use variable instead of checking GPU for "sm_" string.

 