### PR TITLE
[CK] Add installation success marker and ignore intermediate errors

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -349,10 +349,13 @@ if [ "${ShouldInstallCK}" == 'yes' ]; then
   pushd ${CK_BUILD} || exit 1
 
   # TODO: Check parallelism. This may use all available threads.
-  /usr/bin/time -o install-times.tlog ${CKBuildTool} install
+  /usr/bin/time -o install-times.tlog ${CKBuildTool} -k 0 install
   if [ $? -ne 0 ]; then
     exit 1
   fi
+
+  # Find install success in the log
+  echo "CK-INSTALL-SUCCESS"
 
   popd
 fi


### PR DESCRIPTION
Add -k 0 argument to installation
 - CK installation may fail intermediately, hiding other "build" errors

Add print of CK-INSTALL-SUCCESS

## Motivation

Improve the CK CI debugging.

## Test Plan

Performed one test run, using our gfx90a CI machine.