### PR TITLE
[CK] Add flag to enable library-only build

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -20,6 +20,7 @@ function printHelp {
   echo "Usage: run_composable-kernels.sh"
   echo "  -h: Show this help message"
   echo "  -i: Install the (incremental) CK build"
+  echo "  -l: Library-only build (no examples or tests)"
   echo "  -r: Rebuild the CK repo"
   echo "  -u: Update the CK repo"
   echo "  -b: Update the CK benchmarks repo"
@@ -118,6 +119,8 @@ function getLDLibraryPathExportCmd {
 
 # Some tests may require an installed instance of CK.
 ShouldInstallCK='no'
+# It my be desired to build the CK library only, without any examples or tests.
+ShouldBuildLibraryOnly='no'
 # For some situations during testing it may not be desired to rebuild the CK repo.
 ShouldRebuildCK='no'
 # While doing perf / other compiler work, keeping CK fix is useful.
@@ -132,7 +135,7 @@ SelectedSuite='skip'
 # CK may be run using a specfic test from the selected suite.
 SelectedTest=''
 
-while getopts "hirubs:t:" opt; do
+while getopts "hilrubs:t:" opt; do
   case ${opt} in
   h)
     printHelp
@@ -140,6 +143,10 @@ while getopts "hirubs:t:" opt; do
   i)
     # Install the CK build
     ShouldInstallCK='yes'
+    ;;
+  l)
+    # Build the CK library only
+    ShouldBuildLibraryOnly='yes'
     ;;
   r)
     # Rebuild the CK repo
@@ -269,7 +276,16 @@ fi
 # TODO Fix / Finalize the cmake command
 CKCmakeCmd="cmake ${CmakeGenerator} -B ${CK_BUILD} -S ${CK_REPO} -DCMAKE_PREFIX_PATH=${ROCM_PATH} -DCMAKE_INSTALL_PREFIX=${CK_INSTALL} "
 CKCmakeCmd+="-DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ -DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++ "
-CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release -DGPU_TARGETS=${CK_GPU_TARGETS} "
+CKCmakeCmd+="-DCMAKE_BUILD_TYPE=Release "
+
+# Handle library-only build for CK
+# Note: GPU_ARCHS takes precedence over GPU_TARGETS and omits examples & tests
+if [ "${ShouldBuildLibraryOnly}" == 'yes' ]; then
+  CKCmakeCmd+="-DGPU_ARCHS=${CK_GPU_TARGETS} "
+else
+  CKCmakeCmd+="-DGPU_TARGETS=${CK_GPU_TARGETS} "
+fi
+
 # For some reason, CK on gfx12 wants this set.
 CKCmakeCmd+="-DBUILD_DEV=On"
 


### PR DESCRIPTION
Add '-l' flag to omit tests and examples during CK library build

## Motivation

Tests and examples of CK are another point of failure during CK builds.
Also, this may save up on time (e.g. reducing the artifact count from 8k to 3k).

## Technical Details

CK's CMake configuration uses `GPU_ARCHS` and `GPU_TARGETS` to distinguish between those build modes.
`GPU_ARCHS` omits tests & examples -AND- takes precedence over `GPU_TARGETS`.
See here: https://github.com/ROCm/composable_kernel/blob/develop/CMakeLists.txt#L209-L211

## Test Plan

Manually ran CI test partially to confirm changed number of build steps with `-l` flag being set.
