### PR TITLE
Run rocm test therock support

### DIFF
--- a/bin/aomp_common_vars
+++ b/bin/aomp_common_vars
@@ -40,13 +40,13 @@ AOMP=${AOMP:-$HOME/rocm/aomp}
 AOMP_INSTALL_DIR=${AOMP}_${AOMP_VERSION_STRING}
 
 GPURUN_BINDIR=${GPURUN_BINDIR:-$AOMP/bin}
-if [ ! -f "$GPURUN_BINDIR/gpurun" ] || [ ! -f "$GPURUN_BINDIR/rocminfo" ] ; then
+if [ ! -f "$GPURUN_BINDIR/gpurun" ] ; then
     # When using trunk, try to find gpurun and rocminfo in ROCm
     _SILENT=""
     GPURUN_BINDIR=/opt/rocm/llvm/bin
-    export ROCMINFO_BINARY=/opt/rocm/bin/rocminfo
-else
-    export ROCMINFO_BINARY=$GPURUN_BINDIR/rocminfo
+fi
+if [ ! -f "$AOMP/bin/rocminfo" ] ; then
+  export ROCMINFO_BINARY=/opt/rocm/bin/rocminfo
 fi
 
 # For example, if AOMP_REPOS=$HOME/git/aomp11, then the primary aomp repo

--- a/bin/run_accel2023.sh
+++ b/bin/run_accel2023.sh
@@ -35,6 +35,6 @@ if [ "$1" == "-clean" ]; then
 else
   cd ${ACCEL2023_SOURCE_DIR} || exit 1
 fi
-export PATH=$AOMP/../bin:$AOMP/../../bin:$AOMP/lib/llvm/bin:$PATH
+export PATH=$HOME/openmp-utils/bin:$AOMP/../bin:$AOMP/../../bin:$AOMP/lib/llvm/bin:$PATH
 ./runOne
 #grep ratio= result/*.log

--- a/bin/run_hpc2021.sh
+++ b/bin/run_hpc2021.sh
@@ -38,7 +38,7 @@ if [ "$1" == "-clean" ]; then
 else
   cd ${HPC2021_SOURCE_DIR} || exit 1
 fi
-export PATH=$AOMP/../bin:$AOMP/../../bin:$PATH
+export PATH=$HOME/openmp-utils/bin:$AOMP/../bin:$AOMP/../../bin:$PATH
 export MPI=$INST
 ./runOne
 rm -rf $INST

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -7,6 +7,7 @@
 realpath=`realpath $0`
 thisdir=`dirname $realpath`
 export AOMP_USE_CCACHE=0
+
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_nekbone.sh
+++ b/bin/run_nekbone.sh
@@ -7,7 +7,6 @@
 realpath=`realpath $0`
 thisdir=`dirname $realpath`
 export AOMP_USE_CCACHE=0
-
 . $thisdir/aomp_common_vars
 # --- end standard header ----
 

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -65,13 +65,15 @@ if [ $ISVIRT -eq 1 ] ; then
   # run on configurations that do not support USM.
   export OMPX_STRICT_SANITY_CHECKS={OMPX_STRICT_SANITY_CHECKS:-1}
 
-SUITE_LIST=${SUITE_LIST:-"examples smoke-limbo smoke smoke-asan smoke-fort smoke-fort-limbo omp5 openmpapps ovo babelstream fortran-babelstream accel2023 hpc2021"}
+  SUITE_LIST=${SUITE_LIST:-"examples smoke-limbo smoke smoke-asan smoke-fort smoke-fort-limbo omp5 openmpapps ovo babelstream fortran-babelstream accel2023 hpc2021"}
 else
-SUITE_LIST=${SUITE_LIST:-"examples smoke-limbo smoke-dev smoke-fort-dev smoke smoke-asan smoke-fort smoke-fort-limbo omp5 openmpapps LLNL nekbone ovo babelstream fortran-babelstream accel2023 hpc2021"}
+  SUITE_LIST=${SUITE_LIST:-"examples smoke-limbo smoke-dev smoke-fort-dev smoke smoke-asan smoke-fort smoke-fort-limbo omp5 openmpapps LLNL nekbone ovo babelstream fortran-babelstream accel2023 hpc2021"}
 fi
+
 blockinglist="examples smoke smoke-limbo openmpapps sollve45 sollve50 sollve51 sollve52 babelstream ovo accel2023 hpc2021 nekbone smoke-fort smoke-fort-limbo"
 
 EPSDB_LIST=${EPSDB_LIST:-"examples smoke-limbo smoke-dev smoke smoke-asan omp5 openmpapps LLNL nekbone ovo babelstream fortran-babelstream accel2023 hpc2021  smoke-fort smoke-fort-limbo smoke-fort-dev"}
