### PR TITLE
[CK] Build library targets first

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -323,7 +323,9 @@ fi
 if [ "${ShouldRebuildCK}" == 'yes' ] || [ "${ShouldInstallCK}" == 'yes' ]; then
   pushd ${CK_BUILD} || exit 1
 
-  /usr/bin/time -o build-times.tlog ${CKBuildTool} -j ${CKBuildParallelism}
+  # -k parameter avoids stopping at first error
+  # ckProfiler target seems to depend on all library targets, which we want to build first
+  /usr/bin/time -o build-times.tlog ${CKBuildTool} -j ${CKBuildParallelism} -k 0 ckProfiler
   if [ $? -ne 0 ]; then
     exit 1
   fi


### PR DESCRIPTION
Building CK takes long, so we want to get as much done as possible. To do that, we want to keep going to catch as many errors as possible. That is why `-k` is added to the build command.

We also want to restrict it to only the library components first. To that end, we build ckProfiler which appears to depend on the library components and enables us to do that without restricting the CMake configuration to only the library parts.

That means in a subsequent step we can still build smoke / regression tests etc.
