### PR TITLE
[CK] Fix CMake generator string

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -256,15 +256,12 @@ elif [ "${ShouldUpdateCKRepo}" == 'yes' ]; then
   popd
 fi
 
-if ! command -v ninja >/dev/null ; then
-  echo "Ninja not found, falling back to make"
-  CmakeGenerator="Unix Makefiles"
-else
-  CmakeGenerator="Ninja"
+if command -v ninja >/dev/null ; then
+  CmakeGenerator="-GNinja"
 fi
 
 # TODO Fix / Finalize the cmake command
-CKCmakeCmd="cmake -G${CmakeGenerator} -B ${CK_BUILD} -S ${CK_REPO} -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DCMAKE_INSTALL_PREFIX=${CK_INSTALL} "
+CKCmakeCmd="cmake ${CmakeGenerator} -B ${CK_BUILD} -S ${CK_REPO} -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DCMAKE_INSTALL_PREFIX=${CK_INSTALL} "
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ -DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "
 CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=${CK_GPU_TARGETS} "
 # For some reason, CK on gfx12 wants this set.
@@ -410,7 +407,7 @@ fi
 # Handle CK client examples
 if [ "${SelectedSuite}" == 'client-examples' ]; then
   # Configure and build the client examples
-  CKCmakeCmd="cmake -G ${CmakeGenerator} "
+  CKCmakeCmd="cmake ${CmakeGenerator} "
   CKCmakeCmd+="-B ${CK_CLIENT_EXAMPLES_BUILD} -S ${CK_CLIENT_EXAMPLES_SOURCE} "
   CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ "
   CKCmakeCmd+="-DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "


### PR DESCRIPTION
In https://github.com/ROCm/aomp/pull/1727 I did not get the escaping of \" right. This PR will simply use CMake defaul (Unix Makefiles) when ninja is not present and explicitly specify ninja when it is available.