### PR TITLE
[srock] Add list_srock.sh

### DIFF
--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+#Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+#SPDX-License-Identifier:  MIT
+# 
+#  list_srock.sh: List the version of TheRock and submodules
+#
+# --- Start standard header to set SROCK environment variables ----
+realpath=$(realpath "$0")
+thisdir=$(dirname "$realpath")
+. "$thisdir/srock_common_vars"
+# --- end standard header ----
+
+cd "$SROCK_THEROCK_DIR" || exit
+
+do_sub_status=0
+show_fmt=1
+show_unfmt=0
+while [ $# -gt 0 ]; do		# check arguments
+   case "$1" in
+      -u)
+         show_fmt=0
+         show_unfmt=1
+	 ;;
+      -v)
+         do_sub_status=1
+	 ;;
+      -q|-t)
+         do_sub_status=0
+	 ;;
+      *)
+	 echo "Usage: srock-list [OPTION]" >& 2
+	 echo "    -q  quick   (exclude 'submodule status')" >& 2
+	 echo "    -v  verbose (include 'submodule status')" >& 2
+	 echo "    -u  show as unformatted CSV" >& 2
+	 exit 1 ;;
+   esac
+   shift
+done
+declare -a tr_dtop
+declare -a tr_dsub
+# shellcheck disable=SC2116 # echo intended
+# shellcheck disable=SC2046 # word splitting in subcommands is acceptable 
+tr_dtop=( "$(echo $(git branch --show-current)\|TheRock\|TheRock\|parent\|$(git log -1 --format="%H|%as|%cn|%an"))" )
+# shellcheck disable=SC2016 # single quotes intended
+# shellcheck disable=SC2207 # intended split on newline
+IFS=$'\n' tr_dsub=( $(git submodule -q foreach 'echo $(git branch --show-current)\|$sm_path\|$name\|$sha1\|$(git log -1 --format="%H|%as|%cn|%an")') )
+# shellcheck disable=SC2207 # intended split on newline
+declare -a tr_data
+tr_data=( "${tr_dtop[@]}" "${tr_dsub[@]}" )
+
+declare -a tr_fields
+declare -a tr_unders
+tr_fields=("branch" "path" "repo name" "sub SHA" "head SHA" "updated" "commitor" "for author")
+tr_unders=("------" "----" "---------" "-------" "--------" "-------" "--------" "----------")
+if [[ $do_sub_status -ne 0 ]]; then
+    tr_fields+=("sub SHA tag")
+    tr_unders+=("-----------")
+fi
+declare -A tr_htags
+
+# collect SHA tags from submodule status
+if [[ $do_sub_status -ne 0 ]]; then
+    declare -a tr_stat
+    # shellcheck disable=SC2207 # intended split on newline
+    IFS=$'\n' tr_stat=( $(git submodule status) )
+    for entry in "${tr_stat[@]}"; do
+        IFS=" " read -r -a en_split <<< "$entry"
+        sub_sha=${en_split[0]}
+        sub_tag=${en_split[2]}
+        # echo "$entry: $sub_sha -> $sub_tag"
+        tr_htags[$sub_sha]=$sub_tag
+    done
+fi
+
+# formatted output
+if [[ $show_fmt -ne 0 ]]; then
+    echo "TheRock submodules:"
+    fmt="%-20.20s %-44.44s %-21.21s %-10.10s %-10.10s %-10.10s %-10.10s %-19.19s %s\n"
+    # shellcheck disable=SC2059 # variable format intended
+    printf "$fmt" "${tr_fields[@]}"
+    # shellcheck disable=SC2059 # variable format intended
+    printf "$fmt" "${tr_unders[@]}"
+    for entry in "${tr_data[@]}"; do
+        IFS='|' read -r -a en_split <<< "$entry"
+        sub_sha=${en_split[3]}
+        head_sha=${en_split[4]}
+        if [ "$sub_sha" == "$head_sha" ]; then
+            en_split[4]="same"
+        fi
+        tag=""
+        if [[ -v tr_htags[$sub_sha] ]]; then
+            tag=${tr_htags[$sub_sha]}
+        fi
+        # shellcheck disable=SC2059 # variable format intended
+        printf "$fmt"  "${en_split[@]}" "$tag"
+    done
+fi
+
+# unformatted output
+if [[ $show_unfmt -ne 0 ]]; then
+    echo "TheRock submodules versions (unformatted):"
+    fmt="%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
+    # shellcheck disable=SC2059 # variable format intended
+    printf "$fmt" "${tr_fields[@]}"
+    for entry in "${tr_data[@]}"; do
+        IFS='|' read -r -a en_split <<< "$entry"
+        sub_sha=${en_split[3]}
+        tag=${tr_htags[$sub_sha]}
+        echo "$entry|$tag"
+    done
+fi

--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -53,9 +53,11 @@ fi
 
 declare -a tr_dtop
 declare -a tr_dsub
