### PR TITLE
[srock] Move smrev regen from setup to build step

### DIFF
--- a/srock-bin/post_setup_build_srock.sh
+++ b/srock-bin/post_setup_build_srock.sh
@@ -95,6 +95,16 @@ echo "      Compiler branch:   $SROCK_COMPILER_BRANCH"
 echo "      SROCK config name: $SROCK_CONFIG"
 echo "      cmake args:        ${_cmake_args[*]}"
 
+(
+cd "$SROCK_THEROCK_DIR" || exit
+# reconstruct .amd-llvm.smrev using the current SHA
+cd compiler/amd-llvm || exit
+smrev="../.amd-llvm.smrev"
+git config --get remote.origin.url > "$smrev"
+smsha=$(git rev-parse HEAD)
+echo "${smsha}${LLVM_SHA_EXTRA}" >> "$smrev"
+)
+
 cd "$SROCK_THEROCK_DIR" || exit
 _cmd="cmake --build build"
 echo 

--- a/srock-bin/setup_srock.sh
+++ b/srock-bin/setup_srock.sh
@@ -202,16 +202,6 @@ if [ "$SROCK_COMPILER_BRANCH" != "develop" ] ; then
 
 echo "      --- end compiler submodule updates for $SROCK_COMPILER_BRANCH"
 
-(
-cd "$SROCK_THEROCK_DIR" || exit
-# reconstruct .amd-llvm.smrev using the current SHA
-cd compiler/amd-llvm || exit
-smrev="../.amd-llvm.smrev"
-git config --get remote.origin.url > "$smrev"
-smsha=$(git rev-parse HEAD)
-echo "${smsha}${LLVM_SHA_EXTRA}" >> "$smrev"
-)
-
 cd "$SROCK_THEROCK_DIR" || exit
 echo 
 echo "===== cmake CMD: $SROCK_CMAKE ${_cmake_args[*]}"


### PR DESCRIPTION
    - Needs to be reconstructed each time a build is performed
      to ensure any changes to the SHA are captured in the version