### PR TITLE
[NFC] Fix shellcheck warnings for run_miniQMC

### DIFF
--- a/bin/run_miniQMC.sh
+++ b/bin/run_miniQMC.sh
@@ -9,11 +9,11 @@
 # ROCM_INSTALL_PATH       top-level ROCm install directory (default: /opt/rocm-5.3.0)
 
 # --- Start standard header to set AOMP environment variables ----
-realpath=`realpath $0`
-thisdir=`dirname $realpath`
+realpath=`realpath "$0"`
+thisdir=`dirname "$realpath"`
 export AOMP_USE_CCACHE=0
 
-. $thisdir/aomp_common_vars
+. "$thisdir"/aomp_common_vars
 # --- end standard header ----
 
 # Default ROCm installation
@@ -46,31 +46,31 @@ export rocsolver_DIR=${ROCM}/lib/cmake/rocsolver/
 : ${MQMC_GIT_TAG:=9d9d7d3}
 
 
-if [ ! -d $MQMC_SOURCE_DIR ]; then
-  git clone https://github.com/ye-luo/miniqmc $MQMC_SOURCE_DIR
-  git checkout ${MQMC_GIT_TAG}
+if [ ! -d "$MQMC_SOURCE_DIR" ]; then
+  git clone https://github.com/ye-luo/miniqmc "$MQMC_SOURCE_DIR"
+  git checkout "${MQMC_GIT_TAG}"
 fi
 
-rm -rf ${MQMC_BUILD_DIR}
+rm -rf "${MQMC_BUILD_DIR}"
 # Note: We currently need the -fopenmp-assume-no-nested-parallelism to work around a call to malloc which probably should not be there.
 # In the case that we disable hostservices, the application crashes when trying to call malloc.
-CMAKE_PREFIX_PATH=${ROCM}/lib/cmake/ cmake -B ${MQMC_BUILD_DIR} -S ${MQMC_SOURCE_DIR} -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OFFLOAD=ON -DQMC_ENABLE_ROCM=ON -DCMAKE_CXX_FLAGS='-fopenmp-assume-no-nested-parallelism -DCUDART_VERSION=10000 -DcudaMemoryTypeManaged=hipMemoryTypeManaged ' -DAMDGPU_DISABLE_HOST_DEVMEM=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+CMAKE_PREFIX_PATH=${ROCM}/lib/cmake/ cmake -B "${MQMC_BUILD_DIR}" -S "${MQMC_SOURCE_DIR}" -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OFFLOAD=ON -DQMC_ENABLE_ROCM=ON -DCMAKE_CXX_FLAGS='-fopenmp-assume-no-nested-parallelism -DCUDART_VERSION=10000 -DcudaMemoryTypeManaged=hipMemoryTypeManaged ' -DAMDGPU_DISABLE_HOST_DEVMEM=ON -DCMAKE_VERBOSE_MAKEFILE=ON
 
 # Build miniqmc binaries
 #cmake --build ${MQMC_BUILD_DIR}  --clean-first -j ${MQMC_NUM_BUILD_PROCS}
-pushd ${MQMC_BUILD_DIR}
+pushd "${MQMC_BUILD_DIR}" || exit
 make clean
-make --output-sync -j ${MQMC_NUM_BUILD_PROCS}
-popd
+make --output-sync -j "${MQMC_NUM_BUILD_PROCS}"
+popd || exit
 
 echo "Running Tests"
 echo "OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/check_spo_batched_reduction -n 10"
-OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/check_spo_batched_reduction -n 10
+OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} "${MQMC_BUILD_DIR}"/bin/check_spo_batched_reduction -n 10
 
 echo ""
 echo "OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/miniqmc"
-OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/miniqmc -v
+OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} "${MQMC_BUILD_DIR}"/bin/miniqmc -v
 
 echo ""
 echo "OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/check_spo -n 10"
-OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/check_spo -n 10 -v
+OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} "${MQMC_BUILD_DIR}"/bin/check_spo -n 10 -v


### PR DESCRIPTION
This fixes the shellcheck warnings in run script for miniQMC benchmark.
