### PR TITLE
[smoke-fort-fails] Added test case for flang-535416

### DIFF
--- a/test/smoke-fort-fails/flang-535416-private/Makefile
+++ b/test/smoke-fort-fails/flang-535416-private/Makefile
@@ -1,0 +1,20 @@
+#NOOPT        = 1
+#NOOMP        = 1
+#OMP_FLAGS    = -DNO_OMP
+include ../../Makefile.defs
+
+TESTNAME     = test
+TESTSRC_MAIN = test.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        = flang
+CFLAGS       = -O0
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+RUNENV       = HSA_XNACK=1
+
+include ../Makefile.rules

--- a/test/smoke-fort-fails/flang-535416-private/test.f90
+++ b/test/smoke-fort-fails/flang-535416-private/test.f90
@@ -1,0 +1,34 @@
+MODULE rep2
+    implicit none
+    public :: nvars
+
+    INTEGER :: nvars = 5
+END MODULE
+
+MODULE rep
+
+    use rep2, ONLY:nvars
+    implicit none
+
+    public :: foo
+
+  contains
+
+  SUBROUTINE foo()
+    implicit none
+    INTEGER :: i
+    REAL(KIND=8) :: mm(5)
+    !$omp target teams distribute parallel do private(mm)
+    DO i =1,nvars
+       mm(i) = 2.0_8
+    END DO
+    WRITE(*,*) "success"
+    END SUBROUTINE
+END MODULE
+
+PROGRAM rep_arraysyntax
+    use :: rep, ONLY:foo
+    implicit none
+    CALL foo()
+
+END PROGRAM


### PR DESCRIPTION
It's legal OpenMP kernel and it should execute without segfault.

