### PR TITLE
[CI] Only shellcheck touched files

### DIFF
--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -34,3 +34,4 @@ jobs:
               shellcheck "$file"
             fi
           done
+        shell: bash {0}

--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -1,15 +1,30 @@
 name: AOMP Lint
 
 on:
-  push:
   pull_request:
 
 jobs:
   aomp-lint:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
+        with:
+          separator: ','
+          skip_initial_fetch: true
+          base_sha: 'HEAD~1'
+          sha: 'HEAD'
+
+      - name: Echo changed files
+        run: |
+          echo "Changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
 
       - name: Run shellcheck
         run: |

--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -17,7 +17,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323
         with:
-          separator: ','
+          separator: ' '
           skip_initial_fetch: true
           base_sha: 'HEAD~1'
           sha: 'HEAD'
@@ -28,4 +28,9 @@ jobs:
 
       - name: Run shellcheck
         run: |
-          find . -name "*.sh" -exec shellcheck -S info {} +
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [[ $file == *.sh ]]; then
+              echo "Running shellcheck on $file"
+              shellcheck "$file"
+            fi
+          done

--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -282,7 +282,7 @@ elif [ "${ShouldUpdateCKRepo}" == 'yes' ]; then
   git pull
   # TODO: Write current SHA to somewhere such that it is known which SHA
   #       was tested in this nightly run.
-  popd
+  popd || exit 1
 fi
 
 CKBuildTool='make'
@@ -341,7 +341,7 @@ if [ "${ShouldRebuildCK}" == 'yes' ] || [ "${ShouldInstallCK}" == 'yes' ]; then
   # Find build success in the build log
   echo "CK-BUILD-SUCCESS"
 
-  popd
+  popd || exit 1
 fi
 
 # Perform CK installation
@@ -357,7 +357,7 @@ if [ "${ShouldInstallCK}" == 'yes' ]; then
   # Find install success in the log
   echo "CK-INSTALL-SUCCESS"
 
-  popd
+  popd || exit 1
 fi
 
 echo "Run suite: ${SelectedSuite}"
@@ -382,7 +382,7 @@ if [ "${SelectedSuite}" == 'smoke' ]; then
   pushd ${CK_BUILD} || exit 1
   ${CKBuildTool} -j 16 smoke 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/smoke_tests.log"
   echo "Log at ${CK_TESTS_LOG_LOCATION}/smoke_tests.log"
-  popd
+  popd || exit 1
 fi
 
 if [ "${SelectedSuite}" == 'regression' ]; then
@@ -393,7 +393,7 @@ if [ "${SelectedSuite}" == 'regression' ]; then
   pushd ${CK_BUILD} || exit 1
   ${CKBuildTool} -j 16 regression 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/regression_tests.log"
   echo "Log at ${CK_TESTS_LOG_LOCATION}/regression_tests.log"
-  popd
+  popd || exit 1
 fi
 
 # Handle CK benchmarks (also as default, if no suite has been explicitly selected)
@@ -409,7 +409,7 @@ if [ "${SelectedSuite}" == 'benchmarks' ]; then
     git reset --hard origin/${CKBenchmarkRepoBranchName}
     git pull
     # TODO: Dump SHA somewhere
-    popd
+    popd || exit 1
   fi
 
   if [ ! -d ${CK_BENCHMARK_RESULT} ]; then
@@ -447,7 +447,7 @@ if [ "${SelectedSuite}" == 'benchmarks' ]; then
   ${CKBenchmarkProfilerExport}
   ${CKBenchmarkCmd}
 
-  popd
+  popd || exit 1
 
   echo "Benchmark Output File: ${CKBenchmarkResultOutput}"
 fi
@@ -559,7 +559,7 @@ if [ "${SelectedSuite}" == 'client-examples' ]; then
     done
   fi
 
-  popd
+  popd || exit 1
 fi
 
 # Handle CK's regular examples
@@ -629,5 +629,5 @@ if [ "${SelectedSuite}" == 'examples' ]; then
     done
   fi
 
-  popd
+  popd || exit 1
 fi

--- a/bin/run_miniQMC.sh
+++ b/bin/run_miniQMC.sh
@@ -9,8 +9,8 @@
 # ROCM_INSTALL_PATH       top-level ROCm install directory (default: /opt/rocm-5.3.0)
 
 # --- Start standard header to set AOMP environment variables ----
-realpath=`realpath "$0"`
-thisdir=`dirname "$realpath"`
+realpath=$(realpath "$0")
+thisdir=$(dirname "$realpath")
 export AOMP_USE_CCACHE=0
 
 . "$thisdir"/aomp_common_vars


### PR DESCRIPTION
Limit running shellcheck on changed files (I assume this includes new files as well) to reduce the overall noise the workflow creates.
