### PR TITLE
[CK] Enable user-defined build paralellism

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -8,6 +8,12 @@ CKBenchmarkRepoBranchName='main'
 # when building CK. This is likely a bit conservative.
 CKBuildParallelism=$(free -g | grep Mem | awk '{print int($2/10)}')
 
+# Check if the user overrode number of parallel build jobs
+# via env var
+if [ ! -z ${CK_BUILD_PARALLELISM} ];then
+  CKBuildParallelism=${CK_BUILD_PARALLELISM}
+fi
+
 realpath=$(realpath $0)
 thisdir=$(dirname $realpath)
 
@@ -135,8 +141,12 @@ SelectedSuite='skip'
 # CK may be run using a specfic test from the selected suite.
 SelectedTest=''
 
-while getopts "hilrubs:t:" opt; do
+while getopts "j:hilrubs:t:" opt; do
   case ${opt} in
+  j)
+    # User-defined parallelism for CK build via argument
+    CKBuildParallelism="${OPTARG}"
+    ;;
   h)
     printHelp
     ;;


### PR DESCRIPTION
Default is to use as much of the machine as we believe works with CK memory demands.
Can be overridden by env var, which can be overridden by argument.

So, order of precedence from high to low: -j argument, env var, default.