### PR TITLE
[LLaMA] Add LLaMA C++ benchmark

### DIFF
--- a/bin/run_llama.sh
+++ b/bin/run_llama.sh
@@ -19,6 +19,10 @@
 : ${LLAMA_BUILD_MODE:=Release}
 : ${LLAMA_TESTS_LOG_LOCATION:=$LLAMA_TLDIR/logs}
 
+# Model to use in benchmarks (default is a smaller model)
+: ${LLAMA_BENCH_HF_ID:="ggml-org/gemma-3-1b-it-GGUF"}
+: ${LLAMA_CACHE:="$HOME/.cache/llama.cpp"}
+
 pushd ${AOMP_REPOS_TEST}
 mkdir -p ${LLAMA_TLDIR} && cd ${LLAMA_TLDIR}
 
@@ -31,17 +35,21 @@ DoCompile='no'
 # Run ctest
 DoCTest='no'
 
+# Run benchmark (llama-bench)
+DoBenchmark='no'
+
 IsVerbose='no'
 
-while getopts "j:cbtv" opt; do
+while getopts "j:cbtve" opt; do
   case ${opt} in
   j) AOMP_BUILD_JOBS=${OPTARG} ;;
   c) DoConfigure='yes' ;;
   b) DoCompile='yes' ;;
   t) DoCTest='yes' ;;
   v) IsVerbose='yes' ;;
+  e) DoBenchmark='yes' ;;
   \?)
-    echo "Usage: cmd [-j build_jobs] [-c configure] [-b build] [-t ctest]"
+    echo "Usage: cmd [-j build_jobs] [-c configure] [-b build] [-t ctest] [-e benchmark]"
     exit 1
     ;;
   esac
@@ -90,6 +98,24 @@ if [ "${DoCTest}" == "yes" ]; then
   cd ${LLAMA_BUILD_DIR}
   echo "Log in ${LLAMA_TESTS_LOG_LOCATION}/ctest.log"
   ctest --output-on-failure 2>&1 | tee "${LLAMA_TESTS_LOG_LOCATION}/ctest.log"
+fi
+
+if [ "${DoBenchmark}" == "yes" ]; then
+  echo "Running benchmark..."
+  cd ${LLAMA_BUILD_DIR}
+  # Download model from HF (this will make it avail in local cache); bench call requires local model file
+  # llama-cli will turn on interactive mode, so echo /exit to it immediately
+  echo "/exit" | ./bin/llama-cli -hf ${LLAMA_BENCH_HF_ID}
+
+  # For the find command, we need to replace '/' with '_' in the LLAMA_BENCH_HF_ID
+  ModelSearchPattern=${LLAMA_BENCH_HF_ID/\//\_}
+  # Pick up first model with that name. Basically, pick up first quantization of that model
+  LlamaModelPath=$(find "$LLAMA_CACHE" -maxdepth 1 -name "${ModelSearchPattern}*.gguf" 2>/dev/null | head -1)
+
+  # Marker for external scripts
+  echo "LLAMA_BENCHMARK_BEGIN" | tee "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
+  # Run benchmark
+  ./bin/llama-bench -ngl 999 -fa 1 -ub 2048 -m "$LlamaModelPath" 2>&1 | tee -a "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
 fi
 
 popd


### PR DESCRIPTION
We also want to run performance benchmarks. This adds the initial infrastructure to do so.
It uses a randomly picked "trending" model from hugging face that is not too large to download.