+dirname=${PWD##*/}
 # shellcheck disable=SC2116 # echo intended
 # shellcheck disable=SC2046 # word splitting in subcommands is acceptable
-tr_dtop=( "$(echo $(git branch --show-current)\|TheRock\|TheRock\|parent\|$(git log -1 --format="%H|%as|%cn|%an"))" )
+# shellcheck disable=SC2086 # word splitting in substrings is acceptable
+tr_dtop=( "$(echo $(git branch --show-current)\|$dirname\|$dirname\|parent\|$(git log -1 --format="%H|%as|%cn|%an"))" )
 # shellcheck disable=SC2016 # single quotes intended
 # shellcheck disable=SC2207 # intended split on newline
 IFS=$'\n' tr_dsub=( $(git submodule -q foreach 'echo $(git branch --show-current)\|$sm_path\|$name\|$sha1\|$(git log -1 --format="%H|%as|%cn|%an")') )

--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -3,7 +3,7 @@
 #Copyright © Advanced Micro Devices, Inc., or its affiliates.
 #
 #SPDX-License-Identifier:  MIT
-# 
+#
 #  list_srock.sh: List the version of TheRock and submodules
 #
 # --- Start standard header to set SROCK environment variables ----
@@ -41,7 +41,7 @@ done
 declare -a tr_dtop
 declare -a tr_dsub
 # shellcheck disable=SC2116 # echo intended
-# shellcheck disable=SC2046 # word splitting in subcommands is acceptable 
+# shellcheck disable=SC2046 # word splitting in subcommands is acceptable
 tr_dtop=( "$(echo $(git branch --show-current)\|TheRock\|TheRock\|parent\|$(git log -1 --format="%H|%as|%cn|%an"))" )
 # shellcheck disable=SC2016 # single quotes intended
 # shellcheck disable=SC2207 # intended split on newline

--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -76,7 +76,6 @@ fi
 
 # formatted output
 if [[ $show_fmt -ne 0 ]]; then
-    echo "TheRock submodules:"
     fmt="%-20.20s %-44.44s %-21.21s %-10.10s %-10.10s %-10.10s %-12.12s %-19.19s %s\n"
     # shellcheck disable=SC2059 # variable format intended
     printf "$fmt" "${tr_fields[@]}"
@@ -100,7 +99,6 @@ fi
 
 # unformatted output
 if [[ $show_unfmt -ne 0 ]]; then
-    echo "TheRock submodules versions (unformatted):"
     fmt="%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n"
     # shellcheck disable=SC2059 # variable format intended
     printf "$fmt" "${tr_fields[@]}"

--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -77,7 +77,7 @@ fi
 # formatted output
 if [[ $show_fmt -ne 0 ]]; then
     echo "TheRock submodules:"
-    fmt="%-20.20s %-44.44s %-21.21s %-10.10s %-10.10s %-10.10s %-10.10s %-19.19s %s\n"
+    fmt="%-20.20s %-44.44s %-21.21s %-10.10s %-10.10s %-10.10s %-12.12s %-19.19s %s\n"
     # shellcheck disable=SC2059 # variable format intended
     printf "$fmt" "${tr_fields[@]}"
     # shellcheck disable=SC2059 # variable format intended

--- a/srock-bin/list_srock.sh
+++ b/srock-bin/list_srock.sh
@@ -12,13 +12,15 @@ thisdir=$(dirname "$realpath")
 . "$thisdir/srock_common_vars"
 # --- end standard header ----
 
-cd "$SROCK_THEROCK_DIR" || exit
-
+do_cur_dir=0
 do_sub_status=0
 show_fmt=1
 show_unfmt=0
 while [ $# -gt 0 ]; do		# check arguments
    case "$1" in
+      -c)
+         do_cur_dir=1
+         ;;
       -u)
          show_fmt=0
          show_unfmt=1
@@ -31,6 +33,7 @@ while [ $# -gt 0 ]; do		# check arguments
 	 ;;
       *)
 	 echo "Usage: srock-list [OPTION]" >& 2
+	 echo "    -c  current dir (default dir: $SROCK_THEROCK_DIR)" >& 2
 	 echo "    -q  quick   (exclude 'submodule status')" >& 2
 	 echo "    -v  verbose (include 'submodule status')" >& 2
 	 echo "    -u  show as unformatted CSV" >& 2
@@ -38,6 +41,16 @@ while [ $# -gt 0 ]; do		# check arguments
    esac
    shift
 done
+
+if [[ $do_cur_dir -eq 0 ]]; then
+    cd "$SROCK_THEROCK_DIR" || exit
+else
+    if [[ ! -d .git ]]; then
+       echo "Error: .git not found"
+       exit 1
+    fi
+fi
+
 declare -a tr_dtop
 declare -a tr_dsub
 # shellcheck disable=SC2116 # echo intended


### PR DESCRIPTION
Provides a list similar to aomp/clone_aomp.sh list

    Usage: srock-list [OPTION]
        -q  quick   (exclude 'submodule status')
        -v  verbose (include 'submodule status')
        -u  show as unformatted CSV