### PR TITLE
Support for per-target Fortran modules

### DIFF
--- a/bin/build_project.sh
+++ b/bin/build_project.sh
@@ -155,7 +155,9 @@ MYCMAKEOPTS=(-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 if [ -f "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/CMakeLists.txt" ]; then
   MYCMAKEOPTS=("${MYCMAKEOPTS[@]}"
                -DLLVM_RUNTIME_TARGETS='default;amdgcn-amd-amdhsa'
-               -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES='openmp'
+               -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES='flang-rt;openmp'
+               -DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_ENABLE_STATIC=OFF
+               -DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_ENABLE_SHARED=OFF
                -DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON)
 fi
 


### PR DESCRIPTION
Adapt the aomp build to https://github.com/llvm/llvm-project/pull/169638 / https://github.com/ROCm/llvm-project/pull/679

The upstream change requires the Flang module files to be built per-target by flang-rt, including for amdgcn-amd-amdhsa. This change adds 'flang-rt' to the LLVM_ENABLE_RUNTIMES for amdgcn-amd-amdhsa to build the modules. The already present runtime 'openmp' will build omp_lib.mod for amdgcn-amd-amdhsa.

This PR does not change `build_openmp.sh`: Building the .mod files needs to be done only once. The script sets `LIBOMP_FORTRAN_MODULES_COMPILER` which is the old mechanism to build omp_lib.h. It will just do nothing and can be cleaned up later.