### PR TITLE
[calculate_divergence.sh] removes default component "driver"

### DIFF
--- a/bin/calculate_divergence.sh
+++ b/bin/calculate_divergence.sh
@@ -38,7 +38,7 @@ declare -A directories=(
 )
 
 declare -A diff_args=(
-    [component]=${COMPONENT:="driver"}
+    [component]=${COMPONENT:=""}
     [options]="stat patch"
 )
 


### PR DESCRIPTION
Removes default component "driver" accidentally commited from testing. 
Allows the script to default run on entiry llvm-project directory.
