### PR TITLE
[CI][NFC] Rename workflow to indicate shellcheck is used

### DIFF
--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -1,4 +1,4 @@
-name: AOMP Lint
+name: AOMP shellcheck lint
 
 on:
   pull_request:


### PR DESCRIPTION
Make it clear that this workflow does shellcheck and not other linting as well.
