### PR TITLE
add -lm to clang-358841  Makefile

### DIFF
--- a/test/smoke/clang-358841/Makefile
+++ b/test/smoke/clang-358841/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = clang-358841.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-CLANG        = clang
+CLANG        = clang -lm
 
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)


### PR DESCRIPTION
 needed now due to
[SimplifyLibCalls] Avoid simplifying pow(x, 2.0) -> x * x with math-errno. (#183099)