### PR TITLE
Added flang-offload-disabled-env test for verifying `omp_get_default_device()` behavior 

### DIFF
--- a/test/smoke-fort-dev/flang-offload-disabled-env/Makefile
+++ b/test/smoke-fort-dev/flang-offload-disabled-env/Makefile
@@ -1,0 +1,18 @@
+NOOPT        = 1
+include ../../Makefile.defs
+
+TESTNAME     = getInitDevice
+TESTSRC_MAIN = getInitDevice.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+CFLAGS       =
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+RUNCMD       = ./doit.sh ${TESTNAME}
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/flang-offload-disabled-env/doit.sh
+++ b/test/smoke-fort-dev/flang-offload-disabled-env/doit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Test with OMP_DEFAULT_DEVICE=2 and OMP_TARGET_OFFLOAD=DISABLED
+# Before the fix, this would crash with "device number '2' out of range"
+# After the fix, omp_get_default_device() should return 0 (the initial device)
+export OMP_DEFAULT_DEVICE=2
+export OMP_TARGET_OFFLOAD=DISABLED
+./$1
+
+

--- a/test/smoke-fort-dev/flang-offload-disabled-env/getInitDevice.f90
+++ b/test/smoke-fort-dev/flang-offload-disabled-env/getInitDevice.f90
@@ -1,0 +1,30 @@
+       program test_offload_disabled_env
+       use omp_lib
+       integer num, initial_dev
+       
+       ! Test that omp_get_default_device returns the initial device
+       ! when OMP_TARGET_OFFLOAD=DISABLED, even when OMP_DEFAULT_DEVICE=2
+       
+       ! Get initial device (should be 0 when offload is disabled)
+       initial_dev = omp_get_initial_device()
+       print *, 'initial device =', initial_dev
+       
+       ! Get default device (should also be 0, not 2, when offload is disabled)
+       num = omp_get_default_device()
+       print *, 'default device =', num
+       
+       ! Call from within target region
+       !$OMP TARGET
+       num = omp_get_default_device()
+       !$OMP END TARGET
+       print *, 'default device from target =', num
+       
+       ! Verify they match
+       if (num .eq. initial_dev) then
+           print *, 'PASS: default device equals initial device'
+       else
+           print *, 'FAIL: default device does not equal initial device'
+           call exit(1)
+       end if
+       
+       end


### PR DESCRIPTION
Test added to check the working of `omp_get_default_device` behaviour upon being incorrectly set by  `OMP_DEFAULT_DEVICE`

**Test configuration**:
- Sets `OMP_DEFAULT_DEVICE=2`
- Sets `OMP_TARGET_OFFLOAD=DISABLED`
- Calls `omp_get_default_device()` from host and target regions
- Verifies returned device = initial device