### PR TITLE
[LLaMA] Use make if ninja not avail

### DIFF
--- a/bin/run_llama.sh
+++ b/bin/run_llama.sh
@@ -51,6 +51,12 @@ if [ "${IsVerbose}" == "yes" ]; then
   set -x
 fi
 
+TestBuildTool='make'
+if command -v ninja >/dev/null; then
+  CmakeGenerator="-GNinja"
+  TestBuildTool='ninja'
+fi
+
 if [ ! -d ${LLAMA_TESTS_LOG_LOCATION} ]; then
   mkdir -p ${LLAMA_TESTS_LOG_LOCATION}
 fi
@@ -74,7 +80,7 @@ if [ "${DoConfigure}" == "yes" ]; then
     -DGGML_HIP=On \
     -DCMAKE_BUILD_TYPE=${LLAMA_BUILD_MODE} \
     -DGPU_TARGETS=${LLAMA_GPU} \
-    -GNinja \
+    ${CmakeGenerator} \
     -DCMAKE_C_COMPILER=${AOMP}/bin/clang \
     -DCMAKE_CXX_COMPILER=${AOMP}/bin/clang++ \
     -DCMAKE_HIP_COMPILER=${AOMP}/bin/clang++


### PR DESCRIPTION
It seems that some of the test environments do not have the ninja-build tool installed. Auto-detect these cases and use make instead.