+THEROCK_LIST=${THEROCK_LIST:-"smoke smoke-fort accel2023"}
 
 export AOMP_USE_CCACHE=0
 
@@ -138,6 +140,23 @@ export AOMP
 echo "AOMP = $AOMP"
 export REAL_AOMP=`realpath $AOMP`
 
+# Determine ROCm version.
+echo ROCMINF=$ROCMINF
+rocm=$(cat "$ROCMINF"/.info/version*|head -1)
+rocmregex="([0-9]+\.[0-9]+\.[0-9]+)"
+if [[ "$rocm" =~ $rocmregex ]]; then
+  rocmver=$(echo ${BASH_REMATCH[1]} | sed "s/\.//g")
+  echo rocmver: $rocmver
+  therock=0
+  if [ "$rocmver" -ge "7100" ]; then
+    echo "--- Using TheRock Compiler ---"
+    therock=1
+  fi
+else
+  echo Unable to determine rocm version.
+  exit 1
+fi
+
 function extract_rpm(){
   local test_package=$1
   cd $tmpdir
@@ -172,7 +191,7 @@ if [ "$aomp" != 1 ]; then
   os_name=$(cat /etc/os-release | grep NAME)
   test_package_name="openmp-extras-tests"
 
-  if [ "$SKIP_TEST_PACKAGE" != 1 ] && [ "$TEST_BRANCH" == "" ]; then
+  if [ $therock -eq 0 ] && [ "$SKIP_TEST_PACKAGE" != 1 ] && [ "$TEST_BRANCH" == "" ]; then
     rm -rf $tmpdir
     mkdir -p $tmpdir
     export debsupport=0
@@ -379,30 +398,18 @@ function getversion(){
   versions[543]=5.4.3
   versions[550]=5.5.0
 
-  if [ $aomp -eq 1 ]; then
-    echo "AOMP detected at $AOMP, skipping ROCm version detections"
+  if [ $aomp -eq 1 ] || [ $therock -eq 1 ]; then
     maxvers=`echo $supportedvers | grep -o "[0-9].[0-9].[0-9]$" | sed -e 's/\.//g'`
     versionregex="(.*${versions[$maxvers]})"
     if [[ "$supportedvers" =~ $versionregex ]]; then
       finalvers=${BASH_REMATCH[1]}
     else
-      echo "AOMP - Cannot select proper version list."
+      echo "Error: Cannot select proper version list."
       exit 1
     fi
+    echo "AOMP or TheRock detected at $AOMP, skipping ROCm version detections"
     echo "Selecting highest supported version: ${versions[$maxvers]}"
   else
-    # Determine ROCm version.
-    echo ROCMINF=$ROCMINF
-    rocm=$(cat "$ROCMINF"/.info/version*|head -1)
-    rocmregex="([0-9]+\.[0-9]+\.[0-9]+)"
-    if [[ "$rocm" =~ $rocmregex ]]; then
-      rocmver=$(echo ${BASH_REMATCH[1]} | sed "s/\.//g")
-      echo rocmver: $rocmver
-    else
-      echo Unable to determine rocm version.
-      exit 1
-    fi
-
     # Determine OS flavor to properly query openmp-extras version.
     osname=$(cat /etc/os-release | grep -e ^NAME=)
     # Regex to cover single/multi version installs for deb/rpm.
@@ -466,6 +473,7 @@ function getversion(){
     fi
   fi
 }
+
 function notAllMustPass() {
   #if [ "$1" != "smoke" ] && [ "$1" != "smoke-limbo" ] &&  [ "$1" != "smoke-fort" ] && [ "$1" != "smoke-fort-limbo" ]; then
   if [ "$1" != "smoke" ] && [ "$1" != "smoke-limbo" ] && [ "$1" != "smoke-fort" ] && [ "$1" != "examples_openmp" ] && [ "$1" != "examples_fortran" ]; then
@@ -1068,7 +1076,9 @@ rm -rf $resultsdir
 mkdir -p $resultsdir
 
 # Run Tests
-if [ "$EPSDB" == "1" ]; then
+if [ $therock -eq 1 ]; then
+  SUITE_LIST="$THEROCK_LIST"
+elif [ "$EPSDB" == "1" ]; then
   SUITE_LIST="$EPSDB_LIST"
 fi
 echo Running List: $SUITE_LIST

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -140,22 +140,30 @@ export AOMP
 echo "AOMP = $AOMP"
 export REAL_AOMP=`realpath $AOMP`
 
-# Determine ROCm version.
-echo ROCMINF=$ROCMINF
-rocm=$(cat "$ROCMINF"/.info/version*|head -1)
-rocmregex="([0-9]+\.[0-9]+\.[0-9]+)"
-therock=0
-rocmver=0
-if [[ "$rocm" =~ $rocmregex ]]; then
-  rocmver=$(echo ${BASH_REMATCH[1]} | sed "s/\.//g")
-  echo rocmver: $rocmver
-  if [ $rocmver -ge 7100 ]; then
-    echo "--- Using TheRock Compiler ---"
-    therock=1
+clangversion=`$AOMP/bin/clang --version`
+aomp=0
+if [[ "$clangversion" =~ "AOMP_STANDALONE" ]]; then
+  aomp=1
+fi
+
+if [ $aomp -eq 0 ]; then
+  # Determine ROCm version.
+  echo ROCMINF=$ROCMINF
+  rocm=$(cat "$ROCMINF"/.info/version*|head -1)
+  rocmregex="([0-9]+\.[0-9]+\.[0-9]+)"
+  therock=0
+  rocmver=0
+  if [[ "$rocm" =~ $rocmregex ]]; then
+    rocmver=$(echo ${BASH_REMATCH[1]} | sed "s/\.//g")
+    echo rocmver: $rocmver
+    if [ $rocmver -ge 7100 ]; then
+      echo "--- Using TheRock Compiler ---"
+      therock=1
+    fi
+  else
+    echo Unable to determine rocm version.
+    exit 1
   fi
-else
-  echo Unable to determine rocm version.
-  exit 1
 fi
 
 function extract_rpm(){
@@ -178,12 +186,6 @@ if [[ $REAL_AOMP =~ "/opt/rocm-6.0" ]] || [[ $REAL_AOMP =~ "/opt/rocm-6.1" ]]; t
   sleep 5
   ./run_rocm_test.sh
   exit $?
-fi
-
-clangversion=`$AOMP/bin/clang --version`
-aomp=0
-if [[ "$clangversion" =~ "AOMP_STANDALONE" ]]; then
-  aomp=1
 fi
 
 # Support for using openmp-extras-tests package.

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -62,12 +62,12 @@ fi
 blockinglist="examples smoke smoke-limbo openmpapps sollve45 sollve50 sollve51 sollve52 babelstream ovo accel2023 hpc2021 nekbone smoke-fort smoke-fort-limbo"
 
 EPSDB_LIST=${EPSDB_LIST:-"examples smoke-limbo smoke-dev smoke smoke-asan omp5 openmpapps LLNL nekbone ovo babelstream fortran-babelstream accel2023 hpc2021  smoke-fort smoke-fort-limbo smoke-fort-dev"}
-THEROCK_LIST=${THEROCK_LIST:-"smoke smoke-fort accel2023"}
+THEROCK_LIST=${THEROCK_LIST:-"smoke smoke-fort nekbone babelstream fortran-babelstream accel2023 hpc2021"}
 
 export AOMP_USE_CCACHE=0
 
-echo $SUITE_LIST
-echo $blockinglist
+echo Initial SUITE_LIST: $SUITE_LIST
+echo Blocking List: $blockinglist
 
 # Use bogus path to avoid using target.lst, a user-defined target list
 # used by rocm_agent_enumerator.
@@ -142,10 +142,25 @@ fi
 export SKIP_USM=$SKIP_USM
 
 # Download FileCheck if not present
+mkdir -p "$HOME/openmp-utils/bin"
 if [ ! -f "$AOMP/bin/FileCheck" ]; then
-  wget -P $HOME Fileheck https://compute-artifactory.amd.com/artifactory/rocm-generic-local/compiler-infra/FileCheck
+  rm -f "$HOME/openmp-utils/bin/FileCheck"
+  if ! wget -P "$HOME/openmp-utils/bin" https://compute-artifactory.amd.com/artifactory/rocm-generic-local/compiler-infra/FileCheck ; then
+    echo "Error: Could not download FileCheck"
+    exit 1
+  fi
+  chmod 755 "$HOME/openmp-utils/bin/FileCheck"
 fi
 
+if [ ! -f "$AOMP/bin/gpurun" ]; then
+  rm -f "$HOME/openmp-utils/bin/gpurun"
+  if ! wget -P "$HOME/openmp-utils/bin" https://compute-artifactory.amd.com/artifactory/rocm-generic-local/compiler-infra/gpurun ; then
+    echo "Error: Could not download gpurun"
+    exit 1
+  fi
+  chmod 755 "$HOME/openmp-utils/bin/gpurun"
+  export GPURUN_BINDIR="$HOME/openmp-utils/bin"
+fi
 clangversion=`$AOMP/bin/clang --version`
 aomp=0
 if [[ "$clangversion" =~ "AOMP_STANDALONE" ]]; then
@@ -180,19 +195,32 @@ function extract_rpm(){
   cd $(dirname $script)
 }
 
-# Keep support for older release testing that will not have release branch
-# updated. From 6.2 onwards the openmp-extras-tests package will be used for testing.
-if [[ $REAL_AOMP =~ "/opt/rocm-6.0" ]] || [[ $REAL_AOMP =~ "/opt/rocm-6.1" ]]; then
-  if [ "$TEST_BRANCH" == "" ]; then
-    git reset --hard
-    export TEST_BRANCH="aomp-test-6.0-6.1"
-    git checkout 080e9bc62ad8501defc4ec9124c90e28a1f749db
-  fi
-  echo "+++ Using $TEST_BRANCH +++"
-  sleep 5
-  ./run_rocm_test.sh
-  exit $?
-fi
+#if [ $therock -eq 1 ] && [ "$EPSDB" != "1"  ] ; then
+#  if [ "$TEST_BRANCH" == "" ]; then
+#    if ! aomprev=$(grep -Po "OPENMP_TEST_REVISION \K\w+" "$AOMP/include/llvm/Config/llvm-config.h"); then
+#      echo "Error: Cannot determine aomp revision from llvm-config.h"
+#      exit 1
+#    else
+#      echo "Using aomp hash: $aomprev"
+#    fi
+
+    #if ! git checkout $aomprev ; then
+    #  if ! git stash
+    #    git reset --hard
+    #  fi
+    #  if ! git checkout $aomprev; then
+    #    echo "Fatal Error: Cannot checkout $aomprev for aomp."
+#      exit 1
+#      fi
+#    fi
+#    export TEST_BRANCH=$aomprev
+#  fi
+#  echo "+++ Using $TEST_BRANCH +++"
+#  sleep 5
+#  ./run_rocm_test.sh
+#  exit $?
+#fi
+
 
 # Support for using openmp-extras-tests package.
 if [ "$aomp" != 1 ]; then
@@ -848,7 +876,7 @@ function smoke-fort(){
   if [ "$SMOKE_FORT" == "1" ]; then
     mkdir -p "$resultsdir"/smoke-fort
     cd "$aompdir"/test/smoke-fort
-    ./check_smoke_fort.sh
+    AOMP_PARALLEL_SMOKE=1 ./check_smoke_fort.sh
     checkrc $?
     copyresults smoke-fort "$aompdir"/test/smoke-fort
   else

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -144,11 +144,12 @@ export REAL_AOMP=`realpath $AOMP`
 echo ROCMINF=$ROCMINF
 rocm=$(cat "$ROCMINF"/.info/version*|head -1)
 rocmregex="([0-9]+\.[0-9]+\.[0-9]+)"
+therock=0
+rocmver=0
 if [[ "$rocm" =~ $rocmregex ]]; then
   rocmver=$(echo ${BASH_REMATCH[1]} | sed "s/\.//g")
   echo rocmver: $rocmver
-  therock=0
-  if [ "$rocmver" -ge "7100" ]; then
+  if [ $rocmver -ge 7100 ]; then
     echo "--- Using TheRock Compiler ---"
     therock=1
   fi

--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -20,18 +20,7 @@ export CLEANUP=0
 
 # whats the OS ?
 cat /etc/os-release
-rocm-smi
-rocminfo
 
-# Export SKIP_USM=1 if xnack can not be turned ON, even with HSA_XNACK=1.
-# Makefile.defs uses SKIP_USM env var to disable compilation and execution
-# of the tests which require USM support.
-SKIP_USM=0
-XNACK_PLUS=$(HSA_XNACK=1 rocminfo | grep -i "xnack+" | wc -l)
-if [ $XNACK_PLUS -eq 0 ]; then
-  SKIP_USM=1
-fi
-export SKIP_USM=$SKIP_USM
 
 if [ -e /usr/sbin/lspci ]; then
   lspci_loc=/usr/sbin/lspci
@@ -114,13 +103,13 @@ fi
 # Set AOMP to point to rocm symlink or newest version.
 if [ -e /opt/rocm/lib/llvm/bin ]; then
   AOMP=${AOMP:-"/opt/rocm/lib/llvm"}
-  ROCMINF=/opt/rocm
-  ROCMDIR=/opt/rocm/lib
+  ROCMINF="$AOMP/../../"
+  ROCMDIR="$AOMP/../../"
   echo setting 1 $AOMP
 elif [ -e /opt/rocm/llvm/bin ]; then
   AOMP=${AOMP:-"/opt/rocm/llvm"}
-  ROCMINF=/opt/rocm
-  ROCMDIR=/opt/rocm
+  ROCMINF="$AOMP/../"
+  ROCMDIR="$AOMP/../"
   echo setting 2 $AOMP
 else
   newestrocm=$(ls --sort=time /opt | grep -m 1 rocm)
@@ -139,6 +128,23 @@ fi
 export AOMP
 echo "AOMP = $AOMP"
 export REAL_AOMP=`realpath $AOMP`
+"$ROCMINF/bin/rocm-smi"
+"$ROCMINF/bin/rocminfo"
+
+# Export SKIP_USM=1 if xnack can not be turned ON, even with HSA_XNACK=1.
+# Makefile.defs uses SKIP_USM env var to disable compilation and execution
+# of the tests which require USM support.
+SKIP_USM=0
+XNACK_PLUS=$(HSA_XNACK=1 "$ROCMINFO/binrocminfo" | grep -i "xnack+" | wc -l)
+if [ $XNACK_PLUS -eq 0 ]; then
+  SKIP_USM=1
+fi
+export SKIP_USM=$SKIP_USM
+
+# Download FileCheck if not present
+if [ ! -f "$AOMP/bin/FileCheck" ]; then
+  wget -P $HOME Fileheck https://compute-artifactory.amd.com/artifactory/rocm-generic-local/compiler-infra/FileCheck
+fi
 
 clangversion=`$AOMP/bin/clang --version`
 aomp=0

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -107,8 +107,7 @@ endif
 FILECHECK=$(AOMP)/bin/FileCheck
 FILECHECK_RT=$(shell ls $(FILECHECK) 2>/dev/null || echo error)
 ifeq ($(FILECHECK_RT),error)
-TESTPACKAGE_BINDIR=$(shell find $(HOME)/tmp/openmp-extras -type f -name 'aomp_common_vars' | xargs dirname)
-FILECHECK=$(TESTPACKAGE_BINDIR)/FileCheck
+FILECHECK=$(HOME)/FileCheck
 FILECHECK_RT=$(shell ls $(FILECHECK) 2>/dev/null || echo error)
 endif
 ifeq ($(FILECHECK_RT),error)

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -107,7 +107,7 @@ endif
 FILECHECK=$(AOMP)/bin/FileCheck
 FILECHECK_RT=$(shell ls $(FILECHECK) 2>/dev/null || echo error)
 ifeq ($(FILECHECK_RT),error)
-FILECHECK=$(HOME)/FileCheck
+FILECHECK=$(HOME)/openmp-utils/bin/FileCheck
 FILECHECK_RT=$(shell ls $(FILECHECK) 2>/dev/null || echo error)
 endif
 ifeq ($(FILECHECK_RT),error)

--- a/test/smoke/clang-392854/Makefile
+++ b/test/smoke/clang-392854/Makefile
@@ -4,9 +4,10 @@ TESTNAME     = clang-392854
 TESTSRC_MAIN = clang-392854.cpp
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RPTH = -Wl,-rpath,$(AOMPHIP)/lib
 
 CLANG        = amdclang++
-OMP_FLAGS    = -fopenmp -x hip
+OMP_FLAGS    = -fopenmp -x hip $(RPTH)
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = HIPCC_VERBOSE=1 $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke/libgomp-292348/Makefile
+++ b/test/smoke/libgomp-292348/Makefile
@@ -4,9 +4,10 @@ TESTNAME     = libgomp-292348
 TESTSRC_MAIN = libgomp-292348.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+RPTH = -Wl,-rpath,$(AOMPHIP)/lib
 
 CLANG        ?= hipcc
-OMP_FLAGS    = -lgomp
+OMP_FLAGS    = -lgomp $(RPTH)
 CFLAGS      = -g -O0 -m64 -fopenmp -lgomp -lstdc++
 
 ifeq ($(EPSDB),1)


### PR DESCRIPTION
- Does not look for test package if ROCm version >= 7.10
- Downloads FileCheck and gpurun if not present in compiler bin directory
- Add `AOMP_PARALLEL_SMOKE` to smoke-fort
- Add rpath to clang-392854, libgomp-292348 smoke tests