### PR TITLE
[srock] Define CMAKE_HIP_COMPILER

### DIFF
--- a/srock-bin/patches/amd-staging/_TheRock.patch
+++ b/srock-bin/patches/amd-staging/_TheRock.patch
@@ -1,3 +1,15 @@
+diff --git a/cmake/therock_subproject.cmake b/cmake/therock_subproject.cmake
+index e8356406..d3373e56 100644
+--- a/cmake/therock_subproject.cmake
++++ b/cmake/therock_subproject.cmake
+@@ -1410,6 +1410,7 @@ function(_therock_cmake_subproject_setup_toolchain
+     string(APPEND _toolchain_contents "set(AMDGPU_TARGETS @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
+     string(APPEND _toolchain_contents "set(GPU_TARGETS @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
+     string(APPEND _toolchain_contents "set(CMAKE_HIP_ARCHITECTURES @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
++    string(APPEND _toolchain_contents "set(CMAKE_HIP_COMPILER \"@AMD_LLVM_CXX_COMPILER@\")\n")
+   endif()
+ 
+   # General settings applicable to all toolchains.
 diff --git a/compiler/CMakeLists.txt b/compiler/CMakeLists.txt
 index 9db31320..8552b77c 100644
 --- a/compiler/CMakeLists.txt
@@ -63,10 +75,10 @@ index 48aa6a8b..20ea73f1 100644
  # Setup the install rpath (let CMake handle build RPATH per usual):
  # * Executables and libraries can always search their adjacent lib directory
 diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
-index 4b1f02ef..fef7efed 100644
+index de446e14..af47ddad 100644
 --- a/profiler/CMakeLists.txt
 +++ b/profiler/CMakeLists.txt
-@@ -81,11 +81,16 @@ endif(THEROCK_BUILD_TESTING)
+@@ -82,11 +82,16 @@ endif(THEROCK_BUILD_TESTING)
      EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-sdk"
      BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-sdk"
      BACKGROUND_BUILD
@@ -83,7 +95,7 @@ index 4b1f02ef..fef7efed 100644
      COMPILER_TOOLCHAIN
        amd-hip
      RUNTIME_DEPS
-@@ -160,11 +165,15 @@ endif(THEROCK_BUILD_TESTING)
+@@ -163,11 +168,15 @@ endif(THEROCK_BUILD_TESTING)
        # Must build with the HIP compiler.
        amd-hip
      CMAKE_ARGS

--- a/srock-bin/patches/amd-staging/compiler_amd-llvm.patch
+++ b/srock-bin/patches/amd-staging/compiler_amd-llvm.patch
@@ -1,0 +1,16 @@
+diff --git a/libc/CMakeLists.txt b/libc/CMakeLists.txt
+index 46d799cbec11..e1228651d856 100644
+--- a/libc/CMakeLists.txt
++++ b/libc/CMakeLists.txt
+@@ -420,10 +420,9 @@ add_subdirectory(lib)
+ if(LLVM_INCLUDE_TESTS)
+   add_subdirectory(test)
+   add_subdirectory(fuzzing)
++# add_subdirectory(benchmarks)
+ endif()
+ 
+-add_subdirectory(benchmarks)
+-
+ if (LIBC_INCLUDE_DOCS)
+   add_subdirectory(docs)
+ endif()


### PR DESCRIPTION
    - Allows building on systems with /opt/rocm