### PR TITLE
[Flang][OpenMP] Add new subdirectory for fortran map tests cultivated over the past few years

### DIFF
--- a/test/fortran-map-tests/SWDEV-564425-simple.f90
+++ b/test/fortran-map-tests/SWDEV-564425-simple.f90
@@ -1,0 +1,62 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  real(kind=8), pointer :: var_a(:)
+
+  integer :: var_b, var_c, var_d
+  logical var_e
+
+  var_b = 500000
+
+  allocate(var_a(var_b))
+  var_a = [(real(var_c,kind=8), var_c=1,var_b)]
+
+  print *, "var_a    =", var_a(1:10)
+  print *, size(var_a)
+
+  !$omp target enter data map(to: var_a)
+  var_e = (omp_target_is_present(C_LOC(var_a), omp_get_default_device()) /= 0)
+  print *, "before parallel do var_a is present on device: ", var_e
+  !$omp target teams distribute parallel do map(present: var_a)
+  do var_d = 1, size(var_a)
+    var_a(var_d) = var_a(var_d) + 100.0d0
+  end do
+
+  !$omp target update from(var_a)
+
+  if(omp_target_is_present(C_LOC(var_a), omp_get_default_device()) == 0) then
+    print *, "Before release: var_a NOT on device"
+  else
+    print *, "Before release: var_a on device"
+  endif
+
+  !$omp target exit data map(ref_ptr, storage: var_a)
+
+  var_e = omp_target_is_present(C_LOC(var_a), omp_get_default_device()) /= 0
+  print *, "After ref_ptr release: var_a PRESENT on device ", var_e
+
+  if (var_e .NEQV. .true.) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+  !$omp target exit data map(ref_ptee, storage: var_a)
+
+  var_e = omp_target_is_present(C_LOC(var_a), omp_get_default_device()) /= 0
+  print *, "After ref_ptee release: var_a PRESENT on device ", var_e
+
+  if (var_e .NEQV. .false.) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+  deallocate(var_a)
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v2-alloca-parent-and-children.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v2-alloca-parent-and-children.f90
@@ -1,0 +1,218 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+      real(kind=4) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+    type(dtype_b), allocatable :: var_h
+    real(kind=8) :: var_i
+    real(kind=8), pointer :: var_j(:)
+    type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+      print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target update from(var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v2-alloca-parent.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v2-alloca-parent.f90
@@ -1,0 +1,218 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptee, from: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v2.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v2.f90
@@ -1,0 +1,217 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), target :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptee, from: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v3-alloca-parent-and-children.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v3-alloca-parent-and-children.f90
@@ -1,0 +1,221 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b), allocatable :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v3-alloca-parent.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v3-alloca-parent.f90
@@ -1,0 +1,218 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v3.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v3.f90
@@ -1,0 +1,217 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), target :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v4-alloca-parent-and-children.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v4-alloca-parent-and-children.f90
@@ -1,0 +1,243 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b), allocatable :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_j)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_k%var_c)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_k%var_b)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_f)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_g%var_c)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v4-alloca-parent.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v4-alloca-parent.f90
@@ -1,0 +1,219 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8), pointer :: var_j(:)
+     real(kind=8) :: var_i
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o, var_q
+  logical var_p
+  integer :: var_r(12)
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+!$omp end target
+
+!$omp target exit data map(ref_ptee, from: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v5-alloca-parent-and-children.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v5-alloca-parent-and-children.f90
@@ -1,0 +1,241 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b), allocatable :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+ !$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+ !$omp end target
+
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_j)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_k%var_c)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_k%var_b)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_f)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_g%var_c)
+!$omp target exit data map(ref_ptr_ptee, from: var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425-v5-alloca-parent.f90
+++ b/test/fortran-map-tests/SWDEV-564425-v5-alloca-parent.f90
@@ -1,0 +1,219 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8), pointer :: var_j(:)
+     real(kind=8) :: var_i
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o, var_q
+  logical var_p
+  integer :: var_r(12)
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptee, to: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target
+   do var_n = 1, var_m
+      var_l%var_j(var_n) = 20
+      var_l%var_k%var_c(var_n) = 30
+      var_l%var_h%var_g%var_c(var_n) = 40
+   end do
+   var_l%var_k%var_b = 5
+   var_l%var_h%var_f = 20
+   var_l%var_h%var_g%var_b = 25
+!$omp end target
+
+!$omp target exit data map(ref_ptee, from: var_l, var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+   do var_n = 1, var_m
+      if (var_l%var_j(var_n) /= 20) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_k%var_c(var_n) /= 30) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   do var_n = 1, var_m
+      if (var_l%var_h%var_g%var_c(var_n) /= 40) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+      end if
+   end do
+
+   if (var_l%var_k%var_b /= 5) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_f /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_l%var_h%var_g%var_b /= 25) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print *, var_l%var_j
+   print *, var_l%var_k%var_c
+   print *, var_l%var_h%var_g%var_c
+
+   print *, var_l%var_k%var_b
+   print *, var_l%var_h%var_f
+   print *, var_l%var_h%var_g%var_b
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-564425.f90
+++ b/test/fortran-map-tests/SWDEV-564425.f90
@@ -1,0 +1,91 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     real(kind=8), pointer :: var_b(:)
+  end type dtype_a
+
+  type(dtype_a), target :: var_c
+  integer :: var_d, var_e, var_f
+  logical var_g
+
+  var_d = 500000
+  var_c%var_a = 1.23d0
+
+  allocate(var_c%var_b(var_d))
+  var_c%var_b = [(real(var_e,kind=8), var_e=1,var_d)]
+
+  print *, "var_a =", var_c%var_a
+  print *, "var_b    =", var_c%var_b(1:10)
+  print *, size(var_c%var_b)
+
+  !$omp target enter data map(to: var_c, var_c%var_b)
+  var_g = (omp_target_is_present(C_LOC(var_c%var_b), omp_get_default_device()) /= 0)
+  print *, "before parallel do var_c%var_b is present on device: ", var_g
+  !$omp target teams distribute parallel do map(present: var_c)
+  do var_f = 1, size(var_c%var_b)
+    var_c%var_b(var_f) = var_c%var_b(var_f) + 100.0d0
+  end do
+
+  !$omp target map(present: var_c)
+  var_c%var_a = var_c%var_a + 10.0d0
+  !$omp end target
+
+  print *, "var_a =", var_c%var_a
+  print *, "var_b    =", var_c%var_b(1:10)
+  !$omp target update from(var_c)
+  print *, "=== Host after device update ==="
+  print *, "var_a =", var_c%var_a
+  print *, "var_b    =", var_c%var_b(1:10)
+
+
+  if(omp_target_is_present(C_LOC(var_c), omp_get_default_device()) == 0) then
+    print *, "Before release: var_c NOT on device"
+  else
+    print *, "Before release: var_c on device"
+  endif
+
+  if(omp_target_is_present(C_LOC(var_c%var_b), omp_get_default_device()) == 0) then
+    print *, "Before release: var_c%var_b NOT on device"
+  else
+    print *, "Before release: var_c%var_b on device"
+  endif
+
+  !$omp target exit data map(ref_ptee, storage: var_c%var_b)
+
+  var_g = omp_target_is_present(C_LOC(var_c), omp_get_default_device()) /= 0
+  print *, "After ref_ptee, release of var_c%var_b: var_c PRESENT on device ", var_g
+
+  if (var_g .NEQV. .true.) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+  var_g = omp_target_is_present(C_LOC(var_c%var_b), omp_get_default_device()) /= 0
+  print *, "After ref_ptee, release of var_c%var_b: var_c%var_b PRESENT on device ", var_g
+
+  if (var_g .NEQV. .false.) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+  !$omp target exit data map(ref_ptr, storage: var_c%var_b)
+  !$omp target exit data map(delete: var_c)
+
+  var_g = omp_target_is_present(C_LOC(var_c), omp_get_default_device()) /= 0
+  print *, "After exit delete of var_c: var_c PRESENT on device ", var_g
+
+  if (var_g .NEQV. .false.) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/SWDEV-579431.f90
+++ b/test/fortran-map-tests/SWDEV-579431.f90
@@ -1,0 +1,99 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  use iso_fortran_env, only : wp => real64
+  implicit none
+  type dtype_a
+    real(wp), allocatable :: var_a(:,:,:) 
+  end type
+end module mod_a
+
+module mod_b
+  use mod_a
+  implicit none
+  type(dtype_a), allocatable :: var_b(:,:)
+  integer :: var_c = 3, var_d = 4
+  integer :: var_e = -4, var_f = 3
+  integer :: var_g = 0, var_h = 0
+  integer :: var_i = 0, var_j = 0
+
+contains
+  subroutine sub_a()
+    integer :: var_k, var_l, var_m, var_n, var_o
+
+    allocate(var_b(-1:1,1:var_c))
+    !$omp target enter data map(alloc:var_b)
+    
+    do var_l = 1, var_c
+      allocate(var_b(-1,var_l)%var_a(var_e:var_f,var_g:var_h,var_i:var_j))
+      !$omp target enter data map(alloc:var_b(-1,var_l)%var_a)
+    end do
+    
+    !-- Force host to have value
+    do var_l = 1, var_c
+      var_b(-1,var_l)%var_a = -var_l*100.0
+    end do
+    
+    print*, 'Vals at init'
+    do var_k = 1, var_c
+      write(*,*) var_b(-1,var_k)%var_a
+    end do
+    
+    !$omp target teams distribute parallel do collapse(4)
+    do var_l = 1, var_c
+      do var_o = var_i, var_j
+        do var_n = var_g, var_h
+          do var_m = var_e, var_f
+            var_b(-1,var_l)%var_a(var_m,var_n,var_o) = 44
+          end do
+        end do
+      end do
+    end do
+    
+    print*
+    print*, 'Vals after target loop (should be same as init)'
+    do var_k = 1, var_c
+      write(*,*) var_b(-1,var_k)%var_a
+
+    do var_o = var_i, var_j
+        do var_n = var_g, var_h
+          do var_m = var_e, var_f
+              if (var_b(-1,var_k)%var_a(var_m,var_n,var_o) /= -var_k*100.0) then
+                print*, "======= FORTRAN Test Failed! ======="
+                stop 1
+              endif
+          end do
+        end do
+      end do
+    end do
+
+    print*
+    print*, 'Vals after update from device (should be mult. of Pi)'
+    do var_k = 1, var_c
+      !$omp target update from(var_b(-1,var_k)%var_a)
+      write(*,*) var_b(-1,var_k)%var_a
+        do var_o = var_i, var_j
+            do var_n = var_g, var_h
+                do var_m = var_e, var_f
+                    if (var_b(-1,var_k)%var_a(var_m,var_n,var_o) /= 44) then
+                        print*, "======= FORTRAN Test Failed! ======="
+                        stop 1
+                    endif
+                end do
+            end do
+        end do
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+  end subroutine
+end module
+
+program prog_a
+  use mod_b
+  use iso_fortran_env
+  implicit none
+  print*, compiler_version()
+  call sub_a()
+end program

--- a/test/fortran-map-tests/UMT-reproducer-5.f90
+++ b/test/fortran-map-tests/UMT-reproducer-5.f90
@@ -1,0 +1,51 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    type :: dtype_a
+        integer,         pointer, contiguous :: var_a(:) => null()
+    end type dtype_a
+
+    type :: dtype_b
+        integer                         :: var_b
+    end type dtype_b
+
+    type :: dtype_c
+        type(dtype_a),      pointer     :: var_c(:) => null()
+        type(dtype_b),     pointer     :: var_d(:)  => null()
+        integer :: var_e
+    end type dtype_c
+
+    type(dtype_c), pointer :: var_f => null()
+    integer :: var_g, var_h
+
+   allocate(var_f)
+   allocate(var_f%var_c(2))
+   allocate(var_f%var_d(2))
+   allocate(var_f%var_c(1)%var_a(10))
+   allocate(var_f%var_c(2)%var_a(10))
+
+   var_f%var_c(1)%var_a(1) = 20
+
+  !$omp target enter data map(to:var_f)
+  !$omp target enter data map(always,to:var_f%var_c)
+  !$omp target enter data map(always,to:var_f%var_d)
+   do var_g = 1, 2
+    !$omp target enter data map(always,to:var_f% var_c(var_g)% var_a)
+   end do
+
+   !$omp target map(tofrom: var_h)
+        var_h = var_f% var_c(1)% var_a(1)
+   !$omp end target
+
+    if (var_h /= var_f%var_c(1)%var_a(1)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    print *, var_h
+    print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/UMT-reproducer-6.f90
+++ b/test/fortran-map-tests/UMT-reproducer-6.f90
@@ -1,0 +1,84 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        integer                         :: var_a
+    end type dtype_a
+
+    type :: dtype_b
+        integer,      pointer, contiguous :: var_b(:) => null()
+        real(8),      pointer, contiguous :: var_c(:,:) => null()
+        integer :: var_d
+        real(8),      pointer, contiguous :: var_e(:,:,:) => null()
+    end type dtype_b
+
+    type :: dtype_c
+        type(dtype_b),      pointer     :: var_f(:) => null()
+        type(dtype_a),     pointer     :: var_g(:)  => null()
+        integer :: var_h
+    end type dtype_c
+
+    integer :: var_i, var_j
+    type(dtype_c), pointer :: var_k => null()
+
+   var_j = 4
+   allocate(var_k)
+   allocate(var_k%var_f(var_j))
+   allocate(var_k%var_g(var_j))
+   loop_a: do var_i = 1, var_j
+      allocate(var_k%var_f(var_i)%var_e(2,2,2))
+      allocate(var_k%var_f(var_i)%var_b(2))
+      allocate(var_k%var_f(var_i)%var_c(10,10))
+   enddo loop_a
+
+
+    !$omp target enter data map(to:var_k)
+    !$omp target enter data map(always,to:var_k%var_f)
+    !$omp target enter data map(always,to:var_k%var_g)
+   do var_i = 1, var_j
+    !$omp target enter data map(always,to:var_k% var_f(var_i)% var_c)
+    !$omp target enter data map(always,to:var_k% var_f(var_i)% var_b)
+    !$omp target enter data map(always,to:var_k% var_f(var_i)% var_e)
+   end do
+
+    do var_i = 1, var_j
+        if (associated(var_k%var_f(var_i)%var_c)) then
+            print *, "var_c IS ASSOCIATED 1"
+       endif
+    enddo
+
+    loop_b: do var_i = 1, var_j
+!$omp target update from(var_k% var_f(var_i)% var_d)
+!!$omp target update from(var_k% var_f(var_i)% var_c)
+!$omp target update from(var_k% var_f(var_i)% var_e)
+    deallocate(var_k%var_f(var_i)%var_c)
+    deallocate(var_k%var_f(var_i)%var_e)
+    deallocate(var_k%var_f(var_i)%var_b)
+    enddo loop_b
+
+    do var_i = 1, var_j
+        if (associated(var_k%var_f(var_i)%var_c)) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+       endif
+    enddo
+
+    do var_i = 1, var_j
+        if (associated(var_k%var_f(var_i)%var_e)) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+       endif
+    enddo
+
+    do var_i = 1, var_j
+        if (associated(var_k%var_f(var_i)%var_b)) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+       endif
+    enddo
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/UMT-reproducer.f90
+++ b/test/fortran-map-tests/UMT-reproducer.f90
@@ -1,0 +1,27 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,    pointer :: var_a
+    integer,    target, allocatable :: var_b
+
+    allocate(var_b)
+
+    var_b = 30
+
+!$omp target map(var_a)
+    var_a => var_b
+    var_a = 45
+!$omp end target
+
+    print *, var_b
+
+    if (var_b /= 45) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-array-section-1d-upperbound.f95
+++ b/test/fortran-map-tests/allocatable-array-section-1d-upperbound.f95
@@ -1,0 +1,50 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  allocatable :: var_a(:), var_b(:)
+    integer :: var_c
+    allocate(var_a(10))
+    allocate(var_b(10))
+
+    do var_c = 1, 10
+        var_a(var_c) = var_c
+        var_b(var_c) = 0
+    end do
+
+    !$omp target map(tofrom:var_a(2:6)) map(tofrom:var_b(2:6))
+        do var_c = 1, 10
+            var_b(var_c) = var_a(var_c)
+        end do
+    !$omp end target
+
+    do var_c = 1, 10
+        print *, var_b(var_c)
+    end do
+
+    if (var_b(1) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_c = 2, 6
+        if (var_b(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_c = 7, 10
+        if (var_b(var_c) /= 0) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    deallocate(var_a)
+    deallocate(var_b)
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/allocatable-dtype-allocatable-nest-map.f90
+++ b/test/fortran-map-tests/allocatable-dtype-allocatable-nest-map.f90
@@ -1,0 +1,43 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4), allocatable :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+        integer(4) :: var_e
+        real(4), allocatable :: var_f
+        integer(4) :: var_g
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_h
+        real(4), allocatable :: var_i
+        integer(4) :: var_j(10)
+        real(4) :: var_k
+        type(dtype_a), allocatable :: var_l
+        integer(4) :: var_m
+    end type dtype_b
+
+
+    type(dtype_b), allocatable :: var_n
+    allocate(var_n)
+    allocate(var_n%var_l)
+    allocate(var_n%var_l%var_b)
+
+!$omp target map(tofrom: var_n%var_l%var_b)
+    var_n%var_l%var_b = 100
+!$omp end target
+
+print *, var_n%var_l%var_b
+
+if (var_n%var_l%var_b /= 100) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-and-nested-allocatable-map-v2.f90
+++ b/test/fortran-map-tests/allocatable-dtype-and-nested-allocatable-map-v2.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer, allocatable :: var_b
+        integer(4) :: var_c(10)
+        real(4) :: var_d
+        integer, allocatable :: var_e(:)
+        integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a), allocatable :: var_g
+    integer :: var_h
+
+    allocate(var_g)
+    allocate(var_g%var_e(10))
+
+!$omp target map(tofrom: var_g%var_e, var_g)
+    do var_h = 1, 10
+        var_g%var_e(var_h) = var_h
+    end do
+    var_g%var_f = 50
+!$omp end target
+
+print *, var_g%var_e
+print *, var_g%var_f
+
+do var_h = 1, 10
+    if (var_g%var_e(var_h) /= var_h) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+    if (var_g%var_f /= 50) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-and-nested-allocatable-map.f90
+++ b/test/fortran-map-tests/allocatable-dtype-and-nested-allocatable-map.f90
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer, allocatable :: var_b 
+        integer(4) :: var_c(10)
+        real(4) :: var_d
+        integer, allocatable :: var_e(:)
+        integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a), allocatable :: var_g
+    integer :: var_h
+
+    allocate(var_g)
+    allocate(var_g%var_e(10))
+
+!$omp target map(tofrom: var_g, var_g%var_e)
+    do var_h = 1, 10
+        var_g%var_e(var_h) = var_h
+    end do
+    var_g%var_f = 50
+!$omp end target
+
+print *, var_g%var_e
+print *, var_g%var_f
+
+do var_h = 1, 10
+    if (var_g%var_e(var_h) /= var_h) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1    
+    end if  
+end do 
+
+if (var_g%var_f /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1    
+end if  
+
+print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-array-map-v1.f90
+++ b/test/fortran-map-tests/allocatable-dtype-array-map-v1.f90
@@ -1,0 +1,87 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  type :: dtype_a
+  real(4) :: var_a
+  real(4), allocatable :: var_b
+  real(4) :: var_c
+  end type dtype_a
+
+  type :: dtype_b
+    integer(4) :: var_d
+    integer(4) :: var_e
+    integer(4), allocatable :: var_f
+  end type dtype_b
+
+  type :: dtype_c
+    real(4) :: var_g(10)
+    real(4) :: var_h
+    real(4) :: var_i(10)
+  end type dtype_c
+
+  type :: dtype_d
+  real(4) :: var_j ! 4
+  integer, allocatable :: var_k
+  type(dtype_c) :: var_l
+  type(dtype_c), allocatable :: var_m
+  end type dtype_d
+
+  type(dtype_d) :: var_n(5)
+  type(dtype_d), allocatable :: var_o(:)
+
+  allocate(var_n(1)%var_m)
+  allocate(var_n(2)%var_m)
+  allocate(var_n(3)%var_m)
+  allocate(var_n(4)%var_m)
+  allocate(var_n(5)%var_m)
+
+  allocate(var_o(5))
+  allocate(var_o(1)%var_m)
+  allocate(var_o(2)%var_m)
+  allocate(var_o(3)%var_m)
+  allocate(var_o(4)%var_m)
+  allocate(var_o(5)%var_m)
+
+  allocate(var_o(1)%var_k)
+  allocate(var_o(2)%var_k)
+  allocate(var_o(3)%var_k)
+  allocate(var_o(4)%var_k)
+  allocate(var_o(5)%var_k)
+
+!$omp target map(tofrom: var_n(1:3), var_o(1:3))
+  var_o(2)%var_l%var_i(5) = 10
+  var_n(2)%var_l%var_i(5) = 10
+  var_o(2)%var_j = 10
+  var_n(2)%var_j = 10
+!$omp end target
+
+  print *, var_o(2)%var_j
+  print *, var_n(2)%var_j
+
+  print *, var_o(2)%var_l%var_i(5)
+  print *, var_n(2)%var_l%var_i(5)
+
+  if (var_n(2)%var_j/= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_o(2)%var_j/= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_o(2)%var_l%var_i(5)/= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_n(2)%var_l%var_i(5)/= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-map-exp-member.f90
+++ b/test/fortran-map-tests/allocatable-dtype-map-exp-member.f90
@@ -1,0 +1,52 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer, allocatable :: var_f
+        integer(4) :: var_g(10)
+        type(dtype_a) :: var_h
+        real(4) :: var_i
+        integer, allocatable :: var_j(:)
+        integer(4) :: var_k
+    end type dtype_b
+
+    type(dtype_b), allocatable :: var_l
+    integer :: var_m
+
+    allocate(var_l)
+
+!$omp target map(tofrom: var_l%var_h%var_c, var_l%var_k)
+    do var_m = 1, 10
+        var_l%var_h%var_c(var_m) = var_m
+    end do
+    var_l%var_k = 50
+!$omp end target
+
+print *, var_l%var_k
+print *, var_l%var_h%var_c
+
+do var_m = 1, 10
+    if (var_l%var_h%var_c(var_m) /= var_m) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+if (var_l%var_k /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-map.f90
+++ b/test/fortran-map-tests/allocatable-dtype-map.f90
@@ -1,0 +1,43 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer, allocatable :: var_b
+        integer(4) :: var_c(10)
+        real(4) :: var_d
+        integer, allocatable :: var_e(:)
+        integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a), allocatable :: var_g
+    integer :: var_h
+    allocate(var_g)
+
+!$omp target map(tofrom: var_g)
+    do var_h = 1, 10
+        var_g%var_c(var_h) = var_h
+    end do
+    var_g%var_f = 50
+!$omp end target
+
+print *, var_g%var_f
+print *, var_g%var_c
+
+do var_h = 1, 10
+    if (var_g%var_c(var_h) /= var_h) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+if (var_g%var_f /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-dtype-nested-allocatable-map.f90
+++ b/test/fortran-map-tests/allocatable-dtype-nested-allocatable-map.f90
@@ -1,0 +1,37 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        real(4) :: var_c
+        integer, allocatable :: var_d(:)
+        integer(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a), allocatable :: var_f
+    integer :: var_g
+
+    allocate(var_f)
+    allocate(var_f%var_d(10))
+
+!$omp target map(tofrom: var_f%var_d)
+    do var_g = 1, 10
+        var_f%var_d(var_g) = var_g
+    end do
+!$omp end target
+
+print *, var_f%var_d
+
+do var_g = 1, 10
+    if (var_f%var_d(var_g) /= var_g) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-full-struct.f95
+++ b/test/fortran-map-tests/allocatable-full-struct.f95
@@ -1,0 +1,55 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+  type :: dtype_a
+  integer(4) :: var_a = 0
+  real(4) :: var_b = 0.0
+  complex(4) :: var_c = (0,0)
+  end type dtype_a
+
+  type(dtype_a), allocatable :: var_d
+  type(dtype_a), allocatable :: var_e
+  allocate(var_d)
+  allocate(var_e)
+
+  var_d%var_a = 10
+  var_d%var_b = 2.0
+  var_d%var_c = (2, 10)
+
+!$omp target map(from:var_e) map(to:var_d)
+    var_e%var_a = var_d%var_a
+    var_e%var_b = var_d%var_b
+    var_e%var_c = var_d%var_c
+!$omp end target
+
+    print*, var_d%var_a
+    print*, var_d%var_b
+    write (*,*) var_d%var_c
+
+    print*, var_e%var_a
+    print*, var_e%var_b
+    write (*,*)  var_e%var_c
+
+  if (var_e%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_b /= 2.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_c /= (2, 10)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+ deallocate(var_d)
+ deallocate(var_e)
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/allocatable-map-scopes-bounds.f95
+++ b/test/fortran-map-tests/allocatable-map-scopes-bounds.f95
@@ -1,0 +1,84 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none
+  integer :: var_b, var_c
+  integer,  allocatable, intent (inout) :: var_a(:)
+
+!$omp target map(tofrom: var_a(2:6))
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 2, 6
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer :: var_a, var_b
+  integer,  allocatable :: var_c(:)
+  allocate(var_c(10))
+
+!$omp target map(tofrom: var_c(2:6))
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  print *, var_c
+
+  do var_b = 2, 6
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  deallocate(var_c)
+end subroutine sub_b
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_a, var_b
+integer,  allocatable :: var_c(:)
+
+allocate(var_c(10))
+
+!$omp target map(tofrom: var_c(2:6))
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_c
+
+  do var_b = 2, 6
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_c)
+
+  deallocate(var_c)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/allocatable-map-scopes.f95
+++ b/test/fortran-map-tests/allocatable-map-scopes.f95
@@ -1,0 +1,84 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none 
+  integer :: var_b, var_c
+  integer,  allocatable, intent (inout) :: var_a(:)
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer :: var_a, var_b
+  integer,  allocatable :: var_c(:)
+  allocate(var_c(10))
+
+!$omp target map(tofrom: var_c)
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  print *, var_c
+
+  do var_b = 1, 10
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  deallocate(var_c)
+end subroutine sub_b
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_a, var_b
+integer,  allocatable :: var_c(:)
+
+allocate(var_c(10))
+
+!$omp target map(tofrom: var_c)
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_c
+
+  do var_b = 1, 10
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_c)
+
+  deallocate(var_c)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/allocatable-map.f95
+++ b/test/fortran-map-tests/allocatable-map.f95
@@ -1,0 +1,30 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+implicit none
+  integer,  allocatable :: var_a(:)
+  integer :: var_b, var_c
+
+allocate(var_a(10))
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  do var_b = 1, 10
+    print*, var_a(var_b)
+  end do
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/allocatables-scopes-enter-exit-map.f90
+++ b/test/fortran-map-tests/allocatables-scopes-enter-exit-map.f90
@@ -1,0 +1,103 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+  subroutine sub_a(var_a)
+    implicit none 
+    integer :: var_b, var_c
+    integer,  allocatable, intent (inout) :: var_a(:)
+
+  print *, var_a
+
+  !$omp target enter data map(to: var_a)
+
+  !$omp target
+    do var_b = 1, 10
+      var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  !$omp target exit data map(delete: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+      if (var_a(var_c) /= var_c + var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+  end subroutine sub_a
+  end module
+
+  subroutine sub_b
+    implicit none
+    integer :: var_a, var_b
+    integer,  allocatable :: var_c(:)
+    allocate(var_c(10))
+
+  !$omp target enter data map(alloc: var_c)
+
+  !$omp target
+    do var_a = 1, 10
+      var_c(var_a) = var_a
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_c)
+
+  !$omp target exit data map(delete: var_c)
+
+    print *, var_c
+
+    do var_b = 1, 10
+      if (var_c(var_b) /= var_b) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+    deallocate(var_c)
+  end subroutine sub_b
+
+  program prog_a
+  use mod_a
+  implicit none
+  integer :: var_a, var_b
+  integer,  allocatable :: var_c(:)
+  allocate(var_c(10))
+
+  !$omp target enter data map(alloc: var_c)
+
+  !$omp target
+    do var_a = 1, 10
+      var_c(var_a) = var_a
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_c)
+
+  !$omp target exit data map(delete: var_c)
+
+  call sub_b
+
+  print *, var_c
+
+  do var_b = 1, 10
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+    call sub_a(var_c)
+
+    deallocate(var_c)
+
+    print *, "======= FORTRAN Test Passed! ======="
+  end program

--- a/test/fortran-map-tests/always-map-test.f90
+++ b/test/fortran-map-tests/always-map-test.f90
@@ -1,0 +1,34 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(10)
+    integer :: var_b
+
+    do var_b = 1, 10
+        var_a(var_b) = 100
+    end do
+
+    !$omp target enter data map(alloc: var_a)
+
+    !$omp target map(always, tofrom:var_a)
+        do var_b = 1, 10
+            var_a(var_b) = var_a(var_b) + 10
+        end do
+    !$omp end target
+
+    do var_b = 1, 10
+        print *, var_a(var_b)
+    end do
+
+    do var_b = 1, 10
+        if (var_a(var_b) /= 110) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+        end if
+    end do
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/array-section-1d-upperbound.f95
+++ b/test/fortran-map-tests/array-section-1d-upperbound.f95
@@ -1,0 +1,37 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    INTEGER :: var_a(10) = (/1,2,3,4,5,6,7,8,9,10/)
+    INTEGER :: var_b(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    integer :: var_c
+
+    !$omp target map(tofrom:var_a(2:6)) map(tofrom:var_b(2:6))
+        do var_c = 2, 10
+            var_b(var_c) = var_a(var_c)
+        end do
+    !$omp end target
+
+    if (var_b(1) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_c = 2, 6
+        if (var_b(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_c = 7, 10
+        if (var_b(var_c) /= 0) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/array-section-no-lower-bounds.f95
+++ b/test/fortran-map-tests/array-section-no-lower-bounds.f95
@@ -1,0 +1,34 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(10) = (/1,2,3,4,5,6,7,8,9,10/)
+    integer :: var_b = 8
+    integer :: var_c
+
+!$omp target map(tofrom:var_a(:var_b))
+    do var_c = 1, 10
+        var_a(var_c) = 42
+    end do
+!$omp end target
+
+    print *, var_a
+
+    do var_c = 1, var_b
+        if (var_a(var_c) /= 42) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+        end if
+    end do
+
+    do var_c = var_b+1, 10
+        if (var_a(var_c) /= var_c) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/array-section-runtime-bounds.f95
+++ b/test/fortran-map-tests/array-section-runtime-bounds.f95
@@ -1,0 +1,34 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer :: var_a(10) = (/1,2,3,4,5,6,7,8,9,10/)
+    integer :: var_b = 8
+    integer :: var_c = 1
+    integer :: var_d
+
+!$omp target map(tofrom:var_a(var_c:var_b))
+    do var_d = 1, 10
+        var_a(var_d) = 42
+    end do
+!$omp end target
+
+    print *, var_a
+
+    do var_d = 1, var_b
+        if (var_a(var_d) /= 42) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+        end if
+    end do
+
+    do var_d = var_b+1, 10
+        if (var_a(var_d) /= var_d) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/assumed-shape-array-vec-mul-allocatables-with-alloca-param.f95
+++ b/test/fortran-map-tests/assumed-shape-array-vec-mul-allocatables-with-alloca-param.f95
@@ -1,0 +1,69 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+
+ subroutine sub_a(var_a,var_b,var_c,var_d)
+     implicit none
+     integer, allocatable, intent(out) :: var_a(:)
+     integer, allocatable, intent(in) :: var_b(:), var_c(:)
+     integer, intent(in) :: var_d
+     integer :: var_e
+
+     allocate(var_a(5))
+
+    !$omp target map(from: var_a)
+         do var_e=1,var_d
+             var_a(var_e) = var_b(var_e) * var_c(var_e)
+         end do
+    !$omp end target
+  end subroutine
+ end module mod_a
+
+ program prog_a
+    use mod_a
+    implicit none
+    integer :: var_a = 5
+    integer, allocatable :: var_b(:)
+    integer, allocatable :: var_c(:)
+    integer, allocatable :: var_d(:)
+
+    allocate(var_c(5))
+    allocate(var_d(5))
+
+    var_c = (/1, 2, 3, 4, 5/)
+    var_d = (/6, 7, 8, 9, 10/)
+
+    call sub_a(var_b, var_c, var_d, var_a)
+
+    print *, var_b
+
+    if (var_b(1) /= 6) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(2) /= 14) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(3) /= 24) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(4) /= 36) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(5) /= 50) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+ end program

--- a/test/fortran-map-tests/assumed-shape-array-vec-mul-allocatables.f95
+++ b/test/fortran-map-tests/assumed-shape-array-vec-mul-allocatables.f95
@@ -1,0 +1,69 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+
+ subroutine sub_a(var_a,var_b,var_c,var_d)
+     implicit none
+     integer :: var_e
+     integer, intent(out) :: var_a(:)
+     integer, intent(in) :: var_b(:), var_c(:)
+     integer, intent(in) :: var_d
+
+     !$omp target map(to: var_b, var_c) map(from: var_a)
+         do var_e=1,var_d
+             var_a(var_e) = var_b(var_e) * var_c(var_e)
+         end do
+     !$omp end target
+  end subroutine
+ end module mod_a
+
+ program prog_a
+    use mod_a
+    implicit none
+    integer :: var_a = 5
+    integer, allocatable :: var_b(:)
+    integer, allocatable :: var_c(:)
+    integer, allocatable :: var_d(:)
+
+    allocate(var_b(5))
+    allocate(var_c(5))
+    allocate(var_d(5))
+
+    var_b = (/0, 0, 0, 0, 0/)
+    var_c = (/1, 2, 3, 4, 5/)
+    var_d = (/6, 7, 8, 9, 10/)
+
+    call sub_a(var_b, var_c, var_d, var_a)
+
+    print *, var_b
+
+    if (var_b(1) /= 6) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(2) /= 14) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(3) /= 24) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(4) /= 36) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(5) /= 50) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+ end program

--- a/test/fortran-map-tests/assumed-shape-array-vec-mul.f95
+++ b/test/fortran-map-tests/assumed-shape-array-vec-mul.f95
@@ -1,0 +1,61 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+   contains
+
+subroutine sub_a(var_a,var_b,var_c,var_d)
+    implicit none 
+    integer :: var_e
+    integer, intent(out) :: var_a(:)
+    integer, intent(in) :: var_b(:), var_c(:)
+    integer, intent(in) :: var_d
+
+   !$omp target map(to: var_b, var_c) map(from: var_a)
+      do var_e=1,var_d
+         var_a(var_e) = var_b(var_e) * var_c(var_e)
+      end do
+   !$omp end target
+ end subroutine
+end module mod_a
+
+program prog_a
+   use mod_a
+   implicit none
+   integer :: var_a = 5
+   integer :: var_b(5) = (/0, 0, 0, 0, 0/)
+   integer :: var_c(5) = (/1, 2, 3, 4, 5/)
+   integer :: var_d(5) = (/6, 7, 8, 9, 10/)
+
+   call sub_a(var_b, var_c, var_d, var_a)
+
+   print *, var_b
+
+   if (var_b(1) /= 6) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(2) /= 14) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(3) /= 24) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(4) /= 36) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(5) /= 50) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/assumed-size-array-vec-mul-allocatables.f95
+++ b/test/fortran-map-tests/assumed-size-array-vec-mul-allocatables.f95
@@ -1,0 +1,69 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+
+ subroutine sub_a(var_a,var_b,var_c,var_d)
+     implicit none
+     integer :: var_e
+     integer, dimension(*), intent(out) :: var_a(:)
+     integer, dimension(*), intent(in) :: var_b(:), var_c(:)
+     integer, intent(in) :: var_d
+
+     !$omp target map(to: var_b, var_c) map(from: var_a)
+         do var_e=1,var_d
+             var_a(var_e) = var_b(var_e) * var_c(var_e)
+         end do
+     !$omp end target
+  end subroutine
+ end module mod_a
+
+ program prog_a
+    use mod_a
+    implicit none
+    integer :: var_a = 5
+    integer, allocatable :: var_b(:)
+    integer, allocatable :: var_c(:)
+    integer, allocatable :: var_d(:)
+
+    allocate(var_b(5))
+    allocate(var_c(5))
+    allocate(var_d(5))
+
+    var_b = (/0, 0, 0, 0, 0/)
+    var_c = (/1, 2, 3, 4, 5/)
+    var_d = (/6, 7, 8, 9, 10/)
+
+    call sub_a(var_b, var_c, var_d, var_a)
+
+    print *, var_b
+
+    if (var_b(1) /= 6) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(2) /= 14) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(3) /= 24) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(4) /= 36) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    if (var_b(5) /= 50) then
+       print*, "======= FORTRAN Test Failed! ======="
+       stop 1
+    end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+ end program

--- a/test/fortran-map-tests/assumed-size-array-vec-mul.f95
+++ b/test/fortran-map-tests/assumed-size-array-vec-mul.f95
@@ -1,0 +1,56 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a,var_b,var_c,var_d)
+    implicit none
+    integer, dimension(*), intent(out) :: var_a
+    integer, dimension(*), intent(in) :: var_b, var_c
+    integer, intent(in) :: var_d
+    integer :: var_e
+
+    !$omp target map(to: var_b(1:var_d), var_c(:var_d)) map(from: var_a(1:var_d))
+        do var_e=1,var_d
+            var_a(var_e) = var_b(var_e) * var_c(var_e)
+        end do
+    !$omp end target
+ end subroutine
+
+program prog_a
+   implicit none
+   integer :: var_a = 5
+   integer :: var_b(5) = (/0, 0, 0, 0, 0/)
+   integer :: var_c(5) = (/1, 2, 3, 4, 5/)
+   integer :: var_d(5) = (/6, 7, 8, 9, 10/)
+
+   call sub_a(var_b, var_c, var_d, var_a)
+
+   print *, var_b
+
+   if (var_b(1) /= 6) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(2) /= 14) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(3) /= 24) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(4) /= 36) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   if (var_b(5) /= 50) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/attach_always.f90
+++ b/test/fortran-map-tests/attach_always.f90
@@ -1,0 +1,63 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:)
+    integer, target :: var_b(10)
+    integer, target :: var_c(10)
+    integer :: var_d, var_e
+    logical :: var_f
+
+    var_e = 10
+    var_f = .true.
+
+    do var_d = 1, var_e
+        var_b(var_d) = 10
+        var_c(var_d) = 20
+    end do
+
+    var_a => var_b
+
+   ! This should map a,b and map_ptr to device, and attach map_ptr
+   ! to a (as it is assigned to it above), and as b is already on
+   ! device running through target.
+   !$omp target enter data map(ref_ptr_ptee, to: var_a)
+   !$omp target enter data map(to: var_c, var_b)
+
+    !$omp target map(to: var_d) map(tofrom: var_f)
+        do var_d = 1, var_e
+            if (var_a(var_d) /= 10) then
+                var_f = .false.
+            endif
+        end do
+    !$omp end target
+
+    var_a => var_c
+
+    ! No attach always to force re-attachment, so we should still
+    ! be attached to "a"
+    !$omp target map(to: var_d) map(tofrom: var_f)
+        do var_d = 1, var_e
+            if (var_a(var_d) /= 10) then
+                var_f = .false.
+            endif
+        end do
+    !$omp end target
+
+    !$omp target map(to: var_d) map(attach(always): var_a) map(tofrom: var_f)
+        do var_d = 1, var_e
+            if (var_a(var_d) /= 20) then
+                var_f = .false.
+            endif
+        end do
+    !$omp end target
+
+    if (var_f .NEQV. .true.) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/attach_never.f90
+++ b/test/fortran-map-tests/attach_never.f90
@@ -1,0 +1,48 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:)
+    integer, target :: var_b(10)
+    integer, target :: var_c(10)
+    integer :: var_d, var_e
+    logical :: var_f
+
+    var_f = .true.
+    var_e = 10
+
+    do var_d = 1, var_e
+        var_b(var_d) = 10
+        var_c(var_d) = 20
+    end do
+
+    var_a => var_b
+
+    ! This should map a and map_ptr to device, and attach map_ptr
+    ! to a (as it is assigned to it above).
+    !$omp target enter data map(ref_ptr_ptee, to: var_a)
+
+    var_a => var_c
+
+    ! As "b" hasn't been mapped to device yet, the first time it's mapped will
+    ! be when map_ptr is re-mapped (implicitly or explicitly), the default behaviour
+    ! when LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS is switched off would force attachment
+    ! of map_ptr to b as we've assigned it above. To prevent this and test the never
+    ! attachment, we can apply attach(never), which prevents this reattachment from occuring
+    !$omp target map(to: var_d) map(tofrom: var_f) map(attach(never): var_a)
+        do var_d = 1, var_e
+            if (var_a(var_d) /= 10) then
+                var_f = .false.
+            endif
+        end do
+    !$omp end target
+
+    if (var_f .NEQV. .true.) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/basic-double-target-call.f95
+++ b/test/fortran-map-tests/basic-double-target-call.f95
@@ -1,0 +1,40 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a)
+implicit none
+integer, intent(in), dimension(10) :: var_a
+integer var_b
+do var_b = 1, 10
+     PRINT *, var_a(var_b)
+end do
+end subroutine
+
+program prog_a
+  INTEGER :: var_a(10) = (/0,0,0,0,0,0,0,0,0,0/)
+  integer :: var_b
+
+!$omp target map(tofrom:var_a)
+  do var_b = 1, 10
+      var_a(var_b) = var_b;
+  end do
+!$omp end target
+
+!$omp target map(tofrom:var_a)
+  do var_b = 1, 10
+      var_a(var_b) = var_a(var_b) + var_b;
+  end do
+!$omp end target
+
+call sub_a(var_a)
+
+do var_b = 1, 10
+  if (var_a(var_b) /= var_b * 2) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+end do
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/basic-example-v2.f95
+++ b/test/fortran-map-tests/basic-example-v2.f95
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    INTEGER :: var_a = 1
+!$omp declare target link(var_a)
+end module mod_a
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_b
+
+!$omp target map(tofrom:var_b) map(tofrom:var_a)
+    var_b = var_a
+!$omp end target
+
+    PRINT *, var_b
+    PRINT *, var_a
+
+if (var_a /= var_b) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/basic-example.f95
+++ b/test/fortran-map-tests/basic-example.f95
@@ -1,0 +1,40 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    INTEGER :: var_a(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    !$omp declare target link(var_a)
+end module mod_a
+
+subroutine sub_a(var_a)
+integer, intent(in), dimension(10) :: var_a
+integer var_b
+do var_b = 1, 10
+     PRINT *, var_a(var_b)
+end do
+end subroutine
+
+program prog_a
+    use mod_a
+    implicit none
+    integer :: var_b
+
+!$omp target map(tofrom:var_a)
+    do var_b = 1, 10
+        var_a(var_b) = var_b;
+    end do
+!$omp end target
+
+call sub_a(var_a)
+
+do var_b = 1, 10
+    if (var_a(var_b) /= var_b) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/basic-exp-map.f95
+++ b/test/fortran-map-tests/basic-exp-map.f95
@@ -1,0 +1,35 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a)
+implicit none
+real, intent(in), dimension(10) :: var_a
+integer var_b
+do var_b = 1, 10
+     PRINT *, var_a(var_b)
+end do
+end subroutine
+
+program prog_a
+implicit none
+REAL :: var_a(10) = (/0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5/)
+integer :: var_b 
+
+!$omp target map(tofrom:var_a)
+    do var_b = 1, 10
+        var_a(var_b) = var_a(var_b) + var_b
+    end do
+!$omp end target
+
+call sub_a(var_a)
+
+do var_b = 1, 10
+    if (var_a(var_b) /= var_b + 0.5) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/char-array-map-test-v1.f90
+++ b/test/fortran-map-tests/char-array-map-test-v1.f90
@@ -1,0 +1,30 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  TYPE dtype_a
+    CHARACTER(LEN=16), DIMENSION(:,:), ALLOCATABLE :: var_a
+    CHARACTER(LEN=16),             DIMENSION(:,:), ALLOCATABLE :: var_b
+    CHARACTER(LEN=16), DIMENSION(:), POINTER :: var_c
+  END TYPE dtype_a
+  type(dtype_a) :: var_d
+
+  allocate(var_d%var_a(10,10))
+
+!$OMP TARGET ENTER DATA MAP (ALLOC:var_d%var_a)
+
+!$omp target map(tofrom: var_d%var_a)
+    var_d%var_a(2,2) = 'c'
+!$omp end target
+
+!$OMP TARGET UPDATE FROM(var_d%var_a)
+
+
+ print *, var_d%var_a(2,2)
+ if (var_d%var_a(2,2) /= 'c') then
+    print *, "======= FORTRAN Test Failed! ======="
+ end if
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/char-array-map-test-v2.f90
+++ b/test/fortran-map-tests/char-array-map-test-v2.f90
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  TYPE dtype_a
+    CHARACTER(LEN=16), DIMENSION(10,10) :: var_a
+    CHARACTER(LEN=16),             DIMENSION(:,:), ALLOCATABLE :: var_b
+    CHARACTER(LEN=16), DIMENSION(:), POINTER :: var_c
+  END TYPE dtype_a
+  type(dtype_a) :: var_d
+
+!$OMP TARGET ENTER DATA MAP (ALLOC:var_d%var_a)
+
+!$omp target map(tofrom: var_d%var_a)
+    var_d%var_a(2,2) = 'c'
+!$omp end target
+
+!$OMP TARGET UPDATE FROM(var_d%var_a)
+
+ print *, var_d%var_a(2,2)
+ if (var_d%var_a(2,2) /= 'c') then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+ end if
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/check_fortran_map_tests.sh
+++ b/test/fortran-map-tests/check_fortran_map_tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier:  MIT
+
+if [ $# -lt 1 ]; then
+  echo "Error: You need to select execution mode."
+  exit 1
+fi
+
+if [[ "$1" -eq 0 ]]; then
+# These currently should all pass.
+export OMP_TARGET_OFFLOAD=MANDATORY
+
+echo "OFFLOAD MANDATORY"
+
+./test.sh
+
+elif [[ "$1" -eq 1 ]]; then
+# Running these is more for experimental purposes, and future fixing.
+# A lot will currently fail in host fallback mode.
+
+export OMP_TARGET_OFFLOAD=DISABLED
+
+echo "OFFLOAD DISABLED"
+
+./test.sh
+
+# Unset OMP_TARGET_OFFLOAD and remove files.
+
+unset OMP_TARGET_OFFLOAD
+
+fi
+
+rm *.out
+rm *.mod

--- a/test/fortran-map-tests/complex-array.f95
+++ b/test/fortran-map-tests/complex-array.f95
@@ -1,0 +1,29 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    complex  :: var_a(10)
+    complex  :: var_b(10)
+    integer :: var_c
+
+    do var_c = 1, 10
+        var_b(var_c) = (10,20)
+    end do
+
+!$omp target map(from:var_a) map(to:var_b)
+    do var_c = 1, 10
+        var_a(var_c) = var_b(var_c)
+    end do 
+!$omp end target
+
+ do var_c = 1, 10
+ if (var_a(var_c) /= (10,20)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/complex.f95
+++ b/test/fortran-map-tests/complex.f95
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    complex  :: var_a
+    complex  :: var_b
+    var_b = (10,20)
+
+!$omp target map(from:var_a) map(to:var_b)
+    var_a = var_b
+!$omp end target
+
+    write (*,*) var_a
+    write (*,*) var_b
+
+    if (var_b /= (10,20)) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_a /= (10,20)) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/constant-array-access.f95
+++ b/test/fortran-map-tests/constant-array-access.f95
@@ -1,0 +1,29 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    integer :: var_a(1)
+!$omp declare target link(var_a)
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+    integer :: var_b(1)  
+    integer :: var_c(1)  
+    var_a(1) = 10
+    var_b(1) = 20
+   
+!$omp target map(tofrom:var_a,var_b,var_c)
+    var_c(1) = var_a(1) + var_b(1)
+!$omp end target
+
+if ( var_c(1) /= 30 ) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1  
+end if
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/constant-index-in-target.f95
+++ b/test/fortran-map-tests/constant-index-in-target.f95
@@ -1,0 +1,51 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+  subroutine sub_a(var_a)
+      implicit none
+      integer, intent(in), dimension(10) :: var_a
+      integer var_b
+      do var_b = 1, 10
+            PRINT *, var_a(var_b)
+      end do
+  end subroutine
+
+  program prog_a
+      implicit none
+      integer :: var_a(10) = (/0,0,0,0,0,0,0,0,0,0/)
+      integer :: var_b
+
+    !$omp target map(tofrom:var_a)
+       var_a(1) = 20
+       var_a(5) = 10
+    !$omp end target
+
+    call sub_a(var_a)
+
+    if (var_a(1) /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+
+   if (var_a(5) /= 10) then
+     print*, "======= FORTRAN Test Failed! ======="
+     stop 1
+   end if
+
+  do var_b = 2, 4
+    if (var_a(var_b) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_b = 6, 10
+    if (var_a(var_b) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/declare-target-allocatable-array.f90
+++ b/test/fortran-map-tests/declare-target-allocatable-array.f90
@@ -1,0 +1,49 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    integer, allocatable, dimension(:) :: var_a
+    !$omp declare target(var_a)
+  end module mod_a
+
+  program prog_a
+    use mod_a
+    implicit none
+    integer :: var_b, var_c
+
+    allocate(var_a(10))
+
+    do var_c = 1, 10
+        var_a(var_c) = 0
+    end do
+
+!$omp target data map(to:var_a)
+
+  do var_b = 1, 2
+
+    !$omp target
+        do var_c = 1, 10
+            var_a(var_c) = var_a(var_c) + var_c
+        end do
+    !$omp end target
+
+! NOTE: Technically doesn't affect the results, but there is a
+! regression case that'll cause a runtime crash if this is
+! invoked more than once, so this checks for that.
+!$omp target update from(var_a)
+  end do
+
+!$omp end target data
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c + var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+    end if
+  end do
+
+  print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM

--- a/test/fortran-map-tests/declare-target-enter-usm.f90
+++ b/test/fortran-map-tests/declare-target-enter-usm.f90
@@ -1,0 +1,78 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    integer :: var_a = 10
+    integer :: var_b(10)
+    integer, allocatable :: var_c
+    integer, allocatable :: var_d(:)
+!$omp requires unified_shared_memory
+!$omp declare target(var_a)
+!$omp declare target(var_b)
+!$omp declare target(var_c)
+!$omp declare target(var_d)
+ contains
+end module
+program prog_a
+ use mod_a
+ implicit none
+ integer :: var_e
+
+ allocate(var_c)
+ allocate(var_d(10))
+
+ var_c = 25
+
+!$omp target
+    var_a = var_a + 10
+!$omp end target
+
+!$omp target
+  do var_e = 1, 10
+    var_b(var_e) = var_a
+  enddo
+!$omp end target
+
+!$omp target
+    var_c = var_c + 25
+!$omp end target
+
+!$omp target
+  do var_e = 1, 10
+    var_d(var_e) = var_c
+  enddo
+!$omp end target
+
+  print *, var_a
+  print *, var_b
+  print *, var_c
+  print *, var_d
+
+  if (var_a /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_a = 1, 10
+    if (var_b(var_a) /= 20) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  if (var_c /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_a = 1, 10
+    if (var_d(var_a) /= 50) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/declare-target-link-implicit.f90
+++ b/test/fortran-map-tests/declare-target-link-implicit.f90
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    integer :: var_a = 10
+    !$omp declare target link(var_a)
+end module mod_a
+
+program prog_a
+use mod_a
+implicit none
+
+!$omp target
+ var_a = 10 + 10
+!$omp end target
+
+ print *, var_a 
+
+if (var_a /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="     
+    stop 1    
+end if  
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/decltar-double-target-call.f95
+++ b/test/fortran-map-tests/decltar-double-target-call.f95
@@ -1,0 +1,47 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    INTEGER :: var_a(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    !$omp declare target link(var_a)
+end module mod_a
+
+subroutine sub_a(var_b)
+integer, intent(in), dimension(10) :: var_b
+integer var_c
+do var_c = 1, 10
+     PRINT *, var_b(var_c)
+end do
+end subroutine
+
+program prog_a
+  use mod_a
+  implicit none
+  integer :: var_b
+
+!$omp target map(tofrom:var_a)
+  do var_b = 1, 10
+      var_a(var_b) = var_b;
+  end do
+!$omp end target
+
+!$omp target map(tofrom:var_a)
+  do var_b = 1, 10
+      var_a(var_b) = var_a(var_b) + var_b;
+  end do
+!$omp end target
+
+call sub_a(var_a)
+
+do var_b = 1, 10
+  if (var_a(var_b) /= var_b * 2) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+end do
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/derived-type-individual-array-map-with-bounds.f90
+++ b/test/fortran-map-tests/derived-type-individual-array-map-with-bounds.f90
@@ -1,0 +1,48 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+  type(dtype_a) :: var_f
+  integer :: var_g
+
+  !$omp target map(tofrom:var_f%var_b(3:6))
+    do var_g = 3, 6
+      var_f%var_b(var_g) = var_g
+    end do
+  !$omp end target
+
+  print*, var_f%var_b
+  
+  do var_g = 1, 2
+    if (var_f%var_b(var_g) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_g = 3, 6
+    if (var_f%var_b(var_g) /= var_g) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_g = 7, 10
+    if (var_f%var_b(var_g) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/derived-type-individual-array-map.f90
+++ b/test/fortran-map-tests/derived-type-individual-array-map.f90
@@ -1,0 +1,35 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+  implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    integer :: var_g
+
+  !$omp target map(tofrom:var_f%var_d)
+    do var_g = 1, 10
+      var_f%var_d(var_g) = var_g
+    end do
+  !$omp end target
+
+  print*, var_f%var_d
+
+  do var_g = 1, 10
+    if (var_f%var_d(var_g) /= var_g) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/derived-type-map-from-alloca-issue.f90
+++ b/test/fortran-map-tests/derived-type-map-from-alloca-issue.f90
@@ -1,0 +1,54 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+
+  type :: dtype_a
+    real(4) :: var_a
+    integer, allocatable :: var_b
+    integer(4) :: var_c(10)
+    real(4) :: var_d
+    integer, allocatable :: var_e(:)
+    integer(4) :: var_f
+  end type dtype_a
+
+  type(dtype_a) :: var_g
+  integer, allocatable :: var_h(:)
+  integer :: var_i
+
+  allocate(var_g%var_e(10))
+  allocate(var_h(10))
+
+!$omp target map(from: var_h)
+  do var_i = 1, 10
+      var_h(var_i) = var_i
+  end do
+!$omp end target
+
+!$omp target map(from: var_g%var_e)
+  do var_i = 1, 10
+    var_g%var_e(var_i) = var_i
+  end do
+!$omp end target
+
+  print *, var_h
+  print *, var_g%var_e
+
+  do var_i = 1, 10
+    if (var_g%var_e(var_i) /= var_i) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_i = 1, 10
+    if (var_h(var_i) /= var_i) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/derived-type-member-array-map-3.f90
+++ b/test/fortran-map-tests/derived-type-member-array-map-3.f90
@@ -1,0 +1,54 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    integer :: var_g
+
+  do var_g = 1, 10
+    var_f%var_b(var_g) = var_g
+  end do
+
+  !$omp target map(tofrom:var_f%var_b(3:6), var_f%var_d(3:6))
+    do var_g = 1, 10
+      var_f%var_d(var_g) = var_f%var_b(var_g)
+    end do
+  !$omp end target
+
+  print*, var_f%var_b
+  print*, var_f%var_d
+
+  do var_g = 1, 2
+    if (var_f%var_d(var_g) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_g = 3, 6
+    if (var_f%var_d(var_g) /= var_g) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_g = 7, 10
+    if (var_f%var_d(var_g) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/derived-type-member-array-map.f90
+++ b/test/fortran-map-tests/derived-type-member-array-map.f90
@@ -1,0 +1,39 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    integer :: var_g
+
+  do var_g = 1, 10
+    var_f%var_b(var_g) = var_g
+  end do
+
+  !$omp target map(tofrom:var_f%var_b, var_f%var_d)
+    do var_g = 1, 10
+      var_f%var_d(var_g) = var_f%var_b(var_g)
+    end do
+  !$omp end target
+
+  print*, var_f%var_b
+  print*, var_f%var_d
+
+  do var_g = 1, 10
+    if (var_f%var_d(var_g) /= var_g) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-derived-type-double-member-array-map.f90
+++ b/test/fortran-map-tests/double-derived-type-double-member-array-map.f90
@@ -1,0 +1,85 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    type(dtype_a) :: var_g
+
+    integer :: var_h
+
+  do var_h = 1, 10
+    var_f%var_b(var_h) = var_h
+    var_g%var_b(var_h) = var_h
+  end do
+
+  !$omp target map(tofrom:var_f%var_b(3:6), var_f%var_d(3:6), var_g%var_b(3:6), var_g%var_d(3:6))
+    do var_h = 1, 10
+      var_g%var_d(var_h) = var_f%var_b(var_h)
+    end do
+
+    do var_h = 1, 10
+      var_f%var_d(var_h) = var_g%var_b(var_h)
+    end do
+  !$omp end target
+
+  print*, var_f%var_b
+  print*, var_g%var_d
+
+  print*, var_g%var_b
+  print*, var_f%var_d
+
+  do var_h = 1, 2
+    if (var_g%var_d(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 3, 6
+    if (var_g%var_d(var_h) /= var_h) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 7, 10
+    if (var_g%var_d(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 1, 2
+    if (var_f%var_d(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 3, 6
+    if (var_f%var_d(var_h) /= var_h) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 7, 10
+    if (var_f%var_d(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-derived-type-individual-member-map.f90
+++ b/test/fortran-map-tests/double-derived-type-individual-member-map.f90
@@ -1,0 +1,36 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b(10)
+        real(4) :: var_c
+        real(4) :: var_d(10)
+        real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    type(dtype_a) :: var_g
+
+  !$omp target map(tofrom:var_f%var_c, var_g%var_e)
+    var_g%var_e = 10
+    var_f%var_c = 15
+  !$omp end target
+
+  print*, var_f%var_c
+  print*, var_g%var_e
+
+  if (var_f%var_c /= 15) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+  
+  if (var_g%var_e /= 10) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-dtype-mem-individual-arr-bounds-map.f90
+++ b/test/fortran-map-tests/double-dtype-mem-individual-arr-bounds-map.f90
@@ -1,0 +1,72 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c
+      real(4) :: var_d(10)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    type(dtype_a) :: var_g
+    integer :: var_h
+
+  !$omp target map(tofrom:var_f%var_b(3:6), var_g%var_b(3:6))
+    do var_h = 1, 10
+      var_g%var_b(var_h) = var_h
+      var_f%var_b(var_h) = var_h
+    end do
+  !$omp end target
+
+  print*, var_f%var_b  
+  print*, var_g%var_b
+
+  do var_h = 1, 2
+    if (var_g%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 3, 6
+    if (var_g%var_b(var_h) /= var_h) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 7, 10
+    if (var_g%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 1, 2
+    if (var_f%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 3, 6
+    if (var_f%var_b(var_h) /= var_h) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 7, 10
+    if (var_f%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-dtype-mixed-imp-exp-member-maps-with-bounds.f90
+++ b/test/fortran-map-tests/double-dtype-mixed-imp-exp-member-maps-with-bounds.f90
@@ -1,0 +1,54 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b(10)
+        real(4) :: var_c
+        real(4) :: var_d(10)
+        real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    type(dtype_a) :: var_g
+    integer :: var_h
+
+  do var_h = 1, 10
+    var_f%var_b(var_h) = var_h
+  end do
+
+  !$omp target map(tofrom:var_g%var_b(3:6))
+    do var_h = 3, 6
+      var_g%var_b(var_h) = var_f%var_b(var_h)
+    end do
+  !$omp end target
+
+  print*, var_f%var_b
+  print*, var_g%var_b
+
+  do var_h = 1, 2
+    if (var_g%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 3, 6
+    if (var_g%var_b(var_h) /= var_h) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_h = 7, 10
+    if (var_g%var_b(var_h) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-dtype-mixed-imp-exp-member-maps.f90
+++ b/test/fortran-map-tests/double-dtype-mixed-imp-exp-member-maps.f90
@@ -1,0 +1,36 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b(10)
+        real(4) :: var_c
+        real(4) :: var_d(10)
+        real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    type(dtype_a) :: var_g
+
+  !$omp target map(tofrom:var_f%var_c)
+    var_g%var_e = 10
+    var_f%var_c = 15
+  !$omp end target
+
+  print*, var_f%var_c
+  print*, var_g%var_e
+
+  if (var_f%var_c /= 15) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_g%var_e /= 10) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/double-dtype-nested-double-member-array-map.f90
+++ b/test/fortran-map-tests/double-dtype-nested-double-member-array-map.f90
@@ -1,0 +1,89 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+     real(4) :: var_a(10)
+     real(4) :: var_b
+     real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+    real(4) :: var_d
+    real(4) :: var_e(10)
+    real(4) :: var_f
+    real(4) :: var_g(10)
+    real(4) :: var_h
+    type(dtype_a) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+  do var_l = 1, 10
+    var_j%var_i%var_a(var_l) = var_l
+    var_k%var_i%var_a(var_l) = var_l
+  end do
+
+  !$omp target map(tofrom:var_j%var_i%var_a(3:6), var_j%var_i%var_c(3:6), var_k%var_i%var_a(3:6), var_k%var_i%var_c(3:6))
+    do var_l = 3, 6
+      var_k%var_i%var_c(var_l) = var_j%var_i%var_a(var_l)
+    end do
+
+    do var_l = 3, 6
+      var_j%var_i%var_c(var_l) = var_k%var_i%var_a(var_l)
+    end do
+  !$omp end target
+
+  print*, var_j%var_i%var_c
+  print*, var_k%var_i%var_a
+
+  print*, var_k%var_i%var_c
+  print*, var_j%var_i%var_a
+
+  do var_l = 1, 2
+    if (var_k%var_i%var_c(var_l) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_l = 3, 6
+    if (var_k%var_i%var_c(var_l) /= var_l) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_l = 7, 10
+    if (var_k%var_i%var_c(var_l) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_l = 1, 2
+    if (var_j%var_i%var_c(var_l) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_l = 3, 6
+    if (var_j%var_i%var_c(var_l) /= var_l) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_l = 7, 10
+    if (var_j%var_i%var_c(var_l) /= 0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-allocatable-and-array-map.f90
+++ b/test/fortran-map-tests/dtype-allocatable-and-array-map.f90
@@ -1,0 +1,50 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+
+    type :: dtype_a
+    real(4) :: var_a
+    integer, allocatable :: var_b
+    integer(4) :: var_c(10)
+    real(4) :: var_d
+    integer, allocatable :: var_e(:)
+    integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a) :: var_g
+    integer :: var_h
+
+    allocate(var_g%var_e(10))
+    allocate(var_g%var_b)
+
+    do var_h = 1, 10
+        var_g%var_c(var_h) = var_h
+    end do
+
+    !$omp target map(to: var_g%var_c) map(from: var_g%var_e)
+        do var_h = 1, 10
+            var_g%var_e(var_h) = var_g%var_c(var_h) + var_h
+        end do
+    !$omp end target
+
+    print *, var_g%var_c
+    print *, var_g%var_e
+
+    do var_h = 1, 10
+        if (var_g%var_e(var_h) /= var_h + var_h) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_h = 1, 10
+        if (var_g%var_c(var_h) /= var_h) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-allocatable-and-dtype-map.f90
+++ b/test/fortran-map-tests/dtype-allocatable-and-dtype-map.f90
@@ -1,0 +1,57 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_d
+        integer, allocatable :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        integer, allocatable :: var_h(:)
+        integer(4) :: var_i
+        type(dtype_a) :: var_j
+    end type dtype_b
+
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+    allocate(var_k%var_h(10))
+    allocate(var_k%var_e)
+
+    do var_l = 1, 10
+        var_k%var_j%var_b(var_l) = var_l
+    end do
+
+    !$omp target map(tofrom: var_k%var_j, var_k%var_h)
+    do var_l = 1, 10
+        var_k%var_h(var_l) = var_k%var_j%var_b(var_l) + var_l
+    end do
+    !$omp end target
+
+    print *, var_k%var_j%var_b
+    print *, var_k%var_h
+
+    do var_l = 1, 10
+        if (var_k%var_h(var_l) /= var_l + var_l) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_l = 1, 10
+        if (var_k%var_j%var_b(var_l) /= var_l) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-allocatable-array-with-bounds-map.f90
+++ b/test/fortran-map-tests/dtype-allocatable-array-with-bounds-map.f90
@@ -1,0 +1,57 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+    real(4) :: var_d
+    integer, allocatable :: var_e
+    integer(4) :: var_f(10)
+    real(4) :: var_g
+    integer, allocatable :: var_h(:)
+    integer(4) :: var_i
+    type(dtype_a) :: var_j
+    end type dtype_b
+
+    type(dtype_b) :: var_k
+    integer :: var_l, var_m
+
+    allocate(var_k%var_h(10))
+    allocate(var_k%var_e)
+
+!$omp target map(tofrom: var_k%var_h(2:6))
+    do var_m = 1, 10
+        var_k%var_h(var_m) = var_m
+    end do
+!$omp end target
+
+print *, var_k%var_h
+
+if (var_k%var_h(1) == 1) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+do var_l = 2, 6
+    if (var_k%var_h(var_l) /= var_l) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_l = 7, 10
+    if (var_k%var_h(var_l) == var_l) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-allocatable-array3d-with-bounds-map.f90
+++ b/test/fortran-map-tests/dtype-allocatable-array3d-with-bounds-map.f90
@@ -1,0 +1,64 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      integer(4) :: var_b(10)
+      integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_e
+      integer, allocatable :: var_f
+      integer(4) :: var_g(10)
+      real(4) :: var_h
+      integer, allocatable :: var_i(:,:,:)
+      integer(4) :: var_j
+      type(dtype_a) :: var_k
+    end type dtype_b
+
+    type(dtype_b) :: var_l
+    integer :: var_m(3,3,3)
+    integer :: var_n, var_o, var_p
+
+    allocate(var_l%var_i(3,3,3))
+    allocate(var_l%var_f)
+
+    do var_n = 1, 3
+        do var_o = 1, 3
+          do var_p = 1, 3
+              var_m(var_n, var_o, var_p) = 42
+              var_l%var_i(var_n, var_o, var_p) = 0
+          end do
+         end do
+      end do
+
+!$omp target map(tofrom: var_l%var_i(1:3, 1:3, 2:2)) map(to: var_m(1:3, 1:3, 1:3))
+    do var_o = 1, 3
+        do var_p = 1, 3
+            var_l%var_i(var_p, var_o, 2) = var_m(var_p, var_o, 2)
+        end do
+      end do
+!$omp end target
+
+    print *, var_l%var_i
+
+    do var_n = 1, 3
+        do var_o = 1, 3
+          do var_p = 1, 3
+            if (var_n == 2 .and. var_l%var_i(var_p, var_o, var_n) /= 42) then
+              print *, "======= FORTRAN Test Failed! ======="
+              stop 1
+            else if (var_n /= 2 .and. var_l%var_i(var_p, var_o, var_n) /= 0) then
+              print *, "======= FORTRAN Test Failed! ======="
+              stop 1
+            end if
+          end do
+        end do
+    end do
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-allocatable-scalar-map.f90
+++ b/test/fortran-map-tests/dtype-allocatable-scalar-map.f90
@@ -1,0 +1,53 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a
+    type :: dtype_a
+    real(4) :: var_b
+    integer(4) :: var_c(10)
+    integer, allocatable :: var_d(:)
+    integer(4) :: var_e
+    end type dtype_a
+
+    type :: dtype_b
+    real(4) :: var_f
+    integer, allocatable :: var_g 
+    integer(4) :: var_h(10)
+    real(4) :: var_i
+    integer, allocatable :: var_j(:)
+    integer(4) :: var_k
+    type(dtype_a) :: var_l
+    end type dtype_b
+
+    type(dtype_b) :: var_m
+
+    allocate(var_m%var_j(10))
+    allocate(var_m%var_g)
+
+    !$omp target map(tofrom: var_m%var_j, var_m%var_i)
+        do var_a = 1, 10
+            var_m%var_j(var_a) = var_a
+        end do
+        var_m%var_i = 50
+    !$omp end target
+
+    print *, var_m%var_i
+    print *, var_m%var_j
+
+    do var_a = 1, 10
+        if (var_m%var_j(var_a) /= var_a) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    if (var_m%var_i /= 50) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-allocatable.f90
+++ b/test/fortran-map-tests/dtype-array-allocatable.f90
@@ -1,0 +1,38 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer, allocatable :: var_b
+        integer(4) :: var_c(10)
+        real(4) :: var_d
+        integer, allocatable :: var_e(:)
+        integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a) :: var_g
+    integer :: var_h
+
+    allocate(var_g%var_e(10))
+
+!$omp target map(tofrom: var_g%var_e)
+    do var_h = 1, 10
+        var_g%var_e(var_h) = var_h
+    end do
+!$omp end target
+
+print *, var_g%var_e
+
+do var_h = 1, 10
+    if (var_g%var_e(var_h) /= var_h) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map-v2.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map-v2.f90
@@ -1,0 +1,43 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a) :: var_h(10)
+        integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b), allocatable :: var_j
+    integer :: var_k
+    allocate(var_j)
+
+!$omp target map(tofrom: var_j%var_h)
+    do var_k = 1, 10
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 10
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map-v3.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map-v3.f90
@@ -1,0 +1,44 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a), allocatable :: var_h(:)
+        integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    integer :: var_k
+    allocate(var_j%var_h(10))
+
+!$omp target map(tofrom: var_j%var_h)
+    do var_k = 1, 10
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 10
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map-v4.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map-v4.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a), allocatable :: var_h(:)
+        integer(4) :: var_i 
+    end type dtype_b
+    
+    type(dtype_b), allocatable :: var_j
+    integer :: var_k
+    allocate(var_j)
+    allocate(var_j%var_h(10))
+
+!$omp target map(tofrom: var_j%var_h)
+    do var_k = 1, 10
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 10
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1    
+    end if  
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map-v5.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map-v5.f90
@@ -1,0 +1,58 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a), allocatable :: var_h(:)
+        integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b), allocatable :: var_j
+    integer :: var_k
+    allocate(var_j)
+    allocate(var_j%var_h(10))
+
+!$omp target map(tofrom: var_j%var_h(4:8))
+    do var_k = 1, 10
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 3
+    if (var_j%var_h(var_k)%var_d == var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_k = 4, 8
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_k = 9, 10
+    if (var_j%var_h(var_k)%var_d == var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map-v6.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map-v6.f90
@@ -1,0 +1,56 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a) :: var_h(10)
+        integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    integer :: var_k
+
+!$omp target map(tofrom: var_j%var_h(4:8))
+    do var_k = 4, 8
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 3
+    if (var_j%var_h(var_k)%var_d == var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_k = 4, 8
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_k = 9, 10
+    if (var_j%var_h(var_k)%var_d == var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-array-of-dtype-member-map.f90
+++ b/test/fortran-map-tests/dtype-array-of-dtype-member-map.f90
@@ -1,0 +1,42 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer(4) :: var_f(10)
+        real(4) :: var_g
+        type(dtype_a) :: var_h(10)
+        integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    integer :: var_k
+
+!$omp target map(tofrom: var_j%var_h)
+    do var_k = 1, 10
+        var_j%var_h(var_k)%var_d = var_k
+    end do
+!$omp end target
+
+do var_k = 1, 10
+    print *, var_j%var_h(var_k)%var_d
+end do
+
+do var_k = 1, 10
+    if (var_j%var_h(var_k)%var_d /= var_k) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-class-dummy-full-exp-imp-map.f90
+++ b/test/fortran-map-tests/dtype-class-dummy-full-exp-imp-map.f90
@@ -1,0 +1,73 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    type :: dtype_a
+        real(4) :: var_a
+        real(4) :: var_b
+        integer(4) :: var_c(10)
+        integer(4) :: var_d
+        integer(4) :: var_e(10)
+    end type dtype_a
+contains
+subroutine sub_a(var_f)
+    implicit none
+    integer :: var_g
+    class(dtype_a) :: var_f
+
+    !$omp target
+      do var_g = 1, 10
+        var_f%var_c(var_g) = var_g
+      end do
+      var_f%var_d = 20
+    !$omp end target
+end subroutine
+
+subroutine sub_b(var_f)
+    implicit none
+    integer :: var_g
+    class(dtype_a) :: var_f
+
+   !$omp target map(tofrom: var_f)
+      do var_g = 1, 10
+        var_f%var_e(var_g) = var_f%var_c(var_g) + 1
+      end do
+      var_f%var_d = 20 + var_f%var_d
+   !$omp end target
+end subroutine
+
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+    type(dtype_a) :: var_h
+    integer :: var_i
+
+    call sub_a(var_h)
+    call sub_b(var_h)
+
+    print *, var_h
+
+    if (var_h%var_d /= 40) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_i = 1, 10
+        if (var_h%var_c(var_i) /= var_i) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_i = 1, 10
+        if (var_h%var_e(var_i) /= var_i + 1) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-double-allocatable.f90
+++ b/test/fortran-map-tests/dtype-double-allocatable.f90
@@ -1,0 +1,44 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    integer, allocatable :: var_b 
+    integer(4) :: var_c(10)
+    real(4) :: var_d
+    integer, allocatable :: var_e(:)
+    integer(4) :: var_f
+    end type dtype_a
+
+    type(dtype_a) :: var_g
+    integer :: var_h
+
+    allocate(var_g%var_e(10))
+    allocate(var_g%var_b) 
+
+    !$omp target map(tofrom: var_g%var_b, var_g%var_e)
+    do var_h = 1, 10
+        var_g%var_e(var_h) = var_h
+    end do
+    var_g%var_b = 50
+    !$omp end target
+
+    print *, var_g%var_e
+    print *, var_g%var_b
+
+    do var_h = 1, 10
+        if (var_g%var_e(var_h) /= var_h) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    if (var_g%var_b /= 50) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-enter-exit-update.f90
+++ b/test/fortran-map-tests/dtype-enter-exit-update.f90
@@ -1,0 +1,58 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        integer(4) :: var_a(10)
+    end type dtype_a
+
+    type(dtype_a) :: var_b
+    integer :: var_c
+
+    do var_c = 1, 10
+        var_b%var_a(var_c) = var_c + var_c
+    end do
+
+  !$omp target enter data map(to: var_b%var_a(3:6))
+
+    do var_c = 1, 10
+        var_b%var_a(var_c) = 10
+    end do
+
+  !$omp target update to(var_b%var_a(3:6))
+
+   !$omp target
+    do var_c=3,6
+        var_b%var_a(var_c) = var_b%var_a(var_c) + var_c
+    end do
+  !$omp end target 
+
+  !$omp target exit data map(from: var_b%var_a(3:6))
+
+  print*, var_b%var_a
+
+  do var_c = 1, 2
+    if (var_b%var_a(var_c) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_c = 3, 6
+      if (var_b%var_a(var_c) /= 10 + var_c) then
+          print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+  end do
+
+  do var_c = 7, 10
+    if (var_b%var_a(var_c) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/dtype-enter-exit.f90
+++ b/test/fortran-map-tests/dtype-enter-exit.f90
@@ -1,0 +1,56 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        integer(4) :: var_a(10)
+    end type dtype_a
+
+    type(dtype_a) :: var_b
+    integer :: var_c
+
+    do var_c = 1, 10
+        var_b%var_a(var_c) = var_c + var_c
+    end do
+
+    !$omp target enter data map(to: var_b%var_a(3:6))
+
+    do var_c = 1, 10
+        var_b%var_a(var_c) = 10
+    end do
+
+   !$omp target
+    do var_c=3,6
+        var_b%var_a(var_c) = var_b%var_a(var_c) + var_c
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_b%var_a(3:6))
+
+  print*, var_b%var_a
+
+  do var_c = 1, 2
+    if (var_b%var_a(var_c) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_c = 3, 6
+      if (var_b%var_a(var_c) /= var_c * 3) then
+          print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+  end do
+
+  do var_c = 7, 10
+    if (var_b%var_a(var_c) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/dtype-index-access-test.f90
+++ b/test/fortran-map-tests/dtype-index-access-test.f90
@@ -1,0 +1,60 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+PROGRAM prog_a
+  implicit none
+
+  type :: dtype_a
+    integer, allocatable :: var_a
+  end type dtype_a
+
+  type :: dtype_b
+   type(dtype_a), allocatable :: var_b(:)
+  end type dtype_b
+
+  type :: dtype_c
+    integer(4) :: var_c = 0
+    type(dtype_b) :: var_d(10)
+    complex(4) :: var_e = (0,0)
+    real(4) :: var_f = 1.0
+  end type dtype_c
+
+  type(dtype_c), allocatable :: var_g
+  integer :: var_h, var_i
+
+  allocate(var_g)
+  allocate(var_g%var_d(1)%var_b(10))
+  allocate(var_g%var_d(10)%var_b(10))
+
+  allocate(var_g%var_d(1)%var_b(1)%var_a)
+  allocate(var_g%var_d(10)%var_b(10)%var_a)
+
+  var_g%var_d(1)%var_b(1)%var_a = 20
+  var_g%var_d(10)%var_b(10)%var_a = 40
+
+ !$omp target map(tofrom: var_g%var_d(1)%var_b(1)%var_a, var_h)
+    var_h = var_g%var_d(1)%var_b(1)%var_a
+ !$omp end target
+
+ !$omp target map(tofrom: var_g%var_d(10)%var_b(10)%var_a, var_i)
+    var_i = var_g%var_d(10)%var_b(10)%var_a
+ !$omp end target
+
+  print *, var_g%var_d(1)%var_b(1)%var_a
+  print *, var_g%var_d(10)%var_b(10)%var_a
+  print *, var_h
+  print *, var_i
+
+  if (var_h /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_i /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-member-array-map-2.f90
+++ b/test/fortran-map-tests/dtype-member-array-map-2.f90
@@ -1,0 +1,52 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      integer(4) :: var_b(3,3,3)
+      real(4) :: var_c
+      integer(4) :: var_d(3,3,3)
+      real(4) :: var_e
+    end type dtype_a
+
+    type(dtype_a) :: var_f
+    integer :: var_g, var_h, var_i
+
+    do var_g = 1, 3
+      do var_h = 1, 3
+        do var_i = 1, 3
+            var_f%var_b(var_g, var_h, var_i) = 42
+            var_f%var_d(var_g, var_h, var_i) = 0
+        end do
+       end do
+    end do
+
+  !$omp target map(tofrom:var_f%var_b(1:3, 1:3, 2:2), var_f%var_d(1:3, 1:3, 1:3))
+    do var_h = 1, 3
+      do var_i = 1, 3
+        var_f%var_d(var_i, var_h, 2) = var_f%var_b(var_i, var_h, 2)
+      end do
+    end do
+  !$omp end target
+
+  print *, var_f%var_d
+
+  do var_g = 1, 3
+      do var_h = 1, 3
+        do var_i = 1, 3
+          if (var_g == 2 .and. var_f%var_d(var_i, var_h, var_g) /= 42) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          else if (var_g /= 2 .and. var_f%var_d(var_i, var_h, var_g) /= 0) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          end if
+        end do
+      end do
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype-scalar-allocatable.f90
+++ b/test/fortran-map-tests/dtype-scalar-allocatable.f90
@@ -1,0 +1,33 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+
+type :: dtype_a
+real(4) :: var_a
+integer, allocatable :: var_b 
+integer(4) :: var_c(10)
+real(4) :: var_d
+integer, allocatable :: var_e(:)
+integer(4) :: var_f
+end type dtype_a
+
+type(dtype_a) :: var_g
+
+allocate(var_g%var_b) 
+
+!$omp target map(tofrom: var_g%var_b)
+    var_g%var_b = 50
+!$omp end target
+
+print *, var_g%var_b
+
+if (var_g%var_b /= 50) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+  
+ print *, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/dtype-syntax-support-2.f90
+++ b/test/fortran-map-tests/dtype-syntax-support-2.f90
@@ -1,0 +1,291 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    integer :: var_a
+    integer :: var_b, var_c
+
+    type :: dtype_a
+        integer :: var_d
+        integer :: var_e(10)
+        integer(4), allocatable :: var_f(:)
+        integer(4), allocatable :: var_g(:)
+    end type dtype_a
+
+    type dtype_b
+        TYPE(dtype_a) :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+        real(4) :: var_i
+        type(dtype_a), allocatable :: var_j(:)
+        TYPE(dtype_b), DIMENSION(:), allocatable :: var_k
+        integer(4) :: var_l(10)
+        real(4) :: var_m
+        integer, allocatable :: var_n(:)
+        integer(4) :: var_o
+    end type dtype_c
+
+    type(dtype_c) :: var_p
+    type(dtype_c), DIMENSION(:), allocatable :: var_q
+
+    integer :: var_r(10,10,10)
+
+    allocate(var_p%var_j(4))
+    allocate(var_p%var_j(1)%var_f(10))
+    allocate(var_p%var_j(1)%var_g(10))
+    allocate(var_p%var_j(2)%var_f(10))
+    allocate(var_p%var_j(2)%var_g(10))
+    allocate(var_p%var_j(3)%var_f(10))
+    allocate(var_p%var_j(3)%var_g(10))
+    allocate(var_p%var_j(4)%var_f(10))
+    allocate(var_p%var_j(4)%var_g(10))
+    allocate(var_p%var_k(4))
+    allocate(var_p%var_k(1)%var_h%var_f(10))
+    allocate(var_p%var_k(1)%var_h%var_g(10))
+    allocate(var_p%var_k(2)%var_h%var_f(10))
+    allocate(var_p%var_k(2)%var_h%var_g(10))
+    allocate(var_p%var_k(3)%var_h%var_f(10))
+    allocate(var_p%var_k(3)%var_h%var_g(10))
+    allocate(var_p%var_k(4)%var_h%var_f(10))
+    allocate(var_p%var_k(4)%var_h%var_g(10))
+
+    allocate(var_q(3))
+
+    do var_a = 1, 3
+        allocate(var_q(var_a)%var_j(4))
+        allocate(var_q(var_a)%var_j(1)%var_f(10))
+        allocate(var_q(var_a)%var_j(1)%var_g(10))
+        allocate(var_q(var_a)%var_j(2)%var_f(10))
+        allocate(var_q(var_a)%var_j(2)%var_g(10))
+        allocate(var_q(var_a)%var_j(3)%var_f(10))
+        allocate(var_q(var_a)%var_j(3)%var_g(10))
+        allocate(var_q(var_a)%var_j(4)%var_f(10))
+        allocate(var_q(var_a)%var_j(4)%var_g(10))
+        allocate(var_q(var_a)%var_k(4))
+        allocate(var_q(var_a)%var_k(1)%var_h%var_f(10))
+        allocate(var_q(var_a)%var_k(1)%var_h%var_g(10))
+        allocate(var_q(var_a)%var_k(2)%var_h%var_f(10))
+        allocate(var_q(var_a)%var_k(2)%var_h%var_g(10))
+        allocate(var_q(var_a)%var_k(3)%var_h%var_f(10))
+        allocate(var_q(var_a)%var_k(3)%var_h%var_g(10))
+        allocate(var_q(var_a)%var_k(4)%var_h%var_f(10))
+        allocate(var_q(var_a)%var_k(4)%var_h%var_g(10))
+    end do
+
+    var_b = 1
+    var_c = 2
+
+!$omp target map(tofrom: var_p%var_j(var_b)%var_d)
+        var_p%var_j(var_b)%var_d = 3
+!$omp end target
+
+print *, var_p%var_j(var_b)%var_d
+
+if (var_p%var_j(var_b)%var_d /= 3) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+!$omp target map(tofrom: var_p%var_j(var_b)%var_d, var_p%var_j(var_c)%var_d)
+        var_p%var_j(var_b)%var_d = 5
+        var_p%var_j(var_c)%var_d = 10
+!$omp end target
+
+do var_a = 1, 4
+    print *, var_p%var_j(var_a)%var_d
+end do
+
+if (var_p%var_j(var_b)%var_d /= 5) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+if (var_p%var_j(var_c)%var_d /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+!$omp target map(tofrom: var_p%var_k(var_b)%var_h%var_f, &
+!$omp                    var_p%var_k(var_b)%var_h%var_g)
+    do var_a = 1, 10
+        var_p%var_k(var_b)%var_h%var_f(var_a) = var_a
+        var_p%var_k(var_b)%var_h%var_g(var_a) = var_a
+    end do
+!$omp end target
+
+print *, var_p%var_k(var_b)%var_h%var_f
+print *, var_p%var_k(var_b)%var_h%var_g
+
+do var_a = 1, 10
+    if (var_p%var_k(var_b)%var_h%var_f(var_a) /= var_a) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+
+    if (var_p%var_k(var_b)%var_h%var_g(var_a) /= var_a) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+!$omp target map(tofrom:  var_p%var_k(var_b)%var_h%var_d, &
+!$omp                     var_p%var_k(var_c)%var_h%var_d, &
+!$omp                     var_p%var_k(var_b)%var_h%var_g, &
+!$omp                     var_p%var_k(var_c)%var_h%var_g)
+    var_p%var_k(var_c)%var_h%var_d = 9999
+    var_p%var_k(var_c)%var_h%var_g(2) = 9998
+    var_p%var_k(var_b)%var_h%var_d = 9997
+    var_p%var_k(var_b)%var_h%var_g(2) = 9996
+!$omp end target
+
+print *, var_p%var_k(var_b)%var_h%var_d
+print *, var_p%var_k(var_c)%var_h%var_d
+print *, var_p%var_k(var_b)%var_h%var_g(2)
+print *, var_p%var_k(var_c)%var_h%var_g(2)
+
+if (var_p%var_k(var_b)%var_h%var_d /= 9997) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+if (var_p%var_k(var_c)%var_h%var_d /= 9999) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+if (var_p%var_k(var_b)%var_h%var_g(2) /= 9996) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+if (var_p%var_k(var_c)%var_h%var_g(2) /= 9998) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+!$omp target map(tofrom:  var_p%var_k(var_c)%var_h%var_g)
+   var_p%var_k(var_c)%var_h%var_g(2) = 2000
+!$omp end target
+
+if (var_p%var_k(var_c)%var_h%var_g(2) /= 2000) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+!$omp target map(tofrom: var_p%var_j(var_b)%var_f, &
+!$omp                    var_p%var_j(var_b)%var_g, &
+!$omp                    var_p%var_j(var_c)%var_f, &
+!$omp                    var_p%var_j(var_c)%var_g)
+    do var_a = 1, 10
+        var_p%var_j(var_b)%var_f(var_a) = var_a * 2
+        var_p%var_j(var_b)%var_g(var_a) = var_a * 2
+        var_p%var_j(var_c)%var_f(var_a) = var_a * 2
+        var_p%var_j(var_c)%var_g(var_a) = var_a * 2
+    end do
+!$omp end target
+
+print *, var_p%var_j(var_b)%var_f
+print *, var_p%var_j(var_b)%var_g
+print *, var_p%var_j(var_c)%var_f
+print *, var_p%var_j(var_c)%var_g
+
+do var_a = 1, 10
+    if (var_p%var_j(var_b)%var_f(var_a) /= var_a * 2) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+
+    if (var_p%var_j(var_b)%var_g(var_a) /= var_a * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_p%var_j(var_c)%var_f(var_a) /= var_a * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+      if (var_p%var_j(var_c)%var_g(var_a) /= var_a * 2) then
+          print*, "======= FORTRAN Test Failed! ======="
+          stop 1
+      end if
+end do
+
+!$omp target map(tofrom: var_p%var_j(var_b)%var_f, &
+!$omp                    var_p%var_j(var_b)%var_g, &
+!$omp                    var_p%var_j(4)%var_g, &
+!$omp                    var_p%var_j(4)%var_f, &
+!$omp                    var_p%var_j(var_c)%var_f, &
+!$omp                    var_p%var_j(var_c)%var_g)
+    do var_a = 1, 10
+        var_p%var_j(var_b)%var_f(var_a) = var_a * 3
+        var_p%var_j(var_b)%var_g(var_a) = var_a * 3
+        var_p%var_j(4)%var_f(var_a) = var_a * 3
+        var_p%var_j(4)%var_g(var_a) = var_a * 3
+        var_p%var_j(var_c)%var_f(var_a) = var_a * 3
+        var_p%var_j(var_c)%var_g(var_a) = var_a * 3
+    end do
+!$omp end target
+
+
+    print *, var_p%var_j(1)%var_f
+    print *, var_p%var_j(1)%var_g
+    print *, var_p%var_j(4)%var_f
+    print *, var_p%var_j(4)%var_g
+    print *, var_p%var_j(2)%var_f
+    print *, var_p%var_j(2)%var_g
+
+do var_a = 1, 10
+    if (var_p%var_j(1)%var_f(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+        end if
+
+    if (var_p%var_j(1)%var_g(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_p%var_j(4)%var_f(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_p%var_j(4)%var_g(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_p%var_j(2)%var_f(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+        end if
+
+    if (var_p%var_j(2)%var_g(var_a) /= var_a * 3) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+!$omp target map(tofrom: var_q(var_c)%var_l)
+    do var_a = 1, 10
+        var_q(var_c)%var_l(var_a) = var_a
+    end do
+!$omp end target
+
+print *, var_q(var_c)%var_l
+
+do var_a = 1, 10
+    if (var_q(var_c)%var_l(var_a) /= var_a) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print *, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/dtype-syntax-support.f90
+++ b/test/fortran-map-tests/dtype-syntax-support.f90
@@ -1,0 +1,148 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  type dtype_a
+    integer var_a
+    real var_b
+    real var_c(10)
+  end type dtype_a
+
+  type dtype_b
+    character (LEN=30) var_d
+    character (LEN=1) var_e
+    type(dtype_a) var_f
+  end type dtype_b
+
+  type dtype_c
+    integer var_g(20)
+    type(dtype_b) var_h
+    integer var_i
+    type(dtype_a) var_j(5)
+  end type dtype_c
+
+  type(dtype_c) :: var_k(5)
+  integer :: var_l
+
+!$omp target map(tofrom: var_k(5))
+    do var_l = 1, 20
+      var_k(5)%var_g(var_l) = 20 + var_l
+    end do
+
+    var_k(5)%var_h%var_f%var_c(5) = 10
+    var_k(5)%var_i = 40
+!$omp end target
+
+  do var_l = 1, 20
+    print *, var_k(5)%var_g(var_l)
+  end do
+
+  print *, var_k(5)%var_g(5)
+  print *, var_k(5)%var_h%var_f%var_c(5)
+  print *, var_k(5)%var_i
+
+  do var_l = 1, 20
+    if (var_k(5)%var_g(var_l) /= 20 + var_l) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  if (var_k(5)%var_h%var_f%var_c(5) /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_k(5)%var_i /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+!$omp target map(tofrom: var_k(4)%var_g(3))
+  var_k(4)%var_g(3) = 74
+!$omp end target
+
+ print *, var_k(4)%var_g(3)
+
+if (var_k(4)%var_g(3) /= 74) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+!$omp target map(tofrom: var_k(5)%var_g(3:5))
+  do var_l = 3, 5
+     var_k(5)%var_g(var_l) = var_l
+  end do
+!$omp end target
+
+ do var_l = 3, 5
+    print *, var_k(5)%var_g(var_l)
+ end do
+
+ do var_l = 3, 5
+  if (var_k(5)%var_g(var_l) /= var_l) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+!$omp target map(tofrom: var_k(3:5))
+  do var_l = 3, 5
+    var_k(var_l)%var_i = var_l
+  end do
+!$omp end target
+
+  do var_l = 3, 5
+    print *, var_k(var_l)%var_i
+  end do
+
+  do var_l = 3, 5
+    if (var_k(var_l)%var_i /= var_l) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+!$omp target map(tofrom: var_k(4)%var_h%var_f%var_c(8))
+  var_k(4)%var_h%var_f%var_c(8) = 200
+!$omp end target
+
+print *, var_k(4)%var_h%var_f%var_c(8)
+
+if (var_k(4)%var_h%var_f%var_c(8) /= 200) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+!$omp target map(tofrom: var_k(4)%var_h%var_f%var_c(5:10))
+  do var_l = 5, 10
+    var_k(4)%var_h%var_f%var_c(var_l) = var_l
+  end do
+!$omp end target
+
+do var_l = 5, 10
+  print *, var_k(4)%var_h%var_f%var_c(var_l)
+end do
+
+do var_l = 5, 10
+  if (var_k(4)%var_h%var_f%var_c(var_l) /= var_l) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+end do
+
+!$omp target map(tofrom: var_k(4)%var_j(3)%var_c(4))
+  var_k(4)%var_j(3)%var_c(4) = 200
+!$omp end target
+
+print *, var_k(4)%var_j(3)%var_c(4)
+
+if (var_k(4)%var_j(3)%var_c(4) /= 200) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/dtype_pointer_to_member.f90
+++ b/test/fortran-map-tests/dtype_pointer_to_member.f90
@@ -1,0 +1,40 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    type :: dtype_a
+            integer :: var_a, var_b
+            integer,dimension(:),allocatable :: var_c
+    end type
+end module
+
+program prog_a
+    use mod_a
+
+    type(dtype_a),target :: var_d
+    integer,dimension(:),pointer :: var_e
+    integer :: var_f
+
+    allocate(var_d%var_c(1024))
+    var_d%var_a=1
+    var_d%var_b=1024
+
+    var_e => var_d%var_c
+
+    !$omp target enter data map(to:var_d, var_d%var_c)
+
+    !$omp target
+      do var_f = 1,1024
+             var_e(var_f) = var_f
+      end do
+    !$omp end target
+
+    !$omp target exit data map(from:var_d%var_c)
+
+    write(*,*) var_d%var_c
+
+    !$omp target exit data map(release:var_d)
+
+    deallocate(var_d%var_c)
+end program

--- a/test/fortran-map-tests/enter-exit-array-bounds-test.f90
+++ b/test/fortran-map-tests/enter-exit-array-bounds-test.f90
@@ -1,0 +1,52 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(10)
+    integer :: var_b
+
+    do var_b = 1, 10
+      var_a(var_b) = var_b + var_b
+    end do
+
+    !$omp target enter data map(to: var_a(3:6))
+
+    do var_b = 1, 10
+      var_a(var_b) = 10
+    end do
+
+   !$omp target
+    do var_b=3,6
+      var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target 
+
+  !$omp target exit data map(from: var_a(3:6))
+
+  print*, var_a
+
+  do var_b = 1, 2
+    if (var_a(var_b) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  do var_b = 3, 6
+      if (var_a(var_b) /= var_b * 3) then
+          print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+  end do
+
+  do var_b = 7, 10
+    if (var_a(var_b) /= 10) then
+        print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/enter-exit-array-test.f90
+++ b/test/fortran-map-tests/enter-exit-array-test.f90
@@ -1,0 +1,38 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(10)
+    integer :: var_b
+
+    do var_b = 1, 10
+      var_a(var_b) = var_b + var_b
+    end do
+
+    !$omp target enter data map(to: var_a)
+
+    do var_b = 1, 10
+      var_a(var_b) = 10
+    end do
+
+   !$omp target
+    do var_b=1,10
+      var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  print*, var_a
+
+  do var_b = 1, 10
+      if (var_a(var_b) /= var_b * 3) then
+          print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/enter-exit-break-test-2.f90
+++ b/test/fortran-map-tests/enter-exit-break-test-2.f90
@@ -1,0 +1,43 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer, allocatable :: var_a(:)
+    integer :: var_b(10)
+    integer :: var_c
+    allocate(var_a(10))
+
+    do var_c = 1, 10
+        var_a(var_c) = var_c + var_c
+    end do
+
+    !$omp target enter data map(to: var_a)
+
+    do var_c = 1, 10
+        var_a(var_c) = var_c
+    end do
+
+    !$omp target map(tofrom: var_b, var_a)
+        do var_c = 1, 10
+            var_b(var_c) = var_a(var_c)
+        end do
+    !$omp end target
+
+    !$omp target exit data map(from: var_a)
+
+    !$omp target exit data map(delete: var_a)
+
+     print *, var_b
+
+    deallocate(var_a)
+
+    do var_c = 1, 10
+      if (var_b(var_c) /= var_c + var_c) then
+          print *, "======= FORTRAN Test Failed! ======="
+          stop 1
+      end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/enter-exit-break-test.f90
+++ b/test/fortran-map-tests/enter-exit-break-test.f90
@@ -1,0 +1,52 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+integer, allocatable :: var_a(:)
+contains
+subroutine sub_a(var_b)
+    implicit none
+    integer, intent(inout) :: var_b(:)
+    integer :: var_c
+
+    !$omp target
+      do var_c=1,10
+        var_b(var_c) = var_a(var_c)
+      end do
+    !$omp end target
+end subroutine sub_a
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+    integer :: var_b(10)
+    integer :: var_c
+
+    allocate(var_a(10))
+
+    do var_c = 1, 10
+        var_a(var_c) = var_c + var_c
+    end do
+
+    !$omp target enter data map(to: var_a)
+    
+    do var_c = 1, 10
+        var_a(var_c) = var_c
+    end do
+
+    call sub_a(var_b)
+
+    print *, var_b
+
+    do var_c = 1, 10
+        if (var_b(var_c) /= var_c + var_c) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+  print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/enter-exit-in-different-scopes.f90
+++ b/test/fortran-map-tests/enter-exit-in-different-scopes.f90
@@ -1,0 +1,73 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a, var_b)
+    implicit none
+    integer :: var_b
+    integer, dimension(var_b) :: var_a
+    !$omp target enter data map(to:var_a)
+end subroutine sub_a
+
+subroutine sub_b(var_a, var_b)
+    implicit none
+    integer :: var_b
+    integer, dimension(var_b) :: var_a
+    !$omp target exit data map(from:var_a)
+end subroutine sub_b
+
+subroutine sub_c(var_a, var_b)
+    implicit none
+    integer :: var_b
+    integer, dimension(var_b) :: var_a
+    !$omp target update from(var_a)
+end subroutine sub_c
+
+program prog_a
+    implicit none
+    integer :: var_a = 10, var_b = 0
+    integer :: var_c(10), var_d(10), var_e(10)
+
+    call sub_a(var_c, var_a)
+    call sub_a(var_d, var_a)
+
+!$omp target
+    do var_b = 1, 10
+        var_c(var_b) = 10
+    end do
+!$omp end target
+
+!$omp target
+    do var_b = 1, 10
+        var_d(var_b) = 20
+    end do
+!$omp end target
+
+!$omp target map(from: var_e)
+    do var_b = 1, 10
+        var_e(var_b) = var_c(var_b) + var_d(var_b)
+    end do
+!$omp end target
+
+    call sub_c(var_c, var_a)
+    call sub_c(var_d, var_a)
+    call sub_b(var_c, var_a)
+    call sub_b(var_d, var_a)
+
+    do var_b = 1, 10
+        var_e(var_b) = var_e(var_b) + var_c(var_b) + var_d(var_b)
+    end do
+
+    print *, var_c
+    print *, var_d
+    print *, var_e
+
+    do var_b = 1, 10
+     if (var_e(var_b) /= 60) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/enter-exit-scalar-test.f90
+++ b/test/fortran-map-tests/enter-exit-scalar-test.f90
@@ -1,0 +1,27 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer :: var_a
+    var_a = 10
+
+    !$omp target enter data map(to: var_a)
+
+    var_a = 20
+
+   !$omp target
+      var_a = var_a + 50
+   !$omp end target
+
+   !$omp target exit data map(from: var_a)
+
+   print *, var_a
+
+   if (var_a /= 10) then
+     print *, "======= FORTRAN Test Failed! ======="
+     stop 1
+   end if
+
+   print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/even-basicer-example.f95
+++ b/test/fortran-map-tests/even-basicer-example.f95
@@ -1,0 +1,26 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    INTEGER :: var_a = 0
+!$omp declare target link(var_a)
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+!$omp target map(tofrom:var_a)
+    var_a = 1
+!$omp end target
+
+PRINT *, var_a
+
+if (var_a /= 1) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/from-to.f95
+++ b/test/fortran-map-tests/from-to.f95
@@ -1,0 +1,33 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(10)
+    integer :: var_b(10)
+    integer :: var_c, var_d
+
+    do var_c = 1, 10
+        var_b(var_c) = var_c
+    end do
+
+!$omp target map(from:var_a) map(to:var_b)
+    do var_c = 1, 10
+        var_a(var_c) = var_b(var_c)
+    end do
+!$omp end target
+
+    do var_c = 1, 10
+        PRINT *, var_a(var_c)
+    end do
+
+    do var_d = 1, 10
+        if (var_a(var_d) /= var_d) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/full-dtype-map-with-contained-dtype.f90
+++ b/test/fortran-map-tests/full-dtype-map-with-contained-dtype.f90
@@ -1,0 +1,42 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type dtype_a
+       real(4) :: var_a(10)
+    end type dtype_a
+
+    type dtype_b
+      type(dtype_a) :: var_b
+    end type dtype_b
+
+    type :: dtype_c
+        real(4) :: var_c
+        real(4) :: var_d(10)
+        real(4) :: var_e
+        type(dtype_b) :: var_f
+        real(4) :: var_g
+    end type dtype_c
+
+    type(dtype_c) :: var_h
+    integer :: var_i
+
+  !$omp target map(tofrom:var_h)
+    do var_i = 1, 10
+      var_h%var_f%var_b%var_a(var_i) = var_i
+    end do
+  !$omp end target
+
+  print*, var_h%var_f%var_b%var_a
+
+  do var_i = 1, 10
+    if (var_h%var_f%var_b%var_a(var_i) /= var_i) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/implicit-allocatable-write-arrays.f90
+++ b/test/fortran-map-tests/implicit-allocatable-write-arrays.f90
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer, allocatable :: var_a(:)
+    integer :: var_b
+    allocate(var_a(10))
+
+!$omp target
+    do var_b = 1, 10
+        var_a(var_b) = var_b
+ end do
+!$omp end target
+
+ print *, var_a 
+
+ do var_b = 1, 10
+    if (var_a(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print *, "======= FORTRAN Test Passed! =======" 
+
+end program

--- a/test/fortran-map-tests/implicit-allocatable-write.f90
+++ b/test/fortran-map-tests/implicit-allocatable-write.f90
@@ -1,0 +1,23 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer, allocatable :: var_a
+    allocate(var_a)
+
+!$omp target
+    var_a = 1
+!$omp end target
+
+ print *, var_a 
+
+if (var_a /= 1) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+  print *, "======= FORTRAN Test Passed! =======" 
+
+end program

--- a/test/fortran-map-tests/implicit-single-value-alloca.f90
+++ b/test/fortran-map-tests/implicit-single-value-alloca.f90
@@ -1,0 +1,21 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer, allocatable :: var_a
+    allocate(var_a)
+
+!$omp target map(tofrom:var_a)
+     var_a = 50
+!$omp end target
+
+  print *, var_a
+
+  if (var_a /= 50) then
+     print *, "======= FORTRAN Test Failed! ======="
+     stop 1
+   end if
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/individual-dtype-member-map.f90
+++ b/test/fortran-map-tests/individual-dtype-member-map.f90
@@ -1,0 +1,33 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+    real :: var_a
+    type :: dtype_a
+        integer(4) :: var_b = 0
+        real(4) :: var_c = 0.0
+        complex(4) :: var_d = (0,0)
+        real(4) :: var_e = 1.0
+        type(dtype_a), allocatable :: var_f 
+    end type dtype_a  
+  
+    type(dtype_a) :: var_g
+    var_g%var_b = 10
+    var_g%var_c = 2.0
+    var_g%var_d = (2, 10)
+    var_g%var_e = 12.0
+    var_a = 21.0
+
+  !$omp target map(from:var_g%var_c)
+    var_g%var_c = var_a
+  !$omp end target
+
+   if (var_g%var_c /= 21.0) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print*, "======= FORTRAN Test passed! ======="
+  end program prog_a

--- a/test/fortran-map-tests/instruction-replace-test.f90
+++ b/test/fortran-map-tests/instruction-replace-test.f90
@@ -1,0 +1,44 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    type dtype_a
+      integer var_a(20)
+      integer var_b
+    end type dtype_a
+
+    type (dtype_a) var_c(5)
+  contains
+
+  subroutine sub_a()
+    implicit none
+!$omp target map(tofrom: var_c(5))
+    var_c(5)%var_a(5) = 500
+!$omp end target
+  end subroutine
+
+  subroutine sub_b()
+    implicit none
+
+!$omp target map(tofrom: var_c(5))
+    var_c(5)%var_a(5) = var_c(5)%var_a(5) + 500
+!$omp end target
+  end subroutine
+end module mod_a
+
+program prog_a
+   use mod_a
+
+  call sub_a()
+  call sub_b()
+
+  print *, var_c(5)%var_a(5)
+
+  if (var_c(5)%var_a(5) /= 1000) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/jean-example.f90
+++ b/test/fortran-map-tests/jean-example.f90
@@ -1,0 +1,57 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a, var_b)
+    implicit none
+    integer(8) :: var_a,var_b
+    integer :: var_c(var_a:var_b)
+   !$omp target
+       var_c(4) = 22
+       var_c(15) = 2222
+   !$omp end target
+    print *, var_c
+
+    if (var_c(4) /= 22) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_c(15) /= 2222) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end subroutine sub_a
+
+subroutine sub_b(var_a, var_b, var_c)
+    implicit none
+    integer(8) :: var_a,var_b
+    integer :: var_c(var_a:var_b)
+   !$omp target
+       var_c(4) = 22
+       var_c(15) = 2222
+   !$omp end target
+end subroutine sub_b
+
+program prog_a
+    implicit none
+    integer(8) :: var_a,var_b
+    integer :: var_c(20)
+    var_a = 4
+    var_b = 15
+    call sub_a(var_a,var_b)
+    call sub_b(var_a, var_b, var_c)
+    print *, var_c
+
+    if (var_c(1) /= 22) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_c(12) /= 2222) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+     print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/large-allocatable-nested-dtype-double-map-2.f90
+++ b/test/fortran-map-tests/large-allocatable-nested-dtype-double-map-2.f90
@@ -1,0 +1,65 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4) :: var_b
+    real(4), allocatable :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4), allocatable :: var_d
+      integer(4) :: var_e
+      integer(4) :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4), allocatable :: var_i
+     real(4) :: var_j(10)
+     type(dtype_a), allocatable :: var_k
+     integer(4), allocatable :: var_l
+     type(dtype_b), allocatable :: var_m
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_n
+    integer(4) :: var_o(10)
+    real(4) :: var_p
+    integer, allocatable :: var_q(:)
+    integer(4) :: var_r
+    type(dtype_c), allocatable :: var_s
+    end type dtype_d
+
+    type(dtype_d), allocatable :: var_t
+
+    allocate(var_t)
+    allocate(var_t%var_s)
+    allocate(var_t%var_s%var_k)
+    allocate(var_t%var_s%var_m)
+    allocate(var_t%var_s%var_k%var_c)
+    allocate(var_t%var_s%var_m%var_d)
+
+!$omp target map(tofrom: var_t%var_s%var_k%var_c, var_t%var_s%var_m%var_d)
+    var_t%var_s%var_k%var_c = 54
+    var_t%var_s%var_m%var_d = 20
+!$omp end target
+
+  print *, var_t%var_s%var_m%var_d
+  print *, var_t%var_s%var_k%var_c
+
+  if (var_t%var_s%var_k%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_t%var_s%var_m%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-allocatable-nested-dtype-double-map.f90
+++ b/test/fortran-map-tests/large-allocatable-nested-dtype-double-map.f90
@@ -1,0 +1,63 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4) :: var_b
+    real(4), allocatable :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4), allocatable :: var_d
+      integer(4) :: var_e
+      integer(4) :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4), allocatable :: var_i
+     real(4) :: var_j(10)
+     type(dtype_a), allocatable :: var_k
+     integer(4), allocatable :: var_l
+     type(dtype_b), allocatable :: var_m
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_n
+    integer(4) :: var_o(10)
+    real(4) :: var_p
+    integer, allocatable :: var_q(:)
+    integer(4) :: var_r
+    type(dtype_c), allocatable :: var_s
+    end type dtype_d
+
+    type(dtype_d), allocatable :: var_t
+
+    allocate(var_t)
+    allocate(var_t%var_s)
+    allocate(var_t%var_s%var_i)
+    allocate(var_t%var_s%var_l)
+
+!$omp target map(tofrom: var_t%var_s%var_i, var_t%var_s%var_l)
+    var_t%var_s%var_i = 54
+    var_t%var_s%var_l = 20
+!$omp end target
+
+  print *, var_t%var_s%var_l
+  print *, var_t%var_s%var_i
+
+  if (var_t%var_s%var_i /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_t%var_s%var_l /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-allocatable-nested-dtype-multi-map.f90
+++ b/test/fortran-map-tests/large-allocatable-nested-dtype-multi-map.f90
@@ -1,0 +1,104 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4) :: var_b
+    real(4), allocatable :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4), allocatable :: var_d
+      integer(4) :: var_e
+      integer(4) :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     type(dtype_a), allocatable :: var_h
+     real(4) :: var_i
+     real(4), allocatable :: var_j
+     real(4) :: var_k(10)
+     type(dtype_b), allocatable :: var_l
+     integer(4), allocatable :: var_m
+     type(dtype_b), allocatable :: var_n
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_o
+    integer(4) :: var_p(10)
+    real(4) :: var_q
+    integer, allocatable :: var_r(:)
+    integer(4) :: var_s
+    type(dtype_c), allocatable :: var_t
+    end type dtype_d
+
+    type(dtype_d), allocatable :: var_u
+    integer :: var_v
+
+    allocate(var_u)
+    allocate(var_u%var_t)
+    allocate(var_u%var_t%var_h)
+    allocate(var_u%var_t%var_l)
+    allocate(var_u%var_t%var_n)
+    allocate(var_u%var_t%var_h%var_c)
+    allocate(var_u%var_t%var_l%var_d)
+    allocate(var_u%var_t%var_j)
+    allocate(var_u%var_t%var_m)
+    allocate(var_u%var_r(10))
+
+!$omp target map(tofrom: var_u%var_r, var_u%var_t%var_h%var_c, var_u%var_t%var_j) &
+!$omp map(tofrom: var_u%var_t%var_l%var_d, var_u%var_t%var_m, var_u%var_t%var_n)
+    var_u%var_t%var_h%var_c = 54
+    var_u%var_t%var_l%var_d = 20
+    var_u%var_t%var_j = 104
+    var_u%var_t%var_m = 204
+    do var_v = 1, 10
+      var_u%var_r(var_v) = var_v
+    end do
+    var_u%var_t%var_n%var_e = 10
+!$omp end target
+
+  print *, var_u%var_t%var_l%var_d
+  print *, var_u%var_t%var_h%var_c
+  print *, var_u%var_t%var_m
+  print *, var_u%var_t%var_j
+  print *, var_u%var_t%var_n%var_e
+  print *, var_u%var_r
+
+  if (var_u%var_t%var_h%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_l%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_j /= 104) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_m /= 204) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_e /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_v = 1, 10
+    if (var_u%var_r(var_v) /= var_v) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-mixed-nested-dtype-map-2.f90
+++ b/test/fortran-map-tests/large-mixed-nested-dtype-map-2.f90
@@ -1,0 +1,132 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4), allocatable :: var_b
+    real(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4) :: var_d
+      integer(4) :: var_e
+      integer(4), allocatable :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4) :: var_i(10)
+     type(dtype_a) :: var_j
+     type(dtype_b), allocatable :: var_k
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_l
+    integer(4) :: var_m(10)
+    real(4) :: var_n
+    integer, allocatable :: var_o(:)
+    integer(4) :: var_p
+    type(dtype_c) :: var_q
+    end type dtype_d
+
+    type(dtype_d) :: var_r
+    integer :: var_s
+
+    allocate(var_r%var_o(10))
+    allocate(var_r%var_q%var_k)
+    allocate(var_r%var_q%var_k%var_f)
+    allocate(var_r%var_q%var_j%var_b)
+
+    var_r%var_q%var_j%var_b = 12
+
+!$omp target map(tofrom: var_r%var_q%var_j%var_b, var_r%var_q%var_j%var_a) &
+!$omp map(tofrom: var_r%var_q%var_j%var_c, var_r%var_m, var_r%var_q%var_k%var_d) &
+!$omp map(tofrom: var_r%var_q%var_h, var_r%var_q%var_k%var_f, var_r%var_q%var_k%var_e) &
+!$omp map(tofrom: var_r%var_o)
+    var_r%var_q%var_j%var_a = 10
+    var_r%var_q%var_j%var_b = 12 + var_r%var_q%var_j%var_b
+    var_r%var_q%var_j%var_c = 54
+
+    var_r%var_q%var_k%var_d = 20
+    var_r%var_q%var_k%var_e = 40
+    var_r%var_q%var_k%var_f = 60
+
+    var_r%var_q%var_h = 200
+
+    do var_s = 1, 10
+      var_r%var_m(var_s) = var_s
+    end do
+
+    do var_s = 1, 10
+      var_r%var_o(var_s) = var_s
+    end do
+!$omp end target
+
+  print *, var_r%var_q%var_j%var_a
+  print *, var_r%var_q%var_j%var_b
+  print *, var_r%var_q%var_j%var_c
+
+  print *, var_r%var_q%var_k%var_d
+  print *, var_r%var_q%var_k%var_e
+  print *, var_r%var_q%var_k%var_f
+
+  print *, var_r%var_q%var_h
+
+  print *, var_r%var_m
+
+  print *, var_r%var_o
+
+  if (var_r%var_q%var_j%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_e /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_f /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_h /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_s = 1, 10
+    if (var_r%var_m(var_s) /= var_s) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_s = 1, 10
+    if (var_r%var_o(var_s) /= var_s) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-mixed-nested-dtype-map.f90
+++ b/test/fortran-map-tests/large-mixed-nested-dtype-map.f90
@@ -1,0 +1,133 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4), allocatable :: var_b
+    real(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4) :: var_d
+      integer(4) :: var_e
+      integer(4), allocatable :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4) :: var_i(10)
+     type(dtype_a) :: var_j
+     type(dtype_b), allocatable :: var_k
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_l
+    integer(4) :: var_m(10)
+    real(4) :: var_n
+    integer, allocatable :: var_o(:)
+    integer(4) :: var_p
+    type(dtype_c) :: var_q
+    end type dtype_d
+
+    type(dtype_d), allocatable :: var_r
+    integer :: var_s
+
+    allocate(var_r)
+    allocate(var_r%var_o(10))
+    allocate(var_r%var_q%var_k)
+    allocate(var_r%var_q%var_k%var_f)
+    allocate(var_r%var_q%var_j%var_b)
+
+    var_r%var_q%var_j%var_b = 12
+
+!$omp target map(tofrom: var_r%var_q%var_j%var_b, var_r%var_q%var_j%var_a) &
+!$omp map(tofrom: var_r%var_q%var_j%var_c, var_r%var_m, var_r%var_q%var_k%var_d) &
+!$omp map(tofrom: var_r%var_q%var_h, var_r%var_q%var_k%var_f, var_r%var_q%var_k%var_e) &
+!$omp map(tofrom: var_r%var_o)
+    var_r%var_q%var_j%var_a = 10
+    var_r%var_q%var_j%var_b = 12 + var_r%var_q%var_j%var_b
+    var_r%var_q%var_j%var_c = 54
+
+    var_r%var_q%var_k%var_d = 20
+    var_r%var_q%var_k%var_e = 40
+    var_r%var_q%var_k%var_f = 60
+
+    var_r%var_q%var_h = 200
+
+    do var_s = 1, 10
+      var_r%var_m(var_s) = var_s
+    end do
+
+    do var_s = 1, 10
+      var_r%var_o(var_s) = var_s
+    end do
+!$omp end target
+
+  print *, var_r%var_q%var_j%var_a
+  print *, var_r%var_q%var_j%var_b
+  print *, var_r%var_q%var_j%var_c
+
+  print *, var_r%var_q%var_k%var_d
+  print *, var_r%var_q%var_k%var_e
+  print *, var_r%var_q%var_k%var_f
+
+  print *, var_r%var_q%var_h
+
+  print *, var_r%var_m
+
+  print *, var_r%var_o
+
+  if (var_r%var_q%var_j%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_e /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_f /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_h /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_s = 1, 10
+    if (var_r%var_m(var_s) /= var_s) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_s = 1, 10
+    if (var_r%var_o(var_s) /= var_s) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-nested-allocatable-map-test.f90
+++ b/test/fortran-map-tests/large-nested-allocatable-map-test.f90
@@ -1,0 +1,191 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  type dtype_a
+    integer, allocatable :: var_a
+    real, allocatable :: var_b
+    real, allocatable :: var_c(:)
+  end type dtype_a
+
+  type dtype_b
+    character (LEN=30), allocatable :: var_d
+    character (LEN=1), allocatable :: var_e
+    type(dtype_a), allocatable :: var_f
+  end type dtype_b
+
+  type dtype_c
+    integer, allocatable :: var_g(:)
+    type(dtype_b), allocatable :: var_h
+    integer, allocatable :: var_i
+    type(dtype_a), allocatable :: var_j(:)
+  end type dtype_c
+
+  type (dtype_c), allocatable :: var_k
+  type (dtype_c), allocatable :: var_l
+  integer :: var_m, var_n
+
+  allocate(var_k)
+  allocate(var_k%var_g(20))
+  allocate(var_k%var_h)
+  allocate(var_k%var_h%var_d)
+  allocate(var_k%var_h%var_e)
+  allocate(var_k%var_h%var_f)
+  allocate(var_k%var_h%var_f%var_a)
+  allocate(var_k%var_h%var_f%var_b)
+  allocate(var_k%var_h%var_f%var_c(10))
+  allocate(var_k%var_i)
+  allocate(var_k%var_j(5))
+  do var_n = 1, 5
+    allocate(var_k%var_j(var_n)%var_a)
+    allocate(var_k%var_j(var_n)%var_b)
+    allocate(var_k%var_j(var_n)%var_c(10))
+  end do
+
+  allocate(var_l)
+  allocate(var_l%var_g(20))
+  allocate(var_l%var_h)
+  allocate(var_l%var_h%var_d)
+  allocate(var_l%var_h%var_e)
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_h%var_f%var_a)
+  allocate(var_l%var_h%var_f%var_b)
+  allocate(var_l%var_h%var_f%var_c(10))
+  allocate(var_l%var_i)
+  allocate(var_l%var_j(5))
+  do var_n = 1, 5
+    allocate(var_l%var_j(var_n)%var_a)
+    allocate(var_l%var_j(var_n)%var_b)
+    allocate(var_l%var_j(var_n)%var_c(10))
+  end do
+
+  !$omp target map(tofrom: var_k%var_h%var_f%var_a, var_k%var_h%var_f%var_b, var_k%var_h%var_f%var_c, var_k%var_i, var_k%var_g, var_k%var_h%var_e, var_l%var_h%var_f%var_a, var_l%var_h%var_f%var_b, var_l%var_h%var_f%var_c, var_l%var_i, var_l%var_g, var_l%var_h%var_e)
+  var_k%var_h%var_f%var_a = 5
+  var_k%var_h%var_f%var_b = 10
+
+  do var_m = 1, 10
+    var_k%var_h%var_f%var_c(var_m) = 50
+  end do
+
+  var_k%var_i = 20
+
+  do var_m = 1, 20
+    var_k%var_g(var_m) = var_m
+  end do
+
+  var_k%var_h%var_e = "c"
+
+  var_l%var_h%var_f%var_a = 5
+  var_l%var_h%var_f%var_b = 10
+
+  do var_m = 1, 10
+    var_l%var_h%var_f%var_c(var_m) = 50
+  end do
+
+  var_l%var_i = 20
+
+  do var_m = 1, 20
+    var_l%var_g(var_m) = var_m
+  end do
+
+  var_l%var_h%var_e = "c"
+!$omp end target
+
+print *, var_k%var_h%var_e
+print *, var_k%var_i
+print *, var_k%var_h%var_f%var_a
+print *, var_k%var_h%var_f%var_b
+
+do var_m = 1, 20
+  print *, var_k%var_g(var_m)
+end do
+
+do var_m = 1, 10
+  print *, var_k%var_h%var_f%var_c(var_m)
+end do
+
+if (var_k%var_h%var_e /= "c") then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_k%var_i /= 20) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_k%var_h%var_f%var_a /= 5) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_k%var_h%var_f%var_b /= 10) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+do var_m = 1, 20
+  if (var_k%var_g(var_m) /= var_m) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+do var_m = 1, 10
+  if (var_k%var_h%var_f%var_c(var_m) /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+print *, var_l%var_h%var_e
+print *, var_l%var_i
+print *, var_l%var_h%var_f%var_a
+print *, var_l%var_h%var_f%var_b
+
+do var_m = 1, 20
+  print *, var_l%var_g(var_m)
+end do
+
+do var_m = 1, 10
+  print *, var_l%var_h%var_f%var_c(var_m)
+end do
+
+if (var_l%var_h%var_e /= "c") then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_l%var_i /= 20) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_l%var_h%var_f%var_a /= 5) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_l%var_h%var_f%var_b /= 10) then
+  print*, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+do var_m = 1, 20
+  if (var_l%var_g(var_m) /= var_m) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+do var_m = 1, 10
+  if (var_l%var_h%var_f%var_c(var_m) /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-nested-dtype-multi-map-with-allocatables.f90
+++ b/test/fortran-map-tests/large-nested-dtype-multi-map-with-allocatables.f90
@@ -1,0 +1,149 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4) :: var_a
+      real(4) :: var_b
+      integer, pointer :: var_c(:)
+      real(4) :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4) :: var_e
+      integer(4) :: var_f
+      integer, allocatable :: var_g
+      integer(4) :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_i(10)
+     real(4) :: var_j
+     integer, pointer :: var_k
+     real(4) :: var_l(10)
+     type(dtype_a) :: var_m
+     type(dtype_b) :: var_n
+    end type dtype_c
+
+    type :: dtype_d
+      real(4) :: var_o
+      integer(4) :: var_p(10)
+      real(4) :: var_q
+      integer, allocatable :: var_r(:)
+      integer(4) :: var_s
+      type(dtype_c) :: var_t
+    end type dtype_d
+
+    type(dtype_d) :: var_u
+    integer, target :: var_v(10)
+    integer :: var_w
+
+    var_u%var_t%var_m%var_c => var_v
+    allocate(var_u%var_r(10))
+    allocate(var_u%var_t%var_k)
+    allocate(var_u%var_t%var_n%var_g)
+
+    var_u%var_t%var_m%var_b = 12
+!$omp target map(tofrom: var_u%var_t%var_m%var_b, var_u%var_t%var_m%var_a, var_u%var_t%var_n%var_g, var_u%var_t%var_m%var_d, var_u%var_t%var_m%var_c, var_u%var_p, var_u%var_t%var_k, var_u%var_t%var_n%var_e, var_u%var_t%var_j, var_u%var_t%var_n%var_h, var_u%var_r, var_u%var_t%var_n%var_f)
+    var_u%var_t%var_m%var_a = 10
+    var_u%var_t%var_m%var_b = 12 + var_u%var_t%var_m%var_b
+    var_u%var_t%var_m%var_d = 54
+
+    var_u%var_t%var_n%var_e = 20
+    var_u%var_t%var_n%var_f = 40
+    var_u%var_t%var_n%var_h = 60
+
+    var_u%var_t%var_j = 200
+    var_u%var_t%var_n%var_g = 30
+    var_u%var_t%var_k = 200
+
+    do var_w = 1, 10
+      var_u%var_t%var_m%var_c(var_w) = var_w
+      var_u%var_r(var_w) = var_w
+      var_u%var_p(var_w) = var_w
+    end do
+!$omp end target
+
+  print *, var_u%var_t%var_m%var_a
+  print *, var_u%var_t%var_m%var_b
+  print *, var_u%var_t%var_m%var_d
+  print *, var_u%var_t%var_n%var_e
+  print *, var_u%var_t%var_n%var_f
+  print *, var_u%var_t%var_n%var_h
+  print *, var_u%var_t%var_j
+  print *, var_u%var_t%var_m%var_c
+  print *, var_u%var_r
+  print *, var_u%var_p
+  print *, var_u%var_t%var_k
+  print *, var_u%var_t%var_n%var_g
+
+  if (var_u%var_t%var_m%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_m%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_m%var_d /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_e /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_f /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_h /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_j /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_k /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_g /= 30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_w = 1, 10
+    if (var_u%var_t%var_m%var_c(var_w) /= var_w) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_w = 1, 10
+    if (var_u%var_r(var_w) /= var_w) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_w = 1, 10
+    if (var_u%var_p(var_w) /= var_w) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/large-nested-dtype-multi-map.f90
+++ b/test/fortran-map-tests/large-nested-dtype-multi-map.f90
@@ -1,0 +1,110 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4) :: var_b
+    real(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4) :: var_d
+      integer(4) :: var_e
+      integer(4) :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4) :: var_i(10)
+     type(dtype_a) :: var_j
+     type(dtype_b) :: var_k
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_l
+    integer(4) :: var_m(10)
+    real(4) :: var_n
+    integer, allocatable :: var_o(:)
+    integer(4) :: var_p
+    type(dtype_c) :: var_q
+    end type dtype_d
+
+    type(dtype_d) :: var_r
+    integer :: var_s
+
+    var_r%var_q%var_j%var_b = 12
+!$omp target map(tofrom: var_r%var_q%var_j%var_b, var_r%var_q%var_j%var_a, var_r%var_q%var_j%var_c, var_r%var_m, var_r%var_q%var_k%var_d, var_r%var_q%var_h, var_r%var_q%var_k%var_f, var_r%var_q%var_k%var_e)
+    var_r%var_q%var_j%var_a = 10
+    var_r%var_q%var_j%var_b = 12 + var_r%var_q%var_j%var_b
+    var_r%var_q%var_j%var_c = 54
+
+    var_r%var_q%var_k%var_d = 20
+    var_r%var_q%var_k%var_e = 40
+    var_r%var_q%var_k%var_f = 60
+
+    var_r%var_q%var_h = 200
+
+      do var_s = 1, 10
+        var_r%var_m(var_s) = var_s
+      end do
+!$omp end target
+
+  print *, var_r%var_q%var_j%var_a
+  print *, var_r%var_q%var_j%var_b
+  print *, var_r%var_q%var_j%var_c
+
+  print *, var_r%var_q%var_k%var_d
+  print *, var_r%var_q%var_k%var_e
+  print *, var_r%var_q%var_k%var_f
+
+  print *, var_r%var_q%var_h
+
+  print *, var_r%var_m
+
+  if (var_r%var_q%var_j%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_e /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_f /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_h /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_s = 1, 10
+    if (var_r%var_m(var_s) /= var_s) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/main-all.f95
+++ b/test/fortran-map-tests/main-all.f95
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+        implicit none
+        integer :: var_a = 5
+    !$omp declare target link(var_a)
+end module mod_a
+
+program prog_a
+        implicit none
+        integer :: var_b
+        integer :: var_c(10), var_d = 0
+        do var_b = 1, 10
+                var_c(var_b) = 0
+        end do
+        call sub_a(var_c, 10)
+        do var_b = 1, 10
+                if ( var_c(var_b) /= var_b ) then
+                        var_d = var_d + 1
+                end if
+        end do
+        if ( var_d /= 0 ) then
+                print*, "======= FORTRAN Test Failed! ======="
+                stop 1
+        end if
+        print*, "======= FORTRAN Test passed! ======="
+end program prog_a
+subroutine sub_a(var_b, var_c)
+        use mod_a
+        implicit none
+        integer :: var_d
+        integer :: var_b(*)
+        integer :: var_c
+        integer :: var_e
+        integer :: var_f = 5
+
+!$omp target map(tofrom:var_e) map(tofrom:var_a)
+        var_e = var_a + var_f
+!$omp end target
+        print*, var_e
+        do var_d = 1, var_e
+                var_b(var_d) = var_d
+        end do
+end subroutine sub_a

--- a/test/fortran-map-tests/main.f95
+++ b/test/fortran-map-tests/main.f95
@@ -1,0 +1,39 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+        implicit none
+        integer :: var_a(10), var_b = 0, var_c
+
+        do var_c = 1, 10
+                var_a(var_c) = 0
+        end do
+        call sub_a(var_a, 10)
+        do var_c = 1, 10
+                if ( var_a(var_c) /= var_c ) then
+                        var_b = var_b + 1
+                end if
+        end do
+        if ( var_b /= 0 ) then
+                stop 1
+        end if
+        print*, "======= FORTRAN Test passed! ======="
+end program prog_a
+subroutine sub_a(var_a, var_b)
+        implicit none
+        integer :: var_a(*)
+        integer :: var_b
+        integer :: var_c
+        integer :: var_d
+        integer :: var_e
+
+       var_d = 10
+!$omp target map(tofrom:var_c)
+        var_c = var_d
+!$omp end target
+        print*, var_c
+        do var_e = 1, var_c
+                var_a(var_e) = var_e
+        end do
+end subroutine sub_a

--- a/test/fortran-map-tests/map_alloc_ref_ptr_ptee.f90
+++ b/test/fortran-map-tests/map_alloc_ref_ptr_ptee.f90
@@ -1,0 +1,192 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    interface sub_a
+        module procedure :: sub_a_1d, sub_a_2d, sub_a_3d, &
+                            sub_a_4d, sub_a_5d, sub_a_6d, &
+                            sub_a_7d
+    end interface
+contains
+    subroutine sub_a_1d(var_a)
+        implicit none
+        real, dimension(:) :: var_a
+        integer :: var_b
+
+        print *, 'sub_a_1d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do
+        do var_b=1, ubound(var_a, 1)
+            var_a(var_b) = 42.0
+        end do
+        print *, 'sub_a_1d end'
+    end subroutine
+
+    subroutine sub_a_2d(var_a)
+        implicit none
+        real, dimension(:,:) :: var_a
+        integer :: var_b, var_c
+
+        print *, 'sub_a_2d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(2)
+        do var_c=1, ubound(var_a, 2)
+            do var_b=1, ubound(var_a, 1)
+                var_a(var_b,var_c) = 42.0
+            end do
+        end do
+        print *, 'sub_a_2d end'
+    end subroutine
+
+    subroutine sub_a_3d(var_a)
+        implicit none
+        real, dimension(:,:,:) :: var_a
+        integer :: var_b, var_c, var_d
+
+        print *, 'sub_a_3d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(3)
+        do var_d=1, ubound(var_a, 3)
+           do var_c=1, ubound(var_a, 2)
+               do var_b=1, ubound(var_a, 1)
+                   var_a(var_b,var_c,var_d) = 42.0
+               end do
+           end do
+        end do
+        print *, 'sub_a_3d end'
+    end subroutine
+
+    subroutine sub_a_4d(var_a)
+        implicit none
+        real, dimension(:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e
+
+        print *, 'sub_a_4d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(4)
+        do var_e=1, ubound(var_a, 4)
+           do var_d=1, ubound(var_a, 3)
+              do var_c=1, ubound(var_a, 2)
+                  do var_b=1, ubound(var_a, 1)
+                      var_a(var_b,var_c,var_d,var_e) = 42.0
+                  end do
+              end do
+           end do
+        enddo
+        print *, 'sub_a_4d end'
+    end subroutine
+
+    subroutine sub_a_5d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f
+
+        print *, 'sub_a_5d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(5)
+        do var_f=1, ubound(var_a, 5)
+           do var_e=1, ubound(var_a, 4)
+              do var_d=1, ubound(var_a, 3)
+                 do var_c=1, ubound(var_a, 2)
+                     do var_b=1, ubound(var_a, 1)
+                         var_a(var_b,var_c,var_d,var_e,var_f) = 42.0
+                     end do
+                 end do
+              end do
+           enddo
+        enddo
+        print *, 'sub_a_5d end'
+    end subroutine
+
+    subroutine sub_a_6d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f, var_g
+
+        print *, 'sub_a_6d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(6)
+        do var_g=1, ubound(var_a, 6)
+           do var_f=1, ubound(var_a, 5)
+              do var_e=1, ubound(var_a, 4)
+                 do var_d=1, ubound(var_a, 3)
+                    do var_c=1, ubound(var_a, 2)
+                        do var_b=1, ubound(var_a, 1)
+                            var_a(var_b,var_c,var_d,var_e,var_f,var_g) = 42.0
+                        end do
+                    end do
+                 end do
+              enddo
+           enddo
+        enddo
+        print *, 'sub_a_6d end'
+    end subroutine
+
+    subroutine sub_a_7d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f, var_g, var_h
+
+        print *, 'sub_a_7d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(7)
+        do var_h=1, ubound(var_a, 7)
+           do var_g=1, ubound(var_a, 6)
+              do var_f=1, ubound(var_a, 5)
+                 do var_e=1, ubound(var_a, 4)
+                    do var_d=1, ubound(var_a, 3)
+                       do var_c=1, ubound(var_a, 2)
+                           do var_b=1, ubound(var_a, 1)
+                               var_a(var_b,var_c,var_d,var_e,var_f,var_g,var_h) = 42.0
+                           end do
+                       end do
+                    end do
+                 enddo
+              enddo
+           enddo
+        enddo
+        print *, 'sub_a_7d end'
+    end subroutine
+end module
+
+module mod_b
+    use mod_a, only: sub_a
+end module
+
+program prog_a
+    use mod_b, only: sub_a
+    implicit none
+
+    integer, parameter :: var_a = 10
+    real, dimension(:            ), allocatable :: var_b
+    real, dimension(:,:          ), allocatable :: var_c
+    real, dimension(:,:,:        ), allocatable :: var_d
+    real, dimension(:,:,:,:      ), allocatable :: var_e
+    real, dimension(:,:,:,:,:    ), allocatable :: var_f
+    real, dimension(:,:,:,:,:,:  ), allocatable :: var_g
+    real, dimension(:,:,:,:,:,:,:), allocatable :: var_h
+
+    allocate(var_b(var_a))
+    call sub_a(var_b)
+
+    allocate(var_c(var_a, var_a))
+    call sub_a(var_c)
+
+    allocate(var_d(var_a, var_a, var_a))
+    call sub_a(var_d)
+
+    allocate(var_e(var_a, var_a, var_a, var_a))
+    call sub_a(var_e)
+
+    allocate(var_f(var_a, var_a, var_a, var_a, var_a))
+    call sub_a(var_f)
+
+    allocate(var_g(var_a, var_a, var_a, var_a, var_a, var_a))
+    call sub_a(var_g)
+
+    allocate(var_h(var_a, var_a, var_a, var_a, var_a, var_a, var_a))
+    call sub_a(var_h)
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/map_static_ref_ptr_ptee.f90
+++ b/test/fortran-map-tests/map_static_ref_ptr_ptee.f90
@@ -1,0 +1,185 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    interface sub_a
+        module procedure :: sub_a_1d, sub_a_2d, sub_a_3d, &
+                            sub_a_4d, sub_a_5d, sub_a_6d, &
+                            sub_a_7d
+    end interface
+contains
+    subroutine sub_a_1d(var_a)
+        implicit none
+        real, dimension(:) :: var_a
+        integer :: var_b
+
+        print *, 'sub_a_1d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do
+        do var_b=1, ubound(var_a, 1)
+            var_a(var_b) = 42.0
+        end do
+        print *, 'sub_a_1d end'
+    end subroutine
+
+    subroutine sub_a_2d(var_a)
+        implicit none
+        real, dimension(:,:) :: var_a
+        integer :: var_b, var_c
+
+        print *, 'sub_a_2d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(2)
+        do var_c=1, ubound(var_a, 2)
+            do var_b=1, ubound(var_a, 1)
+                var_a(var_b,var_c) = 42.0
+            end do
+        end do
+        print *, 'sub_a_2d end'
+    end subroutine
+
+    subroutine sub_a_3d(var_a)
+        implicit none
+        real, dimension(:,:,:) :: var_a
+        integer :: var_b, var_c, var_d
+
+        print *, 'sub_a_3d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(3)
+        do var_d=1, ubound(var_a, 3)
+           do var_c=1, ubound(var_a, 2)
+               do var_b=1, ubound(var_a, 1)
+                   var_a(var_b,var_c,var_d) = 42.0
+               end do
+           end do
+        end do
+        print *, 'sub_a_3d end'
+    end subroutine
+
+    subroutine sub_a_4d(var_a)
+        implicit none
+        real, dimension(:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e
+
+        print *, 'sub_a_4d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(4)
+        do var_e=1, ubound(var_a, 4)
+           do var_d=1, ubound(var_a, 3)
+              do var_c=1, ubound(var_a, 2)
+                  do var_b=1, ubound(var_a, 1)
+                      var_a(var_b,var_c,var_d,var_e) = 42.0
+                  end do
+              end do
+           end do
+        enddo
+        print *, 'sub_a_4d end'
+    end subroutine
+
+    subroutine sub_a_5d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f
+
+        print *, 'sub_a_5d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(5)
+        do var_f=1, ubound(var_a, 5)
+           do var_e=1, ubound(var_a, 4)
+              do var_d=1, ubound(var_a, 3)
+                 do var_c=1, ubound(var_a, 2)
+                     do var_b=1, ubound(var_a, 1)
+                         var_a(var_b,var_c,var_d,var_e,var_f) = 42.0
+                     end do
+                 end do
+              end do
+           enddo
+        enddo
+        print *, 'sub_a_5d end'
+    end subroutine
+
+    subroutine sub_a_6d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f, var_g
+
+        print *, 'sub_a_6d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(6)
+        do var_g=1, ubound(var_a, 6)
+           do var_f=1, ubound(var_a, 5)
+              do var_e=1, ubound(var_a, 4)
+                 do var_d=1, ubound(var_a, 3)
+                    do var_c=1, ubound(var_a, 2)
+                        do var_b=1, ubound(var_a, 1)
+                            var_a(var_b,var_c,var_d,var_e,var_f,var_g) = 42.0
+                        end do
+                    end do
+                 end do
+              enddo
+           enddo
+        enddo
+        print *, 'sub_a_6d end'
+    end subroutine
+
+    subroutine sub_a_7d(var_a)
+        implicit none
+        real, dimension(:,:,:,:,:,:,:) :: var_a
+        integer :: var_b, var_c, var_d, var_e, var_f, var_g, var_h
+
+        print *, 'sub_a_7d'
+        !$omp target enter data map(ref_ptee, storage:var_a)
+        !$omp target teams distribute parallel do collapse(7)
+        do var_h=1, ubound(var_a, 7)
+           do var_g=1, ubound(var_a, 6)
+              do var_f=1, ubound(var_a, 5)
+                 do var_e=1, ubound(var_a, 4)
+                    do var_d=1, ubound(var_a, 3)
+                       do var_c=1, ubound(var_a, 2)
+                           do var_b=1, ubound(var_a, 1)
+                               var_a(var_b,var_c,var_d,var_e,var_f,var_g,var_h) = 42.0
+                           end do
+                       end do
+                    end do
+                 enddo
+              enddo
+           enddo
+        enddo
+        print *, 'sub_a_7d end'
+    end subroutine
+end module
+
+module mod_b
+    use mod_a, only: sub_a
+end module
+
+program prog_a
+    use mod_b, only: sub_a
+    implicit none
+
+    integer, parameter :: var_a = 10
+    real :: var_b(var_a            )
+    real :: var_c(var_a,var_a          )
+    real :: var_d(var_a,var_a,var_a        )
+    real :: var_e(var_a,var_a,var_a,var_a      )
+    real :: var_f(var_a,var_a,var_a,var_a,var_a    )
+    real :: var_g(var_a,var_a,var_a,var_a,var_a,var_a  )
+    real :: var_h(var_a,var_a,var_a,var_a,var_a,var_a,var_a)
+
+    call sub_a(var_b)
+
+    call sub_a(var_c)
+
+    call sub_a(var_d)
+
+    call sub_a(var_e)
+
+    call sub_a(var_f)
+
+    call sub_a(var_g)
+
+    call sub_a(var_h)
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/michael-map-example.f90
+++ b/test/fortran-map-tests/michael-map-example.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer, parameter :: var_a = 100
+    real, parameter :: var_b=0.2
+
+    type :: dtype_a
+      real, dimension(var_a) :: var_c
+      real, dimension(var_a) :: var_d
+     end type dtype_a
+
+    type :: dtype_b
+      real, dimension(var_a) :: var_e
+     end type dtype_b
+
+    type(dtype_a) :: var_f,var_g
+    type(dtype_b) :: var_h
+
+    integer :: var_i
+
+    do var_i = 1, var_a
+      var_f%var_c(var_i) = var_i-1
+      var_g%var_c(var_i) = 1.0
+    end do
+
+    !$omp target data map(to: var_f%var_c, var_g, var_g%var_c) map(from: var_h%var_e)
+    !$omp target
+    do var_i = 1, var_a
+      var_h%var_e(var_i) =  var_f%var_c(var_i) * var_g%var_c(var_i)
+    end do
+    !$omp end target
+    !$omp end target data
+
+    write(*,*) 'Done! ', var_h%var_e(var_a-1)
+
+    if (var_h%var_e(var_a-1) /= 98) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/milestone-1-map-exact-syntax.f95
+++ b/test/fortran-map-tests/milestone-1-map-exact-syntax.f95
@@ -1,0 +1,24 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    INTEGER :: var_a(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    integer :: var_b, var_c
+
+    !$omp target map(tofrom:var_a(1:10))
+        do var_b = 1, 10
+            var_a(var_b) = var_b
+        end do
+    !$omp end target
+
+    do var_c = 1, 10
+        if (var_a(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/milestone-1-map-syntax.f95
+++ b/test/fortran-map-tests/milestone-1-map-syntax.f95
@@ -1,0 +1,37 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+    program prog_a
+    implicit none
+    INTEGER :: var_a(10) = (/1,2,3,4,5,6,7,8,9,10/)
+    INTEGER :: var_b(10) = (/0,0,0,0,0,0,0,0,0,0/)
+    integer :: var_c
+
+    !$omp target map(tofrom:var_a(2:5)) map(tofrom:var_b(2:5))
+        do var_c = 2, 5
+            var_b(var_c) = var_a(var_c)
+        end do
+    !$omp end target
+
+    if (var_b(1) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_c = 2, 5
+        if (var_b(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_c = 6, 10
+        if (var_b(var_c) /= 0) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/multi-large-nested-dtype-multi-map-with-allocatables.f90
+++ b/test/fortran-map-tests/multi-large-nested-dtype-multi-map-with-allocatables.f90
@@ -1,0 +1,281 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(4), allocatable :: var_a
+      real(4), allocatable :: var_b
+      integer, pointer :: var_c(:)
+      real(4), allocatable :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4), allocatable :: var_e
+      integer(4), allocatable :: var_f
+      integer, allocatable :: var_g
+      integer(4), allocatable :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+      real(4) :: var_i(10)
+      real(4), allocatable :: var_j
+      integer, pointer :: var_k
+      real(4) :: var_l(10)
+      type(dtype_a), allocatable :: var_m
+      type(dtype_b), allocatable :: var_n
+    end type dtype_c
+
+    type :: dtype_d
+      real(4) :: var_o
+      integer(4), allocatable :: var_p(:)
+      real(4) :: var_q
+      integer, allocatable :: var_r(:)
+      integer(4) :: var_s
+      type(dtype_c), allocatable :: var_t
+    end type dtype_d
+
+    type(dtype_d), allocatable :: var_u
+    type(dtype_d), allocatable :: var_v
+    integer, target :: var_w(10)
+    integer, target :: var_x(10)
+    integer :: var_y
+
+    allocate(var_u)
+    allocate(var_v)
+    allocate(var_u%var_t)
+    allocate(var_v%var_t)
+    allocate(var_u%var_t%var_m)
+    allocate(var_v%var_t%var_m)
+    allocate(var_u%var_t%var_n)
+    allocate(var_v%var_t%var_n)
+    allocate(var_u%var_t%var_m%var_b)
+    allocate(var_v%var_t%var_m%var_b)
+    allocate(var_u%var_t%var_m%var_a)
+    allocate(var_v%var_t%var_m%var_a)
+    allocate(var_u%var_t%var_n%var_g)
+    allocate(var_v%var_t%var_n%var_g)
+    allocate(var_u%var_t%var_m%var_d)
+    allocate(var_v%var_t%var_m%var_d)
+    allocate(var_u%var_p(10))
+    allocate(var_v%var_p(10))
+    allocate(var_u%var_t%var_n%var_e)
+    allocate(var_v%var_t%var_n%var_e)
+    allocate(var_u%var_t%var_j)
+    allocate(var_v%var_t%var_j)
+    allocate(var_u%var_t%var_n%var_h)
+    allocate(var_v%var_t%var_n%var_h)
+    allocate(var_u%var_t%var_n%var_f)
+    allocate(var_v%var_t%var_n%var_f)
+
+    var_u%var_t%var_m%var_c => var_w
+    allocate(var_u%var_r(10))
+    allocate(var_u%var_t%var_k)
+
+    var_u%var_t%var_m%var_b = 12
+
+    var_v%var_t%var_m%var_c => var_x
+    allocate(var_v%var_r(10))
+    allocate(var_v%var_t%var_k)
+
+    var_v%var_t%var_m%var_b = 12
+
+!$omp target map(tofrom: var_u%var_p, var_u%var_r, var_u%var_t%var_m%var_c, var_v%var_p, var_v%var_r, var_v%var_t%var_m%var_c, var_u%var_t%var_m%var_a, var_v%var_t%var_m%var_a, var_u%var_t%var_m%var_b, var_u%var_t%var_m%var_d, var_u%var_t%var_n%var_e, var_u%var_t%var_n%var_f, var_u%var_t%var_n%var_h, var_u%var_t%var_j, var_u%var_t%var_n%var_g, var_u%var_t%var_k, var_v%var_t%var_m%var_b, var_v%var_t%var_m%var_d, var_v%var_t%var_n%var_e, var_v%var_t%var_n%var_f, var_v%var_t%var_n%var_h, var_v%var_t%var_j, var_v%var_t%var_n%var_g, var_v%var_t%var_k)
+    var_u%var_t%var_m%var_a = 10
+    var_u%var_t%var_m%var_b = 12 + var_u%var_t%var_m%var_b
+    var_u%var_t%var_m%var_d = 54
+
+    var_u%var_t%var_n%var_e = 20
+    var_u%var_t%var_n%var_f = 40
+    var_u%var_t%var_n%var_h = 60
+
+    var_u%var_t%var_j = 200
+    var_u%var_t%var_n%var_g = 30
+    var_u%var_t%var_k = 200
+
+    do var_y = 1, 10
+      var_u%var_t%var_m%var_c(var_y) = var_y
+      var_u%var_r(var_y) = var_y
+      var_u%var_p(var_y) = var_y
+    end do
+
+    var_v%var_t%var_m%var_a = 10
+    var_v%var_t%var_m%var_b = 12 + var_v%var_t%var_m%var_b
+    var_v%var_t%var_m%var_d = 54
+
+    var_v%var_t%var_n%var_e = 20
+    var_v%var_t%var_n%var_f = 40
+    var_v%var_t%var_n%var_h = 60
+
+    var_v%var_t%var_j = 200
+    var_v%var_t%var_n%var_g = 30
+    var_v%var_t%var_k = 200
+
+    do var_y = 1, 10
+      var_v%var_t%var_m%var_c(var_y) = var_y
+      var_v%var_r(var_y) = var_y
+      var_v%var_p(var_y) = var_y
+    end do
+!$omp end target
+
+  print *, var_u%var_t%var_m%var_a
+  print *, var_u%var_t%var_m%var_b
+  print *, var_u%var_t%var_m%var_d
+  print *, var_u%var_t%var_n%var_e
+  print *, var_u%var_t%var_n%var_f
+  print *, var_u%var_t%var_n%var_h
+  print *, var_u%var_t%var_j
+  print *, var_u%var_t%var_m%var_c
+  print *, var_u%var_r
+  print *, var_u%var_p
+  print *, var_u%var_t%var_k
+  print *, var_u%var_t%var_n%var_g
+
+  print *, var_v%var_t%var_m%var_a
+  print *, var_v%var_t%var_m%var_b
+  print *, var_v%var_t%var_m%var_d
+  print *, var_v%var_t%var_n%var_e
+  print *, var_v%var_t%var_n%var_f
+  print *, var_v%var_t%var_n%var_h
+  print *, var_v%var_t%var_j
+  print *, var_v%var_t%var_m%var_c
+  print *, var_v%var_r
+  print *, var_v%var_p
+  print *, var_v%var_t%var_k
+  print *, var_v%var_t%var_n%var_g
+
+  if (var_u%var_t%var_m%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_m%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_m%var_d /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_e /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_f /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_h /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_j /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_k /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_u%var_t%var_n%var_g /= 30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_y = 1, 10
+    if (var_u%var_t%var_m%var_c(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_y = 1, 10
+    if (var_u%var_r(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_y = 1, 10
+    if (var_u%var_p(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  if (var_v%var_t%var_m%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_m%var_b /= 24) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_m%var_d /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_n%var_e /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_n%var_f /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_n%var_h /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_j /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_k /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_v%var_t%var_n%var_g /= 30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_y = 1, 10
+    if (var_v%var_t%var_m%var_c(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_y = 1, 10
+    if (var_v%var_r(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_y = 1, 10
+    if (var_v%var_p(var_y) /= var_y) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/multi-large-nested-dtype-multi-map.f90
+++ b/test/fortran-map-tests/multi-large-nested-dtype-multi-map.f90
@@ -1,0 +1,126 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    real(4) :: var_b
+    real(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+      integer(4) :: var_d
+      integer(4) :: var_e
+      integer(4) :: var_f
+    end type dtype_b
+
+    type :: dtype_c
+     real(4) :: var_g(10)
+     real(4) :: var_h
+     real(4) :: var_i(10)
+     type(dtype_a) :: var_j
+     type(dtype_b) :: var_k
+    end type dtype_c
+
+    type :: dtype_d
+    real(4) :: var_l
+    integer(4) :: var_m(10)
+    real(4) :: var_n
+    integer, allocatable :: var_o(:)
+    integer(4) :: var_p
+    type(dtype_c) :: var_q
+    end type dtype_d
+
+    type(dtype_d) :: var_r
+    type(dtype_d) :: var_s
+    integer :: var_t
+
+    var_s%var_q%var_j%var_a = 10
+    var_s%var_q%var_j%var_b = 12
+    var_s%var_q%var_j%var_c = 54
+
+    var_s%var_q%var_k%var_d = 20
+    var_s%var_q%var_k%var_e = 40
+    var_s%var_q%var_k%var_f = 60
+
+    var_s%var_q%var_h = 200
+
+      do var_t = 1, 10
+        var_s%var_m(var_t) = var_t
+      end do
+
+!$omp target map(from: var_r%var_q%var_j%var_b, var_r%var_q%var_j%var_a, var_r%var_q%var_j%var_c, var_r%var_m, var_r%var_q%var_k%var_d, var_r%var_q%var_h, var_r%var_q%var_k%var_f, var_r%var_q%var_k%var_e) &
+!$omp map(to: var_s%var_q%var_j%var_b, var_s%var_q%var_j%var_a, var_s%var_q%var_j%var_c, var_s%var_m, var_s%var_q%var_k%var_d, var_s%var_q%var_h, var_s%var_q%var_k%var_f, var_s%var_q%var_k%var_e)
+
+    var_r%var_q%var_j%var_a = var_s%var_q%var_j%var_a
+    var_r%var_q%var_j%var_b = var_s%var_q%var_j%var_b 
+    var_r%var_q%var_j%var_c = var_s%var_q%var_j%var_c
+
+    var_r%var_q%var_k%var_d = var_s%var_q%var_k%var_d
+    var_r%var_q%var_k%var_e = var_s%var_q%var_k%var_e
+    var_r%var_q%var_k%var_f = var_s%var_q%var_k%var_f
+
+    var_r%var_q%var_h = var_s%var_q%var_h
+
+    do var_t = 1, 10
+      var_r%var_m(var_t) = var_s%var_m(var_t)
+    end do
+!$omp end target
+
+  print *, var_r%var_q%var_j%var_a
+  print *, var_r%var_q%var_j%var_b
+  print *, var_r%var_q%var_j%var_c
+
+  print *, var_r%var_q%var_k%var_d
+  print *, var_r%var_q%var_k%var_e
+  print *, var_r%var_q%var_k%var_f
+
+  print *, var_r%var_q%var_h
+
+  print *, var_r%var_m
+
+  if (var_r%var_q%var_j%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_b /= 12) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_j%var_c /= 54) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_e /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_k%var_f /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_r%var_q%var_h /= 200) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_t = 1, 10
+    if (var_r%var_m(var_t) /= var_t) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/multi-nested-dtype-multi-map-bounds.f90
+++ b/test/fortran-map-tests/multi-nested-dtype-multi-map-bounds.f90
@@ -1,0 +1,63 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+    do var_l = 1, 10
+      var_k%var_g%var_b(var_l) = var_l * 2
+    end do
+
+    do var_l = 1, 10
+      var_k%var_e(var_l) = var_l * 2
+    end do
+
+!$omp target map(from: var_j%var_g%var_b(2:6), var_j%var_e(4:8)) &
+!$omp map(to: var_k%var_g%var_b(2:6), var_k%var_e(4:8))
+    do var_l = 2, 6
+      var_j%var_g%var_b(var_l) = var_k%var_g%var_b(var_l)
+    end do
+
+    do var_l = 4, 8
+      var_j%var_e(var_l) = var_k%var_e(var_l)
+    end do
+!$omp end target
+
+  print *, var_j%var_g%var_b
+  print *, var_j%var_e
+
+  do var_l = 2, 6
+    if (var_j%var_g%var_b(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_l = 4, 8
+    if (var_j%var_e(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/multi-nested-dtype-single-map-bounds.f90
+++ b/test/fortran-map-tests/multi-nested-dtype-single-map-bounds.f90
@@ -1,0 +1,54 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+!$omp target map(tofrom: var_j%var_g%var_b(4:8), var_k%var_g%var_c(4:8))
+    do var_l = 4, 8
+      var_j%var_g%var_b(var_l) = var_l * 2
+    end do
+
+    do var_l = 4, 8
+      var_k%var_g%var_c(var_l) = var_l * 2
+    end do
+!$omp end target
+
+  print *, var_j%var_g%var_b
+  print *, var_k%var_g%var_c
+
+  do var_l = 4, 8
+    if (var_k%var_g%var_c(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_l = 4, 8
+    if (var_j%var_g%var_b(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/multi-nested-dtype-single-map.f90
+++ b/test/fortran-map-tests/multi-nested-dtype-single-map.f90
@@ -1,0 +1,54 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+!$omp target map(tofrom: var_j%var_g%var_b, var_k%var_g%var_c)
+    do var_l = 1, 10
+      var_j%var_g%var_b(var_l) = var_l * 2
+    end do
+
+    do var_l = 1, 10
+      var_k%var_g%var_c(var_l) = var_l * 2
+    end do
+!$omp end target
+
+  print *, var_j%var_g%var_b
+  print *, var_k%var_g%var_c
+
+  do var_l = 1, 10
+    if (var_k%var_g%var_c(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_l = 1, 10
+    if (var_j%var_g%var_b(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/multiple-dt-explicit-member-map.f90
+++ b/test/fortran-map-tests/multiple-dt-explicit-member-map.f90
@@ -1,0 +1,30 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  type :: dtype_a
+    integer(4) :: var_a = 0
+    real(4) :: var_b = 0.0
+    complex(4) :: var_c = (0,0)
+    type(dtype_a), allocatable :: var_d
+    real(4) :: var_e = 1.0
+  end type dtype_a
+
+    type(dtype_a) :: var_f
+
+  !$omp target map(from:var_f%var_b, var_f%var_e)
+    var_f%var_b = 21.0
+    var_f%var_e = 27.0
+  !$omp end target
+
+  print*, var_f%var_b
+  print*, var_f%var_e
+
+  if (var_f%var_b /= 21.0 .and. var_f%var_e /= 27.0) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+
+   print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nd-allocatables-bounds-map-syntax.f95
+++ b/test/fortran-map-tests/nd-allocatables-bounds-map-syntax.f95
@@ -1,0 +1,51 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer, allocatable :: var_a(:,:,:)
+    integer, allocatable :: var_b(:,:,:)
+    integer :: var_c, var_d, var_e
+
+    allocate(var_a(3,3,3))
+    allocate(var_b(3,3,3))
+
+    do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+            var_a(var_c, var_d, var_e) = 42
+            var_b(var_c, var_d, var_e) = 0
+        end do
+       end do
+    end do
+
+!$omp target map(tofrom:var_a(1:3, 1:3, 2:2), var_b(1:3, 1:3, 1:3))
+    do var_d = 1, 3
+      do var_e = 1, 3
+        var_b(var_e, var_d, 2) = var_a(var_e, var_d, 2)
+      end do
+    end do
+!$omp end target
+
+ print *, var_b
+
+  do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+          if (var_c == 2 .and. var_b(var_e, var_d, var_c) /= 42) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          else if (var_c /= 2 .and. var_b(var_e, var_d, var_c) /= 0) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          end if
+        end do
+      end do
+  end do
+
+deallocate(var_a)
+deallocate(var_b)
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/nd-allocatables-target-map.f90
+++ b/test/fortran-map-tests/nd-allocatables-target-map.f90
@@ -1,0 +1,39 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  integer,  allocatable :: var_a(:,:,:)
+  integer :: var_b = 1
+  integer :: var_c, var_d, var_e
+
+  allocate(var_a(3,3,3))
+
+!$omp target map(tofrom: var_a)
+    do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+           var_a(var_e, var_d, var_c) = var_b
+           var_b = var_b + 1
+        end do
+      end do
+    end do
+!$omp end target
+
+    print *, var_a
+
+    do var_c = 1, 3
+        do var_d = 1, 3
+          do var_e = 1, 3
+            if (var_a(var_e, var_d, var_c) /= var_b) then
+                print*, "======= FORTRAN Test Failed! ======="
+                stop 1
+            end if
+           var_b = var_b + 1
+          end do
+        end do
+      end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/nd-array-full-map.f95
+++ b/test/fortran-map-tests/nd-array-full-map.f95
@@ -1,0 +1,44 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(3,3,3)
+    integer :: var_b(3,3,3)
+    integer :: var_c, var_d, var_e
+
+    do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+            var_a(var_c, var_d, var_e) = 42
+            var_b(var_c, var_d, var_e) = 0
+        end do
+       end do
+    end do
+
+!$omp target map(tofrom:var_a, var_b)
+do var_c = 1, 3
+    do var_d = 1, 3
+      do var_e = 1, 3
+        var_b(var_e, var_d, var_c) = var_a(var_e, var_d, var_c)
+      end do
+    end do
+end do
+!$omp end target
+
+ print *, var_b
+
+  do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+          if (var_b(var_e, var_d, var_c) /= 42) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          end if
+        end do
+      end do
+  end do
+
+  print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/nd-bounds-map-syntax.f95
+++ b/test/fortran-map-tests/nd-bounds-map-syntax.f95
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer :: var_a(3,3,3)
+    integer :: var_b(3,3,3)
+    integer :: var_c, var_d, var_e
+
+    do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+            var_a(var_c, var_d, var_e) = 42
+            var_b(var_c, var_d, var_e) = 0
+        end do
+       end do
+    end do
+
+!$omp target map(tofrom:var_a(1:3, 1:3, 2:2), var_b(1:3, 1:3, 1:3))
+    do var_d = 1, 3
+      do var_e = 1, 3
+        var_b(var_e, var_d, 2) = var_a(var_e, var_d, 2)
+      end do
+    end do
+!$omp end target
+
+ print *, var_b
+
+  do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+          if (var_c == 2 .and. var_b(var_e, var_d, var_c) /= 42) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          else if (var_c /= 2 .and. var_b(var_e, var_d, var_c) /= 0) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          end if
+        end do
+      end do
+  end do
+
+print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/nd-pointer-bounds-map-syntax.f95
+++ b/test/fortran-map-tests/nd-pointer-bounds-map-syntax.f95
@@ -1,0 +1,52 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer, pointer :: var_a(:,:,:)
+    integer, pointer :: var_b(:,:,:)
+    integer :: var_c, var_d, var_e
+
+    allocate(var_a(3,3,3))
+    allocate(var_b(3,3,3))
+
+    do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+            var_a(var_c, var_d, var_e) = 42
+            var_b(var_c, var_d, var_e) = 0
+        end do
+       end do
+    end do
+
+!$omp target map(tofrom:var_a(1:3, 1:3, 2:2), var_b(1:3, 1:3, 1:3))
+    do var_d = 1, 3
+      do var_e = 1, 3
+        var_b(var_e, var_d, 2) = var_a(var_e, var_d, 2)
+      end do
+    end do
+!$omp end target
+
+ print *, var_b
+
+  do var_c = 1, 3
+      do var_d = 1, 3
+        do var_e = 1, 3
+          if (var_c == 2 .and. var_b(var_e, var_d, var_c) /= 42) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          else if (var_c /= 2 .and. var_b(var_e, var_d, var_c) /= 0) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+          end if
+        end do
+      end do
+  end do
+
+deallocate(var_a)
+deallocate(var_b)
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/neg-bounds-alloca-test.f90
+++ b/test/fortran-map-tests/neg-bounds-alloca-test.f90
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type dtype_a
+        real(4), pointer :: var_a(:,:,:) => null()
+    end type
+    type(dtype_a), allocatable :: var_b(:,:)
+    integer :: var_c
+
+    allocate(var_b(-1:1,1:3))
+    do var_c = 1, 3
+        allocate(var_b(-1,var_c)%var_a(3,3,3))
+    enddo
+
+    !$omp target map(tofrom: var_b(-1,1)%var_a)
+        var_b(-1,1)%var_a(2,2,2) = 30
+    !$omp end target
+
+    if (var_b(-1,1)%var_a(2,2,2) /= 30) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-allocatable-dtype-allocatable-array-with-bounds-map.f90
+++ b/test/fortran-map-tests/nested-allocatable-dtype-allocatable-array-with-bounds-map.f90
@@ -1,0 +1,66 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_d
+        integer(4) :: var_e(10)
+        type(dtype_a) :: var_f
+        integer, allocatable :: var_g(:)
+        integer(4) :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+        real(4) :: var_i
+        integer, allocatable :: var_j
+        integer(4) :: var_k(10)
+        real(4) :: var_l
+        integer, allocatable :: var_m(:)
+        integer(4) :: var_n
+        type(dtype_b), allocatable :: var_o
+    end type dtype_c
+
+    type(dtype_c), allocatable :: var_p
+    integer :: var_q, var_r
+
+    allocate(var_p)
+    allocate(var_p%var_o)
+    allocate(var_p%var_o%var_g(10))
+
+!$omp target map(tofrom: var_p%var_o%var_g(2:6))
+    do var_q = 1, 10
+        var_p%var_o%var_g(var_q) = var_q
+    end do
+!$omp end target
+
+print *, var_p%var_o%var_g
+
+if (var_p%var_o%var_g(1) == 1) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+do var_r = 2, 6
+    if (var_p%var_o%var_g(var_r) /= var_r) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_r = 7, 10
+    if (var_p%var_o%var_g(var_r) == var_r) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-allocatable-and-array-map.f90
+++ b/test/fortran-map-tests/nested-dtype-allocatable-and-array-map.f90
@@ -1,0 +1,58 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    integer, allocatable :: var_b 
+    integer(4) :: var_c(10)
+    integer, allocatable :: var_d(:)
+    integer(4) :: var_e
+    end type dtype_a
+
+    type :: dtype_b
+    real(4) :: var_f
+    integer, allocatable :: var_g 
+    integer(4) :: var_h(10)
+    real(4) :: var_i
+    integer, allocatable :: var_j(:)
+    integer(4) :: var_k
+    type(dtype_a) :: var_l
+    end type dtype_b
+
+    type(dtype_b) :: var_m
+    integer :: var_n
+
+    allocate(var_m%var_l%var_d(10))
+    allocate(var_m%var_l%var_b) 
+
+    do var_n = 1, 10
+        var_m%var_l%var_c(var_n) = var_n
+    end do
+
+    !$omp target map(tofrom: var_m%var_l%var_c, var_m%var_l%var_d)
+    do var_n = 1, 10
+        var_m%var_l%var_d(var_n) = var_m%var_l%var_c(var_n) + var_n
+    end do
+    !$omp end target
+
+    print *, var_m%var_l%var_d
+    print *, var_m%var_l%var_c
+
+    do var_n = 1, 10
+        if (var_m%var_l%var_d(var_n) /= var_n + var_n) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_n = 1, 10
+        if (var_m%var_l%var_c(var_n) /= var_n) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-allocatable-and-dtype-map.f90
+++ b/test/fortran-map-tests/nested-dtype-allocatable-and-dtype-map.f90
@@ -1,0 +1,64 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+    real(4) :: var_a
+    integer(4) :: var_b(10)
+    integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+    real(4) :: var_d
+    integer(4) :: var_e(10)
+    type(dtype_a) :: var_f
+    integer, allocatable :: var_g(:)
+    integer(4) :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+    real(4) :: var_i
+    integer, allocatable :: var_j
+    integer(4) :: var_k(10)
+    real(4) :: var_l
+    integer, allocatable :: var_m(:)
+    integer(4) :: var_n
+    type(dtype_b) :: var_o
+    end type dtype_c
+
+    type(dtype_c) :: var_p
+    integer :: var_q
+
+    allocate(var_p%var_o%var_g(10))
+    allocate(var_p%var_j)
+
+    do var_q = 1, 10
+        var_p%var_o%var_f%var_b(var_q) = var_q
+    end do
+
+    !$omp target map(tofrom: var_p%var_o%var_f, var_p%var_o%var_g)
+    do var_q = 1, 10
+        var_p%var_o%var_g(var_q) = var_p%var_o%var_f%var_b(var_q) + var_q
+    end do
+    !$omp end target
+
+    print *, var_p%var_o%var_g
+    print *, var_p%var_o%var_f%var_b
+
+    do var_q = 1, 10
+        if (var_p%var_o%var_g(var_q) /= var_q + var_q) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_q = 1, 10
+        if (var_p%var_o%var_f%var_b(var_q) /= var_q) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-allocatable-array-with-bounds-map.f90
+++ b/test/fortran-map-tests/nested-dtype-allocatable-array-with-bounds-map.f90
@@ -1,0 +1,63 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        integer(4) :: var_c
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_d
+        integer(4) :: var_e(10)
+        type(dtype_a) :: var_f
+        integer, allocatable :: var_g(:)
+        integer(4) :: var_h
+    end type dtype_b
+
+    type :: dtype_c
+        real(4) :: var_i
+        integer, allocatable :: var_j
+        integer(4) :: var_k(10)
+        real(4) :: var_l
+        integer, allocatable :: var_m(:)
+        integer(4) :: var_n
+        type(dtype_b) :: var_o
+    end type dtype_c
+
+    type(dtype_c) :: var_p
+    integer :: var_q, var_r
+
+    allocate(var_p%var_o%var_g(10))
+
+!$omp target map(tofrom: var_p%var_o%var_g(2:6))
+    do var_q = 1, 10
+        var_p%var_o%var_g(var_q) = var_q
+    end do
+!$omp end target
+
+print *, var_p%var_o%var_g
+
+if (var_p%var_o%var_g(1) == 1) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+do var_r = 2, 6
+    if (var_p%var_o%var_g(var_r) /= var_r) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+do var_r = 7, 10
+    if (var_p%var_o%var_g(var_r) == var_r) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-allocatable-scalar-map.f90
+++ b/test/fortran-map-tests/nested-dtype-allocatable-scalar-map.f90
@@ -1,0 +1,53 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+        real(4) :: var_a
+        integer(4) :: var_b(10)
+        integer, allocatable :: var_c(:)
+        integer(4), allocatable :: var_d
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_e
+        integer, allocatable :: var_f
+        integer(4) :: var_g(10)
+        real(4) :: var_h
+        integer, allocatable :: var_i(:)
+        integer(4) :: var_j
+        type(dtype_a) :: var_k
+    end type dtype_b
+
+    type(dtype_b) :: var_l
+    integer :: var_m
+
+    allocate(var_l%var_k%var_c(10))
+    allocate(var_l%var_k%var_d)
+
+    !$omp target map(tofrom: var_l%var_k%var_c, var_l%var_k%var_d)
+        do var_m = 1, 10
+            var_l%var_k%var_c(var_m) = var_m
+        end do
+        var_l%var_k%var_d = 50
+    !$omp end target
+
+    print *, var_l%var_k%var_d
+    print *, var_l%var_k%var_c
+
+    do var_m = 1, 10
+        if (var_l%var_k%var_c(var_m) /= var_m) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    if (var_l%var_k%var_d  /= 50) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-array-allocatable.f90
+++ b/test/fortran-map-tests/nested-dtype-array-allocatable.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+implicit none
+type :: dtype_a
+    real(4) :: var_a
+    integer(4) :: var_b(10)
+    integer, allocatable :: var_c(:)
+    integer(4) :: var_d
+end type dtype_a
+
+type :: dtype_b
+    real(4) :: var_e
+    integer, allocatable :: var_f
+    integer(4) :: var_g(10)
+    real(4) :: var_h
+    integer, allocatable :: var_i(:)
+    integer(4) :: var_j
+    type(dtype_a) :: var_k
+end type dtype_b
+
+type(dtype_b) :: var_l
+integer :: var_m
+
+allocate(var_l%var_k%var_c(10))
+
+!$omp target map(tofrom: var_l%var_k%var_c)
+    do var_m = 1, 10
+        var_l%var_k%var_c(var_m) = var_m
+    end do
+!$omp end target
+
+print *, var_l%var_k%var_c
+
+do var_m = 1, 10
+    if (var_l%var_k%var_c(var_m) /= var_m) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-complex-map.f90
+++ b/test/fortran-map-tests/nested-dtype-complex-map.f90
@@ -1,0 +1,79 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      complex  :: var_b
+      real(4) :: var_c(10)
+      real(4) :: var_d(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_e
+      integer(4) :: var_f(10)
+      real(4) :: var_g
+      type(dtype_a) :: var_h
+      integer, allocatable :: var_i(:)
+      integer(4) :: var_j
+      complex :: var_k
+    end type dtype_b
+
+    type(dtype_b) :: var_l
+    integer :: var_m
+
+!$omp target map(tofrom: var_l%var_h%var_a, var_l%var_j, var_l%var_h%var_b, var_l%var_h%var_c, var_l%var_k)
+    do var_m = 1, 10
+      var_l%var_h%var_c(var_m) = var_m * 2
+    end do
+
+    var_l%var_k = (10,20)
+    var_l%var_h%var_b = (510,210)
+
+    var_l%var_h%var_a = 30.30
+    var_l%var_j = 74
+!$omp end target
+
+  print *, var_l%var_h%var_a
+  print *, var_l%var_j
+  print *, var_l%var_h%var_c
+  print *, var_l%var_k
+  print *, var_l%var_h%var_b
+
+  if (var_l%var_h%var_a /= 30.30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_l%var_j /= 74) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_l%var_k /= (10,20)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_l%var_h%var_b /= (510,210)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_l%var_j /= 74) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_m = 1, 10
+    if (var_l%var_h%var_c(var_m) /= var_m * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-double-allocatable.f90
+++ b/test/fortran-map-tests/nested-dtype-double-allocatable.f90
@@ -1,0 +1,53 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    type :: dtype_a
+        real(4) :: var_a
+        integer, allocatable :: var_b
+        integer(4) :: var_c(10)
+        integer, allocatable :: var_d(:)
+        integer(4) :: var_e
+    end type dtype_a
+
+    type :: dtype_b
+        real(4) :: var_f
+        integer, allocatable :: var_g
+        integer(4) :: var_h(10)
+        real(4) :: var_i
+        type(dtype_a) :: var_j
+        integer, allocatable :: var_k(:)
+        integer(4) :: var_l
+    end type dtype_b
+
+    type(dtype_b) :: var_m
+    integer :: var_n
+
+    allocate(var_m%var_j%var_d(10))
+    allocate(var_m%var_j%var_b)
+
+    !$omp target map(tofrom: var_m%var_j%var_b, var_m%var_j%var_d)
+        do var_n = 1, 10
+            var_m%var_j%var_d(var_n) = var_n
+        end do
+        var_m%var_j%var_b = 50
+    !$omp end target
+
+    print *, var_m%var_j%var_d
+    print *, var_m%var_j%var_b
+
+    do var_n = 1, 10
+        if (var_m%var_j%var_d(var_n) /= var_n) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    if (var_m%var_j%var_b /= 50) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-map-struct.f90
+++ b/test/fortran-map-tests/nested-dtype-map-struct.f90
@@ -1,0 +1,66 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+      type(dtype_a) :: var_j
+    end type dtype_b
+
+    type(dtype_b) :: var_k
+    integer :: var_l
+
+!$omp target map(tofrom: var_k%var_i, var_k%var_j%var_b, var_k%var_g)
+    do var_l = 1, 10
+      var_k%var_j%var_b(var_l) = var_l * 2
+      var_k%var_g%var_b(var_l) = var_l * 2
+    end do
+
+    var_k%var_g%var_a = 30.30
+    var_k%var_i = 74
+!$omp end target
+
+  print *, var_k%var_g%var_a
+  print *, var_k%var_i
+  print *, var_k%var_g%var_b
+  print *, var_k%var_j%var_b
+
+  if (var_k%var_g%var_a /= 30.30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_k%var_i /= 74) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_l = 1, 10
+    if (var_k%var_g%var_b(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  do var_l = 1, 10
+    if (var_k%var_j%var_b(var_l) /= var_l * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-scalar-allocatable.f90
+++ b/test/fortran-map-tests/nested-dtype-scalar-allocatable.f90
@@ -1,0 +1,41 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+type :: dtype_a
+real(4) :: var_a
+integer, allocatable :: var_b 
+integer(4) :: var_c(10)
+integer, allocatable :: var_d(:)
+integer(4) :: var_e
+end type dtype_a
+
+type :: dtype_b
+real(4) :: var_f
+integer, allocatable :: var_g 
+integer(4) :: var_h(10)
+type(dtype_a) :: var_i
+real(4) :: var_j
+integer, allocatable :: var_k(:)
+integer(4) :: var_l
+end type dtype_b
+
+type(dtype_b) :: var_m
+
+allocate(var_m%var_i%var_b)
+
+!$omp target map(tofrom: var_m%var_i%var_b)
+    var_m%var_i%var_b = 50
+!$omp end target
+
+print *, var_m%var_i%var_b
+
+if (var_m%var_i%var_b /= 50) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+  
+ print *, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/nested-dtype-single-map.f90
+++ b/test/fortran-map-tests/nested-dtype-single-map.f90
@@ -1,0 +1,41 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    integer :: var_k
+
+!$omp target map(tofrom: var_j%var_g%var_b)
+    do var_k = 1, 10
+      var_j%var_g%var_b(var_k) = var_k * 2
+    end do
+!$omp end target
+
+  print *, var_j%var_g%var_b
+
+  do var_k = 1, 10
+    if (var_j%var_g%var_b(var_k) /= var_k * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/no-write-implicit-cap.f95
+++ b/test/fortran-map-tests/no-write-implicit-cap.f95
@@ -1,0 +1,24 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    REAL :: var_a = 0.5
+    REAL :: var_b = 0.5
+    !$omp target map(tofrom:var_b)
+        var_b = var_a + var_b
+        var_a = 15
+    !$omp end target
+
+PRINT *, var_a
+PRINT *, var_b
+
+
+if (var_a /= 0.5 .OR. var_b /= 1.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/parent-member-overlap-test-1.f90
+++ b/test/fortran-map-tests/parent-member-overlap-test-1.f90
@@ -1,0 +1,66 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+
+  integer :: var_a
+
+  type dtype_a
+  integer :: var_b
+  real :: var_c
+  real :: var_d(10)
+  end type dtype_a
+
+  type dtype_b
+  character (LEN=30) :: var_e
+  character (LEN=1) :: var_f
+  type(dtype_a) :: var_g
+  end type dtype_b
+
+  type dtype_c
+  integer :: var_h(10)
+  type(dtype_b) :: var_i
+  integer :: var_j
+  type(dtype_a) :: var_k(3)
+  end type dtype_c
+
+  type (dtype_c) :: var_l
+
+  do var_a = 1, 10
+    var_l%var_h(var_a) = 0
+  end do
+
+!$omp target map(to: var_l) map(tofrom: var_l%var_i%var_g, var_l%var_j)
+  var_l%var_j = 20
+  do var_a = 1, 10
+    var_l%var_h(var_a) = var_a
+  end do
+  var_l%var_i%var_g%var_c = 32.0
+!$omp end target
+
+print *, var_l%var_j
+print *, var_l%var_i%var_g%var_c
+print *, var_l%var_h
+
+do var_a = 1, 10
+  if (var_l%var_h(var_a) /= 0) then
+    print *, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end do
+
+if (var_l%var_j /= 20) then
+  print *, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+if (var_l%var_i%var_g%var_c /= 32.0) then
+  print *, "======= FORTRAN Test Failed! ======="
+  stop 1
+end if
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/pointer-array-section-1d-upperbound.f95
+++ b/test/fortran-map-tests/pointer-array-section-1d-upperbound.f95
@@ -1,0 +1,50 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:), var_b(:)
+    integer :: var_c
+    allocate(var_a(10))
+    allocate(var_b(10))
+
+    do var_c = 1, 10
+        var_a(var_c) = var_c
+        var_b(var_c) = 0
+    end do
+
+    !$omp target map(tofrom:var_a(2:6)) map(tofrom:var_b(2:6))
+        do var_c = 1, 10
+            var_b(var_c) = var_a(var_c)
+        end do
+    !$omp end target
+
+    do var_c = 1, 10
+        print *, var_b(var_c)
+    end do
+
+    if (var_b(1) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_c = 2, 6
+        if (var_b(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_c = 7, 10
+        if (var_b(var_c) /= 0) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    deallocate(var_a)
+    deallocate(var_b)
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-map-scopes-bounds.f95
+++ b/test/fortran-map-tests/pointer-map-scopes-bounds.f95
@@ -1,0 +1,85 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none
+  integer,  pointer, intent (inout) :: var_a(:)
+  integer :: var_b, var_c
+
+!$omp target map(tofrom: var_a(2:6))
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 2, 6
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer,  pointer :: var_a(:)
+  integer :: var_b, var_c
+  allocate(var_a(10))
+
+!$omp target map(tofrom: var_a(2:6))
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 2, 6
+    if (var_a(var_c) /= var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  deallocate(var_a)
+end subroutine sub_b
+
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_b, var_c
+integer,  pointer :: var_a(:)
+
+allocate(var_a(10))
+
+!$omp target map(tofrom: var_a(2:6))
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_a
+
+  do var_c = 2, 6
+    if (var_a(var_c) /= var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_a)
+
+  deallocate(var_a)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-map-scopes.f95
+++ b/test/fortran-map-tests/pointer-map-scopes.f95
@@ -1,0 +1,85 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none 
+  integer :: var_b, var_c
+  integer,  pointer, intent (inout) :: var_a(:)
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer :: var_b, var_c
+  integer,  pointer :: var_a(:)
+  allocate(var_a(10))
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  deallocate(var_a)
+end subroutine sub_b
+
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_b, var_c
+integer,  pointer :: var_a(:)
+
+allocate(var_a(10))
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_a)
+
+  deallocate(var_a)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-map.f95
+++ b/test/fortran-map-tests/pointer-map.f95
@@ -1,0 +1,31 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+  implicit none
+  integer,  pointer :: var_a(:)
+  integer :: var_b, var_c
+
+allocate(var_a(10))
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_b
+  end do
+!$omp end target
+
+  do var_b = 1, 10
+    print*, var_a(var_b)
+  end do
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-scopes-enter-exit-map.f90
+++ b/test/fortran-map-tests/pointer-scopes-enter-exit-map.f90
@@ -1,0 +1,101 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+  subroutine sub_a(var_a)
+    implicit none
+    integer :: var_b, var_c
+    integer,  pointer, intent (inout) :: var_a(:)
+
+  !$omp target enter data map(alloc: var_a)
+
+  !$omp target
+    do var_b = 1, 10
+      var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  !$omp target exit data map(delete: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+      if (var_a(var_c) /= var_c + var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+  end subroutine sub_a
+end module
+
+subroutine sub_b
+    implicit none
+    integer :: var_b, var_c
+    integer,  pointer :: var_a(:)
+    allocate(var_a(10))
+
+  !$omp target enter data map(alloc: var_a)
+
+  !$omp target
+    do var_b = 1, 10
+      var_a(var_b) = var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  !$omp target exit data map(delete: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+      if (var_a(var_c) /= var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+    deallocate(var_a)
+end subroutine sub_b
+
+program prog_a
+  use mod_a
+  implicit none
+  integer :: var_b, var_c
+  integer,  pointer :: var_a(:)
+  allocate(var_a(10))
+
+  !$omp target enter data map(alloc: var_a)
+
+  !$omp target
+    do var_b = 1, 10
+      var_a(var_b) = var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  !$omp target exit data map(delete: var_a)
+
+    call sub_b
+
+    print *, var_a
+
+    do var_c = 1, 10
+      if (var_a(var_c) /= var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+    call sub_a(var_a)
+
+    deallocate(var_a)
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-target-array-section-1d-upperbound.f95
+++ b/test/fortran-map-tests/pointer-target-array-section-1d-upperbound.f95
@@ -1,0 +1,49 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:), var_b(:)
+    integer, target :: var_c(10), var_d(10)
+    integer :: var_e
+
+    var_a => var_d
+    var_b => var_c
+
+    do var_e = 1, 10
+        var_a(var_e) = var_e
+        var_b(var_e) = 0
+    end do
+
+    !$omp target map(tofrom:var_a(2:6)) map(tofrom:var_b(2:6))
+        do var_e = 1, 10
+            var_b(var_e) = var_a(var_e)
+        end do
+    !$omp end target
+
+    do var_e = 1, 10
+        print *, var_b(var_e)
+    end do
+
+    if (var_b(1) /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    do var_e = 2, 6
+        if (var_b(var_e) /= var_e) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    do var_e = 7, 10
+        if (var_b(var_e) /= 0) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-target-map-scopes-bounds.f95
+++ b/test/fortran-map-tests/pointer-target-map-scopes-bounds.f95
@@ -1,0 +1,82 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none
+  integer :: var_b, var_c
+  integer,  pointer, intent (inout) :: var_a(:)
+
+!$omp target map(tofrom: var_a(2:6))
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 2, 6
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer :: var_a, var_b
+  integer,  pointer :: var_c(:)
+  integer, target :: var_d(10)
+  var_c => var_d
+
+!$omp target map(tofrom: var_c(2:6))
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  print *, var_c
+
+  do var_b = 2, 6
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_b
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_a, var_b
+integer,  pointer :: var_c(:)
+integer, target :: var_d(10)
+var_c => var_d
+
+!$omp target map(tofrom: var_c(2:6))
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_c
+
+  do var_b = 2, 6
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_c)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-target-map-scopes.f95
+++ b/test/fortran-map-tests/pointer-target-map-scopes.f95
@@ -1,0 +1,82 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  contains
+subroutine sub_a(var_a)
+  implicit none
+  integer :: var_b, var_c
+  integer,  pointer, intent (inout) :: var_a(:)
+
+!$omp target map(tofrom: var_a)
+  do var_b = 1, 10
+    var_a(var_b) = var_a(var_b) + var_b
+  end do
+!$omp end target
+
+  print *, var_a
+
+  do var_c = 1, 10
+    if (var_a(var_c) /= var_c + var_c) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+end subroutine sub_a
+end module
+
+subroutine sub_b
+  implicit none
+  integer :: var_a, var_b
+  integer,  pointer :: var_c(:)
+  integer, target :: var_d(10)
+  var_c => var_d
+
+!$omp target map(tofrom: var_c)
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  print *, var_c
+
+  do var_b = 1, 10
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+end subroutine sub_b
+
+program prog_a
+use mod_a
+implicit none
+integer :: var_a, var_b
+integer,  pointer :: var_c(:)
+integer, target :: var_d(10)
+
+var_c => var_d
+
+!$omp target map(tofrom: var_c)
+  do var_a = 1, 10
+    var_c(var_a) = var_a
+  end do
+!$omp end target
+
+  call sub_b
+
+  print *, var_c
+
+  do var_b = 1, 10
+    if (var_c(var_b) /= var_b) then
+      print *, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+  call sub_a(var_c)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-target-map.f95
+++ b/test/fortran-map-tests/pointer-target-map.f95
@@ -1,0 +1,32 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+implicit none
+integer,  pointer :: var_a(:)
+integer, target :: var_b(10)
+integer :: var_c, var_d
+
+var_a => var_b
+
+!$omp target map(tofrom: var_a)
+  do var_c = 1, 10
+    var_a(var_c) = var_c
+  end do
+!$omp end target
+
+  do var_c = 1, 10
+    print*, var_a(var_c)
+  end do
+
+  do var_d = 1, 10
+    if (var_a(var_d) /= var_d) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pointer-target-scopes-enter-exit-map.f90
+++ b/test/fortran-map-tests/pointer-target-scopes-enter-exit-map.f90
@@ -1,0 +1,99 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    contains
+  subroutine sub_a(var_a)
+    implicit none 
+    integer :: var_b, var_c
+    integer,  pointer, intent (inout) :: var_a(:)
+
+  !$omp target enter data map(alloc: var_a)
+
+  !$omp target 
+    do var_b = 1, 10
+      var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_a)
+
+  !$omp target exit data map(delete: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+      if (var_a(var_c) /= var_c + var_c) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+  end subroutine sub_a
+  end module
+
+  subroutine sub_b
+    implicit none
+    integer :: var_a, var_b
+    integer,  pointer :: var_c(:)
+    integer, target :: var_d(10)
+    var_c => var_d
+
+  !$omp target enter data map(alloc: var_c)
+
+  !$omp target
+    do var_a = 1, 10
+      var_c(var_a) = var_a
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_c)
+
+  !$omp target exit data map(delete: var_c)
+
+    print *, var_c
+
+    do var_b = 1, 10
+      if (var_c(var_b) /= var_b) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+  end subroutine sub_b
+
+program prog_a
+  use mod_a
+  implicit none
+  integer :: var_a, var_b
+  integer,  pointer :: var_c(:)
+  integer, target :: var_d(10)
+  var_c => var_d
+
+  !$omp target enter data map(alloc: var_c)
+
+  !$omp target
+    do var_a = 1, 10
+      var_c(var_a) = var_a
+    end do
+  !$omp end target
+
+  !$omp target exit data map(from: var_c)
+
+  !$omp target exit data map(delete: var_c)
+
+    call sub_b
+
+    print *, var_c
+
+    do var_b = 1, 10
+      if (var_c(var_b) /= var_b) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+    end do
+
+    call sub_a(var_c)
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/pot3d-reproducer.f90
+++ b/test/fortran-map-tests/pot3d-reproducer.f90
@@ -1,0 +1,25 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    real(8), dimension(:), allocatable :: var_a
+end module mod_a
+
+PROGRAM prog_a
+    use mod_a
+    allocate (var_a(225))
+
+    print *, "1"
+    !$omp target enter data map(to:var_a)
+    print *, "2"
+    !$omp target enter data map(to:var_a)
+    print *, "3"
+    !$omp target
+        var_a(1)=var_a(2)
+    !$omp end target
+    print *, "4"
+    !$omp target exit data map(delete: var_a)
+    print *, "5"
+    print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM

--- a/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_and-children_map-v1.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_and-children_map-v1.f90
@@ -1,0 +1,197 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b), allocatable :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_f)
+
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+! Slightly different from non-descriptor parent cases, the mapping should auotmatically
+! map the parent descriptor and the data. This might not be needed in ref_ptr/ptee cases
+! but it's needed for regular mappings, so for the moment it's left as it is until we run
+! into a case where we need to re-evaluate it.
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_and-children_map-v2.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_and-children_map-v2.f90
@@ -1,0 +1,174 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a), allocatable :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b), allocatable :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a), allocatable :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_h)
+  allocate(var_l%var_k)
+  allocate(var_l%var_h%var_g)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b, var_l%var_k%var_b, var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b, var_l%var_k%var_b, var_l%var_h%var_f)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+! Slightly different from non-descriptor parent cases, the mapping should auotmatically
+! map the parent descriptor and the data. This might not be needed in ref_ptr/ptee cases
+! but it's needed for regular mappings, so for the moment it's left as it is until we run
+! into a case where we need to re-evaluate it.
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_map-v1.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_map-v1.f90
@@ -1,0 +1,192 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_f)
+
+
+! print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+! Slightly different from non-descriptor parent cases, the mapping should auotmatically
+! map the parent descriptor and the data. This might not be needed in ref_ptr/ptee cases
+! but it's needed for regular mappings, so for the moment it's left as it is until we run
+! into a case where we need to re-evaluate it.
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_map-v2.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_alloca_struct_map-v2.f90
@@ -1,0 +1,171 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), pointer :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l)
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j, var_l%var_k%var_c, var_l%var_k%var_b, var_l%var_h%var_f, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j, var_l%var_k%var_c, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b, var_l%var_k%var_b, var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j, var_l%var_k%var_c, var_l%var_h%var_g%var_c, var_l%var_h%var_g%var_b, var_l%var_k%var_b, var_l%var_h%var_f)
+
+print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+! Slightly different from non-descriptor parent cases, the mapping should auotmatically
+! map the parent descriptor and the data. This might not be needed in ref_ptr/ptee cases
+! but it's needed for regular mappings, so for the moment it's left as it is until we run
+! into a case where we need to re-evaluate it.
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l parent structure on device"
+endif
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_struct_map-v1.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_struct_map-v1.f90
@@ -1,0 +1,187 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), target :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_f)
+
+
+! print *, "var_l%var_j ref_ptr on device"
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+   print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_struct_map-v2.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_struct_map-v2.f90
@@ -1,0 +1,188 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding
+  implicit none
+
+  type :: dtype_a
+     real(kind=8) :: var_a
+     integer(kind=4), pointer :: var_b
+     integer(kind=8), pointer :: var_c(:)
+  end type dtype_a
+
+  type :: dtype_b
+     real(kind=8) :: var_d
+     real(kind=8) :: var_e
+     integer(kind=4), pointer :: var_f
+     type(dtype_a) :: var_g
+  end type dtype_b
+
+  type :: dtype_c
+     type(dtype_b) :: var_h
+     real(kind=8) :: var_i
+     real(kind=8), pointer :: var_j(:)
+     type(dtype_a) :: var_k
+  end type dtype_c
+
+  type(dtype_c), target :: var_l
+  integer :: var_m, var_n, var_o
+  logical var_p
+
+  var_m = 10
+
+  allocate(var_l%var_j(var_m))
+  allocate(var_l%var_h%var_f)
+  allocate(var_l%var_k%var_c(var_m))
+  allocate(var_l%var_k%var_b)
+  allocate(var_l%var_h%var_g%var_c(var_m))
+  allocate(var_l%var_h%var_g%var_b)
+
+! Present checking and sending separately as if we send it in a single map/present check it in a single map
+! we end up allocating bits and pieces implicitly due to the implicit binding parent map, but this seems
+! analogous to Clang behaviour. It may need a bit of a rethink though, or a verification if it's the correct
+! OpenMP behaviour.
+! NOTE: Doing it like this will result in an object that isn't useable on device, need to combine the ref_ptee
+! and ref_ptr maps together, so you have 1 ref_ptee map and another for the ref_ptr maps and everything works
+! as expected
+
+!$omp target enter data map(ref_ptee, to: var_l%var_j)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptee, to: var_l%var_h%var_g%var_b)
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+!$omp target enter data map(ref_ptr, to: var_l%var_j)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_j)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_c)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_c)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_g%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_g%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_k%var_b)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_k%var_b)
+
+!$omp target enter data map(ref_ptr, to: var_l%var_h%var_f)
+!$omp target enter data map(ref_ptr, present, storage: var_l%var_h%var_f)
+
+print *, "var_l%var_k%var_c ref_ptr on device"
+print *, "var_l%var_k%var_b ref_ptr on device"
+print *, "var_l%var_h%var_f ref_ptr on device"
+print *, "var_l%var_h%var_g%var_c ref_ptr on device"
+print *, "var_l%var_h%var_g%var_b ref_ptr on device"
+
+if(omp_target_is_present(C_LOC(var_l%var_j), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_j ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_j ref_ptee  on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_k%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_k%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_k%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_f), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_f ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_f ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_c), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_c ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l%var_h%var_g%var_b), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee NOT on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+else
+   print *, "After enter: var_l%var_h%var_g%var_b ref_ptee on device"
+endif
+
+if(omp_target_is_present(C_LOC(var_l), omp_get_default_device()) == 0) then
+   print *, "After enter: var_l parent structure NOT on device"
+else
+   print *, "After enter: var_l parent structure on device"
+   print*, "======= FORTRAN Test Failed! ======="
+   stop 1
+endif
+
+print *, "======= FORTRAN Test Passed! ======="
+
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_test_1.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_test_1.f90
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:)
+    integer, target :: var_b(10)
+    integer :: var_c
+
+    var_a => var_b
+
+    ! Should have auto attach applied if my reading is
+    ! correct and automatically attach to ref_ptee. So
+    ! internally we implicitly apply the attach map
+    ! type.
+    !$omp target enter data map(ref_ptee, to: var_a)
+    !$omp target enter data map(ref_ptr, to: var_a)
+
+    ! should in theory memory access fault if we haven't attached
+    ! correctly above. But if all went well should go fine.
+    !$omp target map(to: var_c)
+        do var_c = 1, 10
+            var_a(var_c) = var_c
+        end do
+    !$omp end target
+
+    ! Don't care about the descriptor, but we do want to
+    ! deallocate it and only it and then map the data
+    ! back. Doing it in a weird-ish order to test we can
+    ! delete the descriptor separately and still pull the
+    ! data back.
+    !$omp target exit data map(ref_ptee, from: var_a)
+    !$omp target exit data map(ref_ptr, delete: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+        if (var_a(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        endif
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/ref_ptr_ptee_test_2.f90
+++ b/test/fortran-map-tests/ref_ptr_ptee_test_2.f90
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    integer,  pointer :: var_a(:)
+    integer, target :: var_b(10)
+    integer :: var_c
+
+    var_a => var_b
+
+    ! Should have auto attach applied if my reading is
+    ! correct and automatically attach to ref_ptee. So
+    ! internally we implicitly apply the attach map
+    ! type.
+    !$omp target enter data map(ref_ptr, to: var_a)
+    !$omp target enter data map(ref_ptee, to: var_a)
+
+    ! should in theory memory access fault if we haven't attached
+    ! correctly above. But if all went well should go fine.
+    !$omp target map(to: var_c)
+        do var_c = 1, 10
+            var_a(var_c) = var_c
+        end do
+    !$omp end target
+
+    ! Don't care about the descriptor, but we do want to
+    ! deallocate it and only it and then map the data
+    ! back. Doing it in a weird-ish order to test we can
+    ! delete the descriptor separately and still pull the
+    ! data back.
+    !$omp target exit data map(ref_ptr, delete: var_a)
+    !$omp target exit data map(ref_ptee, from: var_a)
+
+    print *, var_a
+
+    do var_c = 1, 10
+        if (var_a(var_c) /= var_c) then
+            print*, "======= FORTRAN Test Failed! ======="
+            stop 1
+        endif
+    end do
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/reproducer-3-47779-v2.f90
+++ b/test/fortran-map-tests/reproducer-3-47779-v2.f90
@@ -1,0 +1,125 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+implicit none
+
+TYPE dtype_a
+REAL,    DIMENSION(:,:), ALLOCATABLE :: var_a, var_b
+INTEGER         :: var_c
+REAL,    DIMENSION(:,:), ALLOCATABLE :: var_d
+INTEGER         :: var_e
+REAL,    DIMENSION(:,:), ALLOCATABLE :: var_f, var_g
+END TYPE dtype_a
+
+TYPE dtype_b
+TYPE(dtype_a):: var_h
+integer :: var_i
+INTEGER :: var_j(4)
+END TYPE dtype_b
+
+TYPE dtype_c
+INTEGER         :: var_k
+TYPE(dtype_b), DIMENSION(:), ALLOCATABLE :: var_l
+END TYPE dtype_c
+
+end module mod_a
+
+program prog_a
+    use mod_a
+  implicit none
+  integer :: var_m, var_n, var_o
+  TYPE(dtype_c)       :: var_p
+
+  var_o = 0
+  allocate(var_p%var_l(2))
+  do var_m = 1, 2
+      allocate(var_p%var_l(var_m)%var_h%var_a(2, 2))
+      allocate(var_p%var_l(var_m)%var_h%var_b(2, 2))
+      allocate(var_p%var_l(var_m)%var_h%var_d(2, 2))
+      allocate(var_p%var_l(var_m)%var_h%var_f(2, 2))
+      allocate(var_p%var_l(var_m)%var_h%var_g(2, 2))
+      do var_n = 1, 4
+          var_p%var_l(var_m)%var_j(var_n) = var_n * 10
+      end do
+  end do
+
+var_p%var_l(1)%var_h%var_e = 30
+
+print *, "Before: "
+print *, var_p%var_l(1)%var_j
+print *, var_p%var_l(2)%var_j
+
+print *, var_p%var_l(1)%var_h%var_a(1, 1)
+print *, var_p%var_l(1)%var_h%var_d(2, 2)
+print *, var_p%var_l(1)%var_h%var_g(1, 2)
+print *, var_p%var_l(1)%var_h%var_e
+print *, var_o
+
+!$omp target enter data map(alloc:     &
+!$omp   var_p%var_l(1)%var_h%var_a, &
+!$omp   var_p%var_l(1)%var_h%var_d, &
+!$omp   var_p%var_l(1)%var_h%var_g, &
+!$omp   var_p%var_l(1)%var_h%var_e)
+
+!$omp target map(tofrom: var_o)
+  var_p%var_l(1)%var_h%var_a(1, 1) = 20333
+  var_p%var_l(1)%var_h%var_d(2, 2) = 20222
+  var_p%var_l(1)%var_h%var_g(1, 2) = 20444
+  var_p%var_l(1)%var_h%var_e = 512
+  var_o = 10
+!$omp end target
+
+!$omp target exit data map(from:       &
+!$omp   var_p%var_l(1)%var_h%var_a, &
+!$omp   var_p%var_l(1)%var_h%var_d, &
+!$omp   var_p%var_l(1)%var_h%var_g, &
+!$omp   var_p%var_l(1)%var_h%var_e)
+
+  print *, "After: "
+  print *, var_p%var_l(1)%var_j
+  print *, var_p%var_l(2)%var_j
+
+  print *, var_p%var_l(1)%var_h%var_a(1, 1)
+  print *, var_p%var_l(1)%var_h%var_d(2, 2)
+  print *, var_p%var_l(1)%var_h%var_g(1, 2)
+  print *, var_p%var_l(1)%var_h%var_e
+  print *, var_o
+
+  do var_m = 1, 2
+    do var_n = 1, 4
+      if (var_p%var_l(var_m)%var_j(var_n) /= var_n * 10) then
+          print*, "======= FORTRAN Test Failed! ======="
+          stop 1
+      end if
+    end do
+  end do
+
+  if (var_p%var_l(1)%var_h%var_a(1,1) /= 20333) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_p%var_l(1)%var_h%var_d(2, 2) /= 20222) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_p%var_l(1)%var_h%var_g(1, 2) /= 20444) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_p%var_l(1)%var_h%var_e /= 512) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_o /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/reproducer-476419.f90
+++ b/test/fortran-map-tests/reproducer-476419.f90
@@ -1,0 +1,22 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    DOUBLE PRECISION, ALLOCATABLE, DIMENSION(:) :: var_a
+    !$omp declare target(var_a)
+  end module mod_a
+
+  PROGRAM prog_a
+  use mod_a
+
+  ALLOCATE(var_a(10))
+
+  !$omp target data map(alloc:var_a)
+    DO var_b = 1, 2
+      print *, "executing update"
+      !$omp target update from(var_a)
+    end do
+  !$omp end target data
+  print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM

--- a/test/fortran-map-tests/reproducer-497977.f90
+++ b/test/fortran-map-tests/reproducer-497977.f90
@@ -1,0 +1,66 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    use iso_fortran_env, only: real64
+    implicit none
+contains
+    subroutine sub_a(var_a, var_b, var_c, var_d, var_e)
+        import
+        implicit none
+        real(kind=real64), dimension(:,:) :: var_a, var_b
+        real(kind=real64) :: var_f(5)
+        integer :: var_c, var_d, var_e
+        integer :: var_g,var_h
+
+        real(kind=real64), dimension(size(var_a, 1), size(var_a, 2)) :: var_i
+
+        var_f(1) = 6
+        var_f(2) = 8
+        var_f(3) = 10
+        var_f(4) = 12
+        var_f(5) = 14
+
+!$omp target data map(alloc:var_i)
+    !$omp target teams
+    !$omp distribute parallel do
+        do var_h = var_c, var_d
+            var_i(var_h,var_e) = var_a(var_h,var_e)+var_b(var_h,var_e)
+        end do
+    !$omp end target teams
+
+    !$omp target update from(var_i)
+!$omp end target data
+
+       print *, var_i
+
+       do var_h = var_c, var_d
+           if (var_i(var_h,var_e) /= var_f(var_h)) then
+               print*, "======= FORTRAN Test Failed! ======="
+               stop 1
+           end if
+       end do
+
+       print *, "======= FORTRAN Test Passed! ======="
+    end subroutine
+end module mod_a
+
+
+program prog_a
+    use mod_a
+    implicit none
+    integer :: var_a, var_b
+    real(kind=real64), allocatable :: var_c(:,:), var_d(:,:)
+    allocate(var_c(5,5))
+    allocate(var_d(5,5))
+
+    do var_a = 1, 5
+        do var_b = 1, 5
+            var_d(var_a,var_b) = var_a + var_b
+            var_c(var_a,var_b) = var_a + var_b
+        end do
+    end do
+
+    call sub_a(var_c, var_d, 1, 5, 2)
+end program prog_a

--- a/test/fortran-map-tests/reproducer-SWDEV-471201-v2.f90
+++ b/test/fortran-map-tests/reproducer-SWDEV-471201-v2.f90
@@ -1,0 +1,20 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    save
+    real(8), allocatable          ::   var_a(:,:)
+    !$omp declare target(var_a)
+end module mod_a
+
+program prog_a
+  use mod_a
+  allocate(var_a(3,0:27647))
+
+!$omp target enter data map(alloc: var_a)
+!$omp target update from(var_a)
+!$omp target update from(var_a)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/reproducer-SWDEV-471201-v3.f90
+++ b/test/fortran-map-tests/reproducer-SWDEV-471201-v3.f90
@@ -1,0 +1,38 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    real(4), allocatable          ::   var_a(:)
+    !$omp declare target(var_a)
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+
+    allocate(var_a(0:10))
+
+    var_a(0) = 30.0
+    var_a(1) = 40.0
+    var_a(10) = 25.0
+
+    !$omp target map(tofrom: var_a)
+         var_a(0) = var_a(1)
+    !$omp end target
+
+    print *, var_a(0)
+    print *, var_a(1)
+
+    if (var_a(0) /= 40.0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_a(1) /= 40.0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print*, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/reproducer-SWDEV-471201.f90
+++ b/test/fortran-map-tests/reproducer-SWDEV-471201.f90
@@ -1,0 +1,59 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    real(8), allocatable          ::   var_a(:)
+    real(8)          ::   var_b(4) = (/10,20,30,40/)
+    real(8)          ::   var_c = 20
+
+    !$omp declare target(var_a)
+    !$omp declare target(var_b)
+    !$omp declare target(var_c)
+end module mod_a
+
+program prog_a
+    use mod_a
+    real(8) :: var_d
+
+    var_c = 10.0
+    allocate(var_a(10))
+
+    var_a(5) = 40
+
+!$omp target map(to: var_c) map(tofrom: var_d)
+    var_d = var_c
+!$omp end target
+
+    print *, var_d
+
+ if (var_d /= 20) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+ end if
+
+!$omp target map(to: var_b) map(tofrom: var_d)
+   var_d = var_b(3)
+!$omp end target
+
+   print *, var_d
+
+ if (var_d /= 30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+ end if
+
+!$omp target map(to: var_a) map(tofrom: var_d)
+    var_d = var_a(5)
+!$omp end target
+
+  print *, var_d
+
+if (var_d /= 40) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+end if
+
+print*, "======= FORTRAN Test Passed! ======="
+
+end program

--- a/test/fortran-map-tests/reproducer-SWDEV-483255.f90
+++ b/test/fortran-map-tests/reproducer-SWDEV-483255.f90
@@ -1,0 +1,38 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a, var_b)
+    !$omp declare target
+    real :: var_b
+    integer :: var_a
+    var_b = var_b - var_a
+end subroutine
+
+function func_a(var_a)
+    !$omp declare target
+    real, intent(in) :: var_a
+    func_a = var_a
+end function func_a
+
+program prog_a
+real var_a
+!$omp declare target(sub_a)
+!$omp declare target(func_a)
+var_a = func_a(var_a)
+call sub_a(2,var_a)
+call sub_b(var_a)
+return
+end
+
+subroutine sub_b(var_a)
+real var_a
+integer var_b
+!$omp declare target(sub_a)
+!$omp declare target(func_a)
+!$omp target
+    var_a = func_a(var_a)
+    call sub_a(var_b,var_a)
+!$omp end target
+return
+end

--- a/test/fortran-map-tests/reproducer-SWDEV-502486.f90
+++ b/test/fortran-map-tests/reproducer-SWDEV-502486.f90
@@ -1,0 +1,25 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+contains
+    subroutine sub_a(var_a)
+        implicit none
+        real, dimension(:), optional :: var_a
+        integer :: var_b
+       !$omp target data if(present(var_a)) map(alloc:var_a)
+            do var_b = 1, 10
+                var_a(var_b) = var_b
+            end do
+       !$omp end target data
+    end subroutine sub_a
+end module mod_a
+
+program prog_a
+    use mod_a
+    real :: var_a(10)
+    call sub_a(var_a)
+    print *, var_a
+end program prog_a

--- a/test/fortran-map-tests/reproducer-for-471028.f90
+++ b/test/fortran-map-tests/reproducer-for-471028.f90
@@ -1,0 +1,58 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+subroutine sub_a(var_a, var_b, var_c)
+    implicit none
+    real, intent(out) :: var_c
+    real(4), dimension(var_a,var_b) :: var_d
+    integer :: var_a,var_b
+!$omp target enter data map(alloc:var_d)
+
+!$omp target
+      var_d(2, 2) = 10
+!$omp end target
+
+!$omp target update from(var_d)
+
+   var_c = var_d(2, 2)
+
+!$omp target exit data map(delete:var_d)
+end subroutine sub_a
+
+subroutine sub_b(var_a, var_b)
+    implicit none
+    real, intent(inout) :: var_b
+    integer :: var_a
+    real(4), dimension(var_a) :: var_c
+
+!$omp target enter data map(to:var_c)
+
+!$omp target
+    var_c(8) = 20
+!$omp end target
+
+!$omp target update from(var_c)
+
+var_b = var_b + var_c(8)
+
+end subroutine sub_b
+
+program prog_a
+    implicit none
+    integer :: var_a = 10
+    integer :: var_b = 10, var_c = 10
+    real :: var_d = 0
+
+    call sub_a(var_b, var_c,  var_d)
+    call sub_b(var_a, var_d)
+
+    print *, var_d
+
+    if (var_d /= 30) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+      end if
+
+     print *, "======= FORTRAN Test Passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/scalar-allocatable-block-map.f90
+++ b/test/fortran-map-tests/scalar-allocatable-block-map.f90
@@ -1,0 +1,28 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+PROGRAM prog_a
+    integer, allocatable :: var_a
+    allocate(var_a)
+
+    var_a = 0
+!$omp target map(tofrom:var_a)
+   block_a : BLOCK
+      do var_b = 1, 10
+        BLOCK
+           var_a = var_a + var_b
+        END BLOCK
+     end do
+    END BLOCK block_a
+!$omp end target
+
+    print *, var_a
+
+    if (var_a /= 55) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM prog_a

--- a/test/fortran-map-tests/seismic-reproducer.f90
+++ b/test/fortran-map-tests/seismic-reproducer.f90
@@ -1,0 +1,20 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    double precision, allocatable, dimension(:) :: var_a
+end module mod_a
+
+PROGRAM prog_a
+    use mod_a
+    allocate (var_a(5))
+
+    !$omp target data map(alloc: var_a)
+
+    !$omp target update from(var_a)
+
+    !$omp end target data
+
+      print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM

--- a/test/fortran-map-tests/simple-declare-target-to-target.f90
+++ b/test/fortran-map-tests/simple-declare-target-to-target.f90
@@ -1,0 +1,39 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+    integer :: var_a(10)
+    !$omp declare target(var_a)
+end module mod_a
+
+PROGRAM prog_a
+    use mod_a
+    implicit none
+    integer :: var_b
+
+  !$omp target
+    do var_b = 1, 10
+        var_a(var_b) = var_b
+    end do
+  !$omp end target
+
+  !$omp target
+    do var_b = 1, 10
+        var_a(var_b) = var_a(var_b) + var_b
+    end do
+  !$omp end target
+
+  !$omp target update from(var_a)
+
+   print *, var_a
+
+   do var_b = 1, 10
+    if (var_a(var_b) /= var_b + var_b) then
+        print *, "======= FORTRAN Test Failed! ======="
+    end if
+   end do
+
+   print *, "======= FORTRAN Test Passed! ======="
+END PROGRAM

--- a/test/fortran-map-tests/simple-full-struct-2.f95
+++ b/test/fortran-map-tests/simple-full-struct-2.f95
@@ -1,0 +1,67 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  type :: dtype_a
+    integer(4) :: var_a = 0
+    real(4) :: var_b = 0.0
+    complex(4) :: var_c = (0,0)
+    integer(4) :: var_d(5)
+  end type dtype_a
+
+  type(dtype_a) :: var_e
+  type(dtype_a) :: var_f
+  integer :: var_g
+
+  var_f%var_a = 10
+  var_f%var_b = 2.0
+  var_f%var_c = (2, 10)
+
+  do var_g = 1, 5
+    var_f%var_d(var_g) = var_g
+  end do
+
+!$omp target map(from:var_e) map(to:var_f)
+  var_e%var_a = var_f%var_a
+  var_e%var_b = var_f%var_b
+  var_e%var_c = var_f%var_c
+
+  do var_g = 1, 5
+    var_e%var_d(var_g) = var_f%var_d(var_g)
+  end do
+!$omp end target
+
+    print*, var_f%var_a
+    print*, var_f%var_b
+    write (*,*) var_f%var_c
+
+    print*, var_e%var_a
+    print*, var_e%var_b
+    write (*,*)  var_e%var_c
+
+  if (var_e%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_b /= 2.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_c /= (2, 10)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_g = 1, 5
+    if (var_e%var_d(var_g) /= var_g) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/simple-full-struct-implicit-2.f95
+++ b/test/fortran-map-tests/simple-full-struct-implicit-2.f95
@@ -1,0 +1,68 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  type :: dtype_a
+    integer(4) :: var_a = 0
+    real(4) :: var_b = 0.0
+    complex(4) :: var_c = (0,0)
+    integer(4) :: var_d(5)
+  end type dtype_a
+
+  type(dtype_a) :: var_e
+  type(dtype_a) :: var_f
+
+  integer :: var_g
+
+  var_f%var_a = 10
+  var_f%var_b = 2.0
+  var_f%var_c = (2, 10)
+
+  do var_g = 1, 5
+    var_f%var_d(var_g) = var_g
+  end do
+
+!$omp target map(from:var_e)
+  var_e%var_a = var_f%var_a
+  var_e%var_b = var_f%var_b
+  var_e%var_c = var_f%var_c
+
+  do var_g = 1, 5
+    var_e%var_d(var_g) = var_f%var_d(var_g)
+  end do
+!$omp end target
+
+    print*, var_f%var_a
+    print*, var_f%var_b
+    write (*,*) var_f%var_c
+
+    print*, var_e%var_a
+    print*, var_e%var_b
+    write (*,*)  var_e%var_c
+
+  if (var_e%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_b /= 2.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_c /= (2, 10)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_g = 1, 5
+    if (var_e%var_d(var_g) /= var_g) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+  end do
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/simple-full-struct-implicit.f95
+++ b/test/fortran-map-tests/simple-full-struct-implicit.f95
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  type :: dtype_a
+  integer(4) :: var_a = 0
+  real(4) :: var_b = 0.0
+  complex(4) :: var_c = (0,0)
+  end type dtype_a
+
+  type(dtype_a) :: var_d
+  type(dtype_a) :: var_e
+  var_d%var_a = 10
+  var_d%var_b = 2.0
+  var_d%var_c = (2, 10)
+
+!$omp target map(from:var_e)
+    var_e = var_d
+!$omp end target
+
+    print*, var_d%var_a
+    print*, var_d%var_b
+    write (*,*) var_d%var_c
+
+    print*, var_e%var_a
+    print*, var_e%var_b
+    write (*,*)  var_e%var_c
+
+  if (var_e%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_b /= 2.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_c /= (2, 10)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/simple-full-struct.f95
+++ b/test/fortran-map-tests/simple-full-struct.f95
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  type :: dtype_a
+  integer(4) :: var_a = 0
+  real(4) :: var_b = 0.0
+  complex(4) :: var_c = (0,0)
+  end type dtype_a
+
+  type(dtype_a) :: var_d
+  type(dtype_a) :: var_e
+  var_d%var_a = 10
+  var_d%var_b = 2.0
+  var_d%var_c = (2, 10)
+
+!$omp target map(from:var_e) map(to:var_d)
+    var_e = var_d
+!$omp end target
+
+    print*, var_d%var_a
+    print*, var_d%var_b
+    write (*,*) var_d%var_c
+
+    print*, var_e%var_a
+    print*, var_e%var_b
+    write (*,*)  var_e%var_c
+
+  if (var_e%var_a /= 10) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_b /= 2.0) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_e%var_c /= (2, 10)) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+ print*, "======= FORTRAN Test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/simplified-SWDEV-498999-reproducer-v2.f90
+++ b/test/fortran-map-tests/simplified-SWDEV-498999-reproducer-v2.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    type dtype_a
+       integer :: var_a(1000)
+    end type dtype_a
+    integer :: var_b
+    type(dtype_a), pointer :: var_c
+    type(dtype_a), pointer :: var_d=>null()
+
+    integer, dimension(:), pointer :: var_e
+
+!$omp THREADPRIVATE(var_d)
+
+nullify(var_c)
+allocate(var_c)
+
+var_d=>var_c
+
+var_d%var_a(:)=1
+
+var_e=>var_d%var_a
+
+!$omp target teams distribute parallel do
+  do var_b = 1, 1000
+   var_e(var_b) = var_b
+ end do
+!$omp end target teams distribute parallel do
+
+print *, var_e
+
+do var_b = 1, 1000
+   if (var_e(var_b) /= var_b) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+ end do
+
+ print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/simplified-SWDEV-498999-reproducer.f90
+++ b/test/fortran-map-tests/simplified-SWDEV-498999-reproducer.f90
@@ -1,0 +1,46 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+
+    type dtype_a
+       integer :: var_a(10)
+    end type dtype_a
+    integer :: var_b
+    type(dtype_a), pointer :: var_c=>null()
+    type(dtype_a), pointer :: var_d
+    type(dtype_a), pointer :: var_e=>null()
+
+    integer, dimension(:), pointer :: var_f
+
+!$omp threadprivate(var_c, var_e)
+
+nullify(var_d)
+allocate(var_d)
+
+var_e=>var_d
+
+var_e%var_a(:)=1
+
+var_f=>var_e%var_a
+
+!$omp target
+   do var_b = 1, 10
+     var_f(var_b) = var_b
+   end do
+!$omp end target
+
+print *, var_f
+
+do var_b = 1, 10
+   if (var_f(var_b) /= var_b) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+ end do
+
+ print*, "======= FORTRAN Test Passed! ======="
+
+end program prog_a

--- a/test/fortran-map-tests/simplified-reproducer-497977.f90
+++ b/test/fortran-map-tests/simplified-reproducer-497977.f90
@@ -1,0 +1,45 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    use iso_fortran_env, only: real64
+    implicit none
+contains
+    subroutine sub_a(var_a)
+        implicit none
+        integer :: var_b
+        real(kind=real64), dimension(:) :: var_a
+        real(kind=real64), dimension(size(var_a, 1)) :: var_c
+
+!$omp target map(tofrom: var_c)
+        do var_b = 1, 10
+            var_c(var_b) = var_b
+        end do
+!$omp end target
+
+        print *, var_c
+
+        do var_b = 1, 10
+            if (var_c(var_b) /= var_b) then
+                print*, "======= FORTRAN Test Failed! ======="
+                stop 1
+            end if
+        end do
+
+        print *, "======= FORTRAN Test Passed! ======="
+    end subroutine
+end module mod_a
+
+program prog_a
+    use mod_a
+    real(kind=real64), allocatable :: var_a(:)
+    integer :: var_b
+    allocate(var_a(10))
+
+    do var_b = 1, 10
+        var_a(var_b) = var_b
+    end do
+
+    call sub_a(var_a)
+end program prog_a

--- a/test/fortran-map-tests/single-value-alloca-loop.f90
+++ b/test/fortran-map-tests/single-value-alloca-loop.f90
@@ -1,0 +1,26 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer(4), allocatable :: var_a
+    allocate(var_a)
+    var_a = 0
+
+!$omp target map(tofrom:var_a)
+    do var_b = 1, 10
+      var_a = var_a + 50
+    end do
+!$omp end target
+
+  print *, var_a
+
+  if (var_a /= 500) then
+     print *, "======= FORTRAN Test Failed! ======="
+     stop 1
+  end if
+
+  deallocate(var_a)
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/single-value-alloca.f90
+++ b/test/fortran-map-tests/single-value-alloca.f90
@@ -1,0 +1,21 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer, allocatable :: var_a
+    allocate(var_a)
+
+!$omp target map(tofrom:var_a)
+     var_a = 50
+!$omp end target
+
+  print *, var_a
+
+  if (var_a /= 50) then
+     print *, "======= FORTRAN Test Failed! ======="
+     stop 1
+   end if
+
+  print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/small-nested-dtype-map.f90
+++ b/test/fortran-map-tests/small-nested-dtype-map.f90
@@ -1,0 +1,57 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+
+program prog_a
+    implicit none
+    type :: dtype_a
+      real(8) :: var_a
+      real(4) :: var_b(10)
+      real(4) :: var_c(10)
+    end type dtype_a
+
+    type :: dtype_b
+      real(4) :: var_d
+      integer(4) :: var_e(10)
+      real(4) :: var_f
+      type(dtype_a) :: var_g
+      integer, allocatable :: var_h(:)
+      integer(4) :: var_i
+    end type dtype_b
+
+    type(dtype_b) :: var_j
+    integer :: var_k
+
+!$omp target map(tofrom: var_j%var_g%var_a, var_j%var_i, var_j%var_g%var_b)
+    do var_k = 1, 10 
+      var_j%var_g%var_b(var_k) = var_k * 2
+    end do
+
+    var_j%var_g%var_a = 30.30
+    var_j%var_i = 74
+!$omp end target
+
+  print *, var_j%var_g%var_a
+  print *, var_j%var_i
+  print *, var_j%var_g%var_b
+
+  if (var_j%var_g%var_a /= 30.30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_j%var_i /= 74) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  do var_k = 1, 10
+    if (var_j%var_g%var_b(var_k) /= var_k * 2) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+  end do
+
+  print*, "======= FORTRAN test passed! ======="
+end program prog_a

--- a/test/fortran-map-tests/swdev-561059.f90
+++ b/test/fortran-map-tests/swdev-561059.f90
@@ -1,0 +1,117 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+  implicit none
+contains
+  subroutine sub_a(var_a, var_b, var_c, var_d)
+    implicit none
+    integer, intent(in) :: var_a
+    real(8), intent(in) :: var_b(var_a)
+    real(8), intent(in) :: var_c(var_a)
+    real(8), intent(out) :: var_d(var_a)
+    integer :: var_e
+    !$omp target data map(present, alloc:var_b, var_c, var_d)
+    !$omp end target data
+
+    !$omp target teams distribute parallel do
+    do var_e=1,var_a
+       var_d(var_e) = var_c(var_e) + var_b(var_e)
+    end do
+
+  end subroutine sub_a
+end module mod_a
+
+program prog_a
+  use mod_a, only : sub_a
+  implicit none
+  integer :: var_a, var_b, var_c, var_d, var_e, var_f, var_g, var_h, var_i, var_j, var_k
+  real(kind=8), allocatable :: var_l(:,:,:)
+  real(kind=8), allocatable :: var_m(:,:,:)
+  CHARACTER(LEN=256) :: var_n
+  INTEGER :: var_o
+  INTEGER :: var_p
+
+  CALL GET_COMMAND_ARGUMENT(1, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_a
+  CALL GET_COMMAND_ARGUMENT(2, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_b
+  CALL GET_COMMAND_ARGUMENT(3, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_c
+
+  CALL GET_COMMAND_ARGUMENT(4, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_g
+  CALL GET_COMMAND_ARGUMENT(5, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_h
+  CALL GET_COMMAND_ARGUMENT(6, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_j
+  CALL GET_COMMAND_ARGUMENT(7, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_i
+  CALL GET_COMMAND_ARGUMENT(8, var_n, STATUS=var_p)
+  READ(var_n, *, IOSTAT=var_p) var_k
+
+  allocate(var_l(1:var_a,1:var_b,1:var_c))
+  allocate(var_m(1:var_a,1:var_b,1:var_c))
+
+  do var_d=1, var_a
+     do var_e=1, var_b
+        do var_f=1, var_c
+           var_l(var_d,var_e,var_f) = var_e
+        end do
+     end do
+  end do
+
+  do var_f=1, var_c
+     do var_d=1,var_a
+        var_m(var_d,var_i,var_f) = var_l(var_d,var_g,var_f) + var_l(var_d,var_k+1,var_f)
+        var_m(var_d,var_k,var_f) = var_l(var_d,var_h,var_f) + var_l(var_d,var_j,var_f)
+     end do
+
+     !$OMP TARGET ENTER DATA MAP(ALLOC:var_l(1:var_a,:,var_f))
+
+     !$OMP TARGET UPDATE TO(var_l(1:var_a,var_g:var_h,var_f), &
+     !$OMP&                 var_l(1:var_a,var_k+1:var_j,var_f))
+
+     call sub_a(var_a,var_l(:,var_g,var_f),var_l(:,var_k+1,var_f),var_l(:,var_i,var_f))
+     call sub_a(var_a,var_l(:,var_h,var_f),var_l(:,var_j,var_f),var_l(:,var_k,var_f))
+
+     !$OMP TARGET UPDATE FROM(var_l(1:var_a,var_i:var_k,var_f))
+     !$OMP TARGET EXIT DATA MAP(DELETE:var_l(1:var_a,:,var_f))
+
+    if (var_m(1,var_k,var_f) /= var_l(1,var_k,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    if (var_m(2,var_i,var_f) /= var_l(2,var_i,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    if (var_m(var_a,var_i,var_f) /= var_l(var_a,var_i,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    if (var_m(1,var_k,var_f) /= var_l(1,var_k,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    if (var_m(2,var_k,var_f) /= var_l(2,var_k,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+
+    if (var_m(var_a,var_k,var_f) /= var_l(var_a,var_k,var_f)) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    endif
+  end do
+
+
+  deallocate(var_l)
+
+  print *, "======= FORTRAN Test Success! ======="
+end program prog_a

--- a/test/fortran-map-tests/target-alloca-from-map.f90
+++ b/test/fortran-map-tests/target-alloca-from-map.f90
@@ -1,0 +1,39 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    implicit none
+contains
+    subroutine sub_a(var_a, var_b)
+       implicit none 
+       integer, allocatable :: var_a(:)
+       integer :: var_b, var_c
+
+      !$omp target map(from:var_a)
+          do var_c = 1,var_b
+                var_a(var_c) = var_c
+         end do
+       !$omp end target
+
+         write (*,*) var_a
+
+         do var_c = 1, var_b
+            if (var_a(var_c) /= var_c) then
+              print *, "======= FORTRAN Test Failed! ======="
+              stop 1
+            end if
+          end do
+
+          print *, "======= FORTRAN Test Passed! =======" 
+    end subroutine
+end module
+
+program prog_a
+    use mod_a
+    implicit none
+    integer, parameter :: var_a = 256
+    integer, allocatable :: var_b(:)
+    allocate(var_b(var_a))
+    call sub_a(var_b, var_a)
+end program

--- a/test/fortran-map-tests/target_enter_exit_milestone_3.f90
+++ b/test/fortran-map-tests/target_enter_exit_milestone_3.f90
@@ -1,0 +1,88 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+module mod_a
+    use, intrinsic :: ISO_Fortran_env
+    implicit none
+
+real(kind=REAL64), allocatable :: var_a(:), var_b(:), var_c(:)
+integer(kind=4) :: var_d
+
+contains
+
+subroutine sub_a(var_e)
+    implicit none
+    integer(kind=4) :: var_e
+    var_d = var_e
+    allocate( var_a(1:var_d), var_b(1:var_d), var_c(1:var_d) )
+    !$omp target enter data map(alloc: var_a,var_b,var_c)
+end subroutine sub_a
+
+subroutine sub_b()
+    implicit none
+    !$omp target exit data map(delete: var_a,var_b,var_c)
+    deallocate( var_a, var_b, var_c)
+end subroutine sub_b
+
+subroutine sub_c()
+    implicit none 
+!$omp target exit data map(from: var_a,var_b,var_c)
+end subroutine sub_c
+
+subroutine sub_d(var_e)
+    implicit none
+    integer(kind=4) :: var_e
+    integer :: var_f
+    var_d = var_e
+!$omp target
+    do var_f = 1, var_d
+        var_a(var_f) = 0
+        var_b(var_f) = 2
+        var_c(var_f) = 3
+    end do
+!$omp end target
+end subroutine sub_d
+
+subroutine sub_e(var_e)
+    implicit none
+    integer(kind=4) :: var_e
+    integer :: var_f
+    var_d = var_e
+!$omp target parallel do
+do var_f = 1, var_d
+    var_a(var_f) = var_b(var_f) + var_c(var_f)
+end do
+
+!$omp target teams distribute parallel do
+    do var_f = 1, var_d
+        var_a(var_f) = var_a(var_f) + var_b(var_f) + var_c(var_f)
+    end do
+end subroutine sub_e
+
+subroutine sub_f(var_e)
+    implicit none
+    integer(kind=4) :: var_e
+    integer :: var_f
+    var_d = var_e
+
+    do var_f = 1, var_d
+        print *, var_a(var_f)
+        print *, var_b(var_f)
+        print *, var_c(var_f)
+    end do
+end subroutine sub_f
+
+end module mod_a
+
+program prog_a
+    use mod_a
+    implicit none
+
+    call sub_a(10)
+    call sub_d(10)
+    call sub_e(10)
+    call sub_c()
+    call sub_f(10)
+    call sub_b()
+end program

--- a/test/fortran-map-tests/target_enter_exit_milestone_3a.f90
+++ b/test/fortran-map-tests/target_enter_exit_milestone_3a.f90
@@ -1,0 +1,32 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+integer :: var_a(10)
+integer :: var_b
+
+!$omp target enter data map(alloc: var_a(1:10))
+
+!$omp target
+    do var_b = 1, 10
+        var_a(var_b) = var_b
+    end do
+!$omp end target
+
+!$omp target exit data map(from: var_a(1:10))
+
+!$omp target exit data map(delete: var_a(1:10))
+
+print *, var_a
+
+do var_b = 1, 10
+    if (var_a(var_b) /= var_b) then
+        print *, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+end do
+
+print*, "======= FORTRAN Test passed! ======="
+
+end program

--- a/test/fortran-map-tests/target_enter_exit_milestone_3b.f90
+++ b/test/fortran-map-tests/target_enter_exit_milestone_3b.f90
@@ -1,0 +1,34 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    integer, allocatable :: var_a(:)
+    integer :: var_b
+    allocate(var_a(10))
+
+   !$omp target enter data map(alloc: var_a)
+
+    !$omp target
+        do var_b = 1, 10
+            var_a(var_b) = var_b
+        end do
+    !$omp end target
+
+    !$omp target exit data map(from: var_a)
+
+    !$omp target exit data map(delete: var_a)
+
+     print *, var_a
+
+     do var_b = 1, 10
+        if (var_a(var_b) /= var_b) then
+            print *, "======= FORTRAN Test Failed! ======="
+            stop 1
+        end if
+    end do
+
+    deallocate(var_a)
+
+    print*, "======= FORTRAN Test passed! ======="
+end program

--- a/test/fortran-map-tests/target_map_common_block_1.f90
+++ b/test/fortran-map-tests/target_map_common_block_1.f90
@@ -1,0 +1,25 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    use omp_lib
+    integer :: var_a(2), var_b
+    common var_b
+    var_b = 10
+    print *, "var_b before target = ", var_b
+    var_a(1) = omp_get_device_num()
+    !$omp target map(tofrom:var_a) map(tofrom:var_b)
+      var_b = 20
+      var_a(2) = omp_get_device_num()
+    !$omp end target
+    print *, "var_b after target = ", var_b
+    print *, "var_a: ", var_a
+
+    if (var_b /= 20) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/target_map_common_block_2.f90
+++ b/test/fortran-map-tests/target_map_common_block_2.f90
@@ -1,0 +1,23 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    use omp_lib
+    integer :: var_a, var_b
+    common var_b
+    var_b = 24
+    var_a = 12
+    print *, "var_b before target = ", var_b
+    !$omp target map(tofrom:var_b)
+      var_b = var_a
+    !$omp end target
+    print *, "var_b after target = ", var_b
+
+    if (var_b /= 12) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    print *, "======= FORTRAN Test Passed! ======="
+end program

--- a/test/fortran-map-tests/target_map_common_block_3.f90
+++ b/test/fortran-map-tests/target_map_common_block_3.f90
@@ -1,0 +1,51 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    common /cblock_a/ var_a, var_b
+    integer :: var_a, var_b
+
+    call sub_a
+
+  !$omp target map(tofrom: /cblock_a/)
+      var_a = var_a + 20
+      var_b = var_b + 50
+  !$omp end target
+
+    call sub_b
+
+      print *, "var_a after target = ", var_a
+      print *, "var_b after target = ", var_b
+
+    if (var_a /= 400) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_b /= 800) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: /cblock_a/)
+  var_a = var_a + 20
+  var_b = var_b + 30
+!$omp end target
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: /cblock_a/)
+  var_a = var_a * 10
+  var_b = var_b * 10
+!$omp end target
+end

--- a/test/fortran-map-tests/target_map_common_block_4.f90
+++ b/test/fortran-map-tests/target_map_common_block_4.f90
@@ -1,0 +1,48 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    common /cblock_a/ var_a, var_b
+    integer :: var_a, var_b
+
+    call sub_a
+
+  !$omp target map(tofrom: var_a)
+      var_a = var_a + 20
+  !$omp end target
+
+    call sub_b
+
+      print *, "var_a after target = ", var_a
+      print *, "var_b after target = ", var_b
+
+    if (var_a /= 400) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_b /= 0) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+   end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: var_a)
+  var_a = var_a + 20
+!$omp end target
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: var_a)
+  var_a = var_a * 10
+!$omp end target
+end

--- a/test/fortran-map-tests/target_map_common_block_5.f90
+++ b/test/fortran-map-tests/target_map_common_block_5.f90
@@ -1,0 +1,48 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    common /cblock_a/ var_a, var_b
+    integer :: var_a, var_b
+
+    call sub_a
+
+  !$omp target map(tofrom: var_b)
+      var_b = var_b + 20
+  !$omp end target
+
+    call sub_b
+
+      print *, "var_a after target = ", var_a
+      print *, "var_b after target = ", var_b
+
+    if (var_a /= 0) then
+        print*, "======= FORTRAN Test Failed! ======="
+        stop 1
+    end if
+
+    if (var_b /= 400) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+    end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: var_b)
+  var_b = var_b + 20
+!$omp end target
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b
+  integer :: var_a, var_b
+!$omp target map(tofrom: var_b)
+  var_b = var_b * 10
+!$omp end target
+end

--- a/test/fortran-map-tests/target_map_common_block_6.f90
+++ b/test/fortran-map-tests/target_map_common_block_6.f90
@@ -1,0 +1,60 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    common /cblock_a/ var_a, var_b, var_c
+    integer :: var_a = 0, var_b = 0, var_c = 0
+
+    call sub_a
+
+  !$omp target map(tofrom: var_a, var_b, var_c)
+    var_c = var_c * 10
+    var_b = var_b * 10
+    var_a = var_a * 10
+ !$omp end target
+
+ call sub_b
+
+  print *, "var_a after target = ", var_a
+  print *, "var_b after target = ", var_b
+  print *, "var_c after target = ", var_c
+
+  if (var_a /= 310) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+
+  if (var_b /= 215) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_c /= 420) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+   print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+!$omp target map(tofrom: var_b, var_a, var_c)
+  var_c = var_c + 40
+  var_b = var_b + 20
+  var_a = var_a + 30
+!$omp end target
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+!$omp target map(tofrom: var_b, var_c, var_a)
+  var_c = var_c + 20
+  var_a = var_a + 10
+  var_b = var_b + 15
+!$omp end target
+end

--- a/test/fortran-map-tests/target_map_common_block_7.f90
+++ b/test/fortran-map-tests/target_map_common_block_7.f90
@@ -1,0 +1,66 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  implicit none
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+
+  call sub_a
+
+  !$omp target map(tofrom: var_b)
+    var_b = var_b + var_c
+  !$omp end target
+
+  call sub_b
+
+  print *, "var_a after target = ", var_a
+  print *, "var_b after target = ", var_b
+  print *, "var_c after target = ", var_c
+
+  if (var_a /= 10) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+
+  if (var_b /= 50) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_c /= 30) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+
+!$omp target map(tofrom: /cblock_a/)
+  var_a = 10
+  var_b = 20
+  var_c = 30
+!$omp end target
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+  integer :: var_d
+
+!$omp target map(tofrom: var_d)
+  var_d =  var_b + var_c
+!$omp end target
+
+  print *, "var_d after target = ", var_d
+
+  if (var_d /= 80) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end

--- a/test/fortran-map-tests/target_map_common_block_8.f90
+++ b/test/fortran-map-tests/target_map_common_block_8.f90
@@ -1,0 +1,81 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+    implicit none
+    common /cblock_a/ var_a, var_b, var_c
+    integer :: var_a, var_b, var_c
+    !$omp declare target link(/cblock_a/)
+
+    call sub_a
+
+  !$omp target map(tofrom: var_b)
+    var_b = var_b + var_c
+  !$omp end target
+
+  call sub_b
+
+  print *, "var_a after target = ", var_a
+  print *, "var_b after target = ", var_b
+  print *, "var_c after target = ", var_c
+
+  call sub_c
+
+  if (var_a /= 20) then
+      print*, "======= FORTRAN Test Failed! ======="
+      stop 1
+  end if
+
+  if (var_b /= 100) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  if (var_c /= 60) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+
+  print*, "======= FORTRAN Test Passed! ======="
+end program
+
+subroutine sub_a
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+
+!$omp target map(tofrom: /cblock_a/)
+  var_a = 10
+  var_b = 20
+  var_c = 30
+!$omp end target
+
+end
+
+subroutine sub_b
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+  integer :: var_d
+
+!$omp target map(tofrom: var_d)
+  var_d =  var_b + var_c
+!$omp end target
+
+  print *, "var_d after target = ", var_d
+
+  if (var_d /= 80) then
+    print*, "======= FORTRAN Test Failed! ======="
+    stop 1
+  end if
+end
+
+subroutine sub_c
+  common /cblock_a/ var_a, var_b, var_c
+  integer :: var_a, var_b, var_c
+
+!$omp target map(tofrom: /cblock_a/)
+  var_a = var_a + var_a
+  var_b = var_b + var_b
+  var_c = var_c + var_c
+!$omp end target
+end

--- a/test/fortran-map-tests/test.sh
+++ b/test/fortran-map-tests/test.sh
@@ -1,0 +1,1609 @@
+# !/bin/bash
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier:  MIT
+
+AOMP=${AOMP:-$HOME/rocm/aomp/llvm}
+FORTRAN_OMP_MOD_FILES=${FORTRAN_OMP_MOD_FILES:-$HOME/rocm/aomp/lib/llvm/include/flang}
+OFFLOAD_RUNTIME_DIR=${OFFLOAD_RUNTIME_DIR:-$HOME/rocm/aomp/lib/llvm/lib}
+AOMPHIP=${AOMPHIP:-$(realpath -m $(realpath -m $AOMP)/../..)}
+# for ROCm utilities (e.g. rocm_agent_enumerator)
+ROCM=${ROCM:-$(realpath -m $(realpath -m $AOMP)/../..)}
+
+echo "compiling basic-exp-map.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  basic-exp-map.f95 -o basic-exp-map.out
+
+echo "compiling basic-example.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  basic-example.f95 -o basic-example.out
+
+echo "compiling basic-example-v2.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  basic-example-v2.f95 -o basic-example-v2.out
+
+echo "compiling basic-double-target-call.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  basic-double-target-call.f95 -o basic-double-target-call.out
+
+echo "compiling even-basicer-example.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  even-basicer-example.f95 -o even-basicer-example.out
+
+echo "compiling main-all.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  main-all.f95 -o main-all.out
+
+echo "compiling main.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  main.f95 -o main.out
+
+echo "compiling no-write-implicit-cap.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  no-write-implicit-cap.f95 -o no-write-implicit-cap.out
+
+echo "compiling milestone-1-map-syntax.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  milestone-1-map-syntax.f95 -o milestone-1-map-syntax.out
+
+echo "compiling milestone-1-map-exact-syntax.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  milestone-1-map-exact-syntax.f95 -o milestone-1-map-exact-syntax.out
+
+echo "compiling decltar-double-target-call.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  decltar-double-target-call.f95 -o decltar-double-target-call.out
+
+echo "compiling constant-index-in-target.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  constant-index-in-target.f95 -o constant-index-in-target.out 
+
+echo "compiling from-to.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  from-to.f95 -o from-to.out
+
+echo "compiling complex.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  complex.f95 -o complex.out
+
+echo "compiling complex-array.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  complex-array.f95 -o complex-array.out
+
+echo "compiling constant-array-access.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  constant-array-access.f95 -o constant-array-access.out
+
+echo "compiling simple-full-struct.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  simple-full-struct.f95 -o simple-full-struct.out
+
+echo "compiling simple-full-struct-2.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  simple-full-struct-2.f95 -o simple-full-struct-2.out
+
+echo "compiling simple-full-struct-implicit.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  simple-full-struct-implicit.f95 -o simple-full-struct-implicit.out
+
+echo "compiling simple-full-struct-implicit-2.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  simple-full-struct-implicit-2.f95 -o simple-full-struct-implicit-2.out
+
+echo "compiling pointer-target-map.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-target-map.f95 -o pointer-target-map.out
+
+echo "compiling pointer-map.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-map.f95 -o pointer-map.out
+
+echo "compiling nd-pointer-bounds-map-syntax.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nd-pointer-bounds-map-syntax.f95 -o nd-pointer-bounds-map-syntax.out
+
+echo "compiling nd-allocatables-bounds-map-syntax.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nd-allocatables-bounds-map-syntax.f95 -o nd-allocatables-bounds-map-syntax.out
+
+echo "compiling pointer-map-scopes.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-map-scopes.f95 -o pointer-map-scopes.out
+
+echo "compiling pointer-scopes-enter-exit-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-scopes-enter-exit-map.f90 -o pointer-scopes-enter-exit-map.out
+
+echo "compiling pointer-map-scopes-bounds.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-map-scopes-bounds.f95 -o pointer-map-scopes-bounds.out
+
+echo "compiling pointer-array-section-1d-upperbound.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-array-section-1d-upperbound.f95 -o pointer-array-section-1d-upperbound.out
+
+echo "compiling pointer-target-map-scopes.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-target-map-scopes.f95 -o pointer-target-map-scopes.out
+
+echo "compiling pointer-target-scopes-enter-exit-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-target-scopes-enter-exit-map.f90 -o pointer-target-scopes-enter-exit-map.out
+
+echo "compiling pointer-target-map-scopes-bounds.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-target-map-scopes-bounds.f95 -o pointer-target-map-scopes-bounds.out
+
+echo "compiling pointer-target-array-section-1d-upperbound.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  pointer-target-array-section-1d-upperbound.f95 -o pointer-target-array-section-1d-upperbound.out
+
+echo "compiling allocatable-map.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-map.f95 -o allocatable-map.out 
+
+echo "compiling nd-allocatables-target-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nd-allocatables-target-map.f90 -o nd-allocatables-target-map.out 
+
+echo "compiling array-section-1d-upperbound.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  array-section-1d-upperbound.f95 -o array-section-1d-upperbound.out 
+
+echo "compiling nd-bounds-map-syntax.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nd-bounds-map-syntax.f95 -o nd-bounds-map-syntax.out 
+
+echo "compiling array-section-runtime-bounds.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  array-section-runtime-bounds.f95 -o array-section-runtime-bounds.out 
+
+echo "compiling array-section-no-lower-bounds.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  array-section-no-lower-bounds.f95 -o array-section-no-lower-bounds.out 
+
+echo "compiling nd-array-full-map.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nd-array-full-map.f95 -o nd-array-full-map.out 
+
+echo "compiling assumed-size-array-vec-mul-allocatables.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  assumed-size-array-vec-mul-allocatables.f95 -o assumed-size-array-vec-mul-allocatables.out 
+
+echo "compiling assumed-shape-array-vec-mul-allocatables.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  assumed-shape-array-vec-mul-allocatables.f95 -o assumed-shape-array-vec-mul-allocatables.out 
+
+echo "compiling assumed-shape-array-vec-mul.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  assumed-shape-array-vec-mul.f95 -o assumed-shape-array-vec-mul.out 
+
+echo "compiling assumed-size-array-vec-mul.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  assumed-size-array-vec-mul.f95 -o assumed-size-array-vec-mul.out 
+
+echo "compiling target_enter_exit_milestone_3a.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_enter_exit_milestone_3a.f90 -o target_enter_exit_milestone_3a.out 
+
+echo "compiling target_enter_exit_milestone_3b.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_enter_exit_milestone_3b.f90 -o target_enter_exit_milestone_3b.out 
+
+echo "compiling allocatable-map-scopes.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-map-scopes.f95 -o allocatable-map-scopes.out
+
+echo "compiling allocatables-scopes-enter-exit-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatables-scopes-enter-exit-map.f90 -o allocatable-scopes-enter-exit-map.out
+
+echo "compiling allocatable-map-scopes-bounds.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-map-scopes-bounds.f95 -o allocatable-map-scopes-bounds.out
+
+echo "compiling allocatable-array-section-1d-upperbound.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-array-section-1d-upperbound.f95 -o allocatable-array-section-1d-upperbound.out
+
+echo "compiling target-alloca-from-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target-alloca-from-map.f90 -o target-alloca-from-map.out 
+
+echo "compiling enter-exit-break-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-break-test.f90 -o enter-exit-break-test.out 
+
+echo "compiling enter-exit-break-test-2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-break-test-2.f90 -o enter-exit-break-test-2.out 
+
+echo "compiling target_enter_exit_milestone_3.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_enter_exit_milestone_3.f90 -o target_enter_exit_milestone_3.out
+
+echo "compiling assumed-shape-array-vec-mul-allocatables-with-alloca-param.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  assumed-shape-array-vec-mul-allocatables-with-alloca-param.f95	 -o assumed-shape-array-vec-mul-allocatables-with-alloca-param.out
+
+echo "compiling individual-dtype-member-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  individual-dtype-member-map.f90 -o individual-dtype-member-map.out
+
+echo "compiling derived-type-individual-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  derived-type-individual-array-map.f90 -o individual-dtype-array-member-map.out
+
+echo "compiling multiple-dt-explicit-member-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  multiple-dt-explicit-member-map.f90 -o multiple-dtype-member-map.out
+
+echo "compiling derived-type-member-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  derived-type-member-array-map.f90 -o dt-member-array-map.out
+
+echo "compiling full-dtype-map-with-contained-dtype.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  full-dtype-map-with-contained-dtype.f90 -o full-dtype-map-with-contained-dtype.out
+
+echo "compiling dtype-member-array-map-2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-member-array-map-2.f90 -o dt-member-array-map-2.out
+
+echo "compiling derived-type-member-array-map-3.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  derived-type-member-array-map-3.f90 -o dt-member-array-map-3.out
+
+echo "compiling double-derived-type-double-member-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-derived-type-double-member-array-map.f90 -o double-dtype-double-arr-map.out
+
+echo "compiling double-derived-type-individual-member-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-derived-type-individual-member-map.f90 -o double-dtype-individual-scalar-map.out
+
+echo "compiling derived-type-individual-array-map-with-bounds.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  derived-type-individual-array-map-with-bounds.f90 -o dtype-individual-array-map-with-bounds.out
+
+echo "compiling double-dtype-mem-individual-arr-bounds-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-dtype-mem-individual-arr-bounds-map.f90 -o double-derived-type-individual-member-array-bounds-map.out
+
+echo "compiling double-dtype-mixed-imp-exp-member-maps.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-dtype-mixed-imp-exp-member-maps.f90 -o dtype-exp-imp-member-map.out
+
+echo "compiling double-dtype-mixed-imp-exp-member-maps-with-bounds.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-dtype-mixed-imp-exp-member-maps-with-bounds.f90 -o dtype-exp-imp-member-map-bounds.out
+
+echo "compiling enter-exit-array-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-array-test.f90 -o enter-exit-array-test.out 
+
+echo "compiling enter-exit-array-bounds-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-array-bounds-test.f90 -o enter-exit-array-bounds-test.out
+
+echo "compiling enter-exit-scalar-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-scalar-test.f90 -o enter-exit-scalar-test.out
+
+echo "compiling dtype-enter-exit.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-enter-exit.f90 -o dtype-enter-exit.out
+
+echo "compiling dtype-enter-exit-update.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-enter-exit-update.f90 -o dtype-enter-exit-update.out
+
+echo "compiling always-map-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  always-map-test.f90 -o always-map-test.out
+
+echo "compiling allocatable-full-struct.f95"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-full-struct.f95 -o allocatable-full-struct.out
+
+echo "compiling declare-target-link-implicit.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  declare-target-link-implicit.f90 -o declare-target-link-implicit.out
+
+echo "compiling implicit-allocatable-write-arrays.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  implicit-allocatable-write-arrays.f90 -o imp-alloca-write-arr.out 
+
+echo "compiling double-dtype-nested-double-member-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  double-dtype-nested-double-member-array-map.f90 -o explicit-nested-array-map.out
+
+echo "compiling large-nested-dtype-multi-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  large-nested-dtype-multi-map.f90 -o large-nested-dtype-multi-map.out
+
+echo "compiling multi-large-nested-dtype-multi-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  multi-large-nested-dtype-multi-map.f90 -o multi-large-nested-dtype-multi-map.out
+
+echo "compiling small-nested-dtype-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  small-nested-dtype-map.f90 -o small-nested-dtype-map.out
+
+echo "compiling nested-dtype-single-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-single-map.f90 -o nested-dtype-single-map.out
+
+echo "compiling multi-nested-dtype-single-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  multi-nested-dtype-single-map.f90 -o multi-nested-dtype-single-map.out
+
+echo "compiling multi-nested-dtype-single-map-bounds.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  multi-nested-dtype-single-map-bounds.f90 -o multi-nested-dtype-single-map-bounds.out
+
+echo "compiling multi-nested-dtype-multi-map-bounds.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  multi-nested-dtype-multi-map-bounds.f90 -o multi-nested-dtype-multi-map-bounds.out
+
+echo "compiling nested-dtype-map-struct.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-map-struct.f90 -o nested-dtype-map-struct.out
+
+echo "compiling nested-dtype-complex-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-complex-map.f90 -o nested-dtype-complex-map.out
+
+echo "compiling dtype-array-allocatable.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-allocatable.f90 -o dtype-array-allocatable.out
+
+echo "compiling dtype-allocatable-scalar-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-allocatable-scalar-map.f90 -o dtype-allocatable-scalar-map.out
+
+echo "compiling dtype-allocatable-and-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-allocatable-and-array-map.f90 -o dtype-allocatable-and-array-map.out
+
+echo "compiling dtype-allocatable-and-dtype-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-allocatable-and-dtype-map.f90 -o dtype-allocatable-and-dtype-map.out
+
+echo "compiling dtype-allocatable-array-with-bounds-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-allocatable-array-with-bounds-map.f90 -o dtype-allocatable-array-with-bounds-map.out
+
+echo "compiling nested-dtype-array-allocatable.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-array-allocatable.f90 -o nested-dtype-array-allocatable.out
+
+echo "compiling nested-dtype-allocatable-and-array-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-allocatable-and-array-map.f90 -o nested-dtype-allocatable-and-array-map.out
+
+echo "compiling nested-dtype-allocatable-array-with-bounds-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-allocatable-array-with-bounds-map.f90 -o nested-dtype-allocatable-array-with-bounds-map.out
+
+echo "compiling nested-dtype-allocatable-and-dtype-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-dtype-allocatable-and-dtype-map.f90 -o nested-dtype-allocatable-and-dtype-map.out
+
+echo "compiling allocatable-dtype-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-dtype-map.f90 -o allocatable-dtype-map.out
+
+echo "compiling dtype-array-of-dtype-member-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map.f90 -o dtype-array-of-dtype-member-map.out
+
+echo "compiling dtype-array-of-dtype-member-map-v2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map-v2.f90 -o dtype-array-of-dtype-member-map-v2.out
+
+echo "compiling dtype-array-of-dtype-member-map-v3.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map-v3.f90 -o dtype-array-of-dtype-member-map-v3.out
+
+echo "compiling dtype-array-of-dtype-member-map-v4.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map-v4.f90 -o dtype-array-of-dtype-member-map-v4.out
+
+echo "compiling type_pointer_to_member.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype_pointer_to_member.f90 -o dtype_pointer_to_member.out
+
+echo "compiling dtype-array-of-dtype-member-map-v5.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map-v5.f90 -o dtype-array-of-dtype-member-map-v5.out
+
+echo "compiling type-array-of-dtype-member-map-v6.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-array-of-dtype-member-map-v6.f90 -o dtype-array-of-dtype-member-map-v6.out
+
+echo "compiling allocatable-dtype-nested-allocatable-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-dtype-nested-allocatable-map.f90 -o allocatable-dtype-nested-allocatable-map.out
+
+echo "compiling allocatable-dtype-and-nested-allocatable-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-dtype-and-nested-allocatable-map.f90 -o allocatable-dtype-and-nested-allocatable-map.out
+
+echo "compiling allocatable-dtype-and-nested-allocatable-map-v2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-dtype-and-nested-allocatable-map-v2.f90 -o allocatable-dtype-and-nested-allocatable-map-v2.out
+
+echo "compiling nested-allocatable-dtype-allocatable-array-with-bounds-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  nested-allocatable-dtype-allocatable-array-with-bounds-map.f90 -o nested-allocatable-dtype-allocatable-array-with-bounds-map.out
+
+echo "compiling michael-map-example.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  michael-map-example.f90 -o michael-map-example.out
+
+echo "compiling target_map_common_block_1.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_1.f90 -o target_map_common_block_1.out
+
+echo "compiling target_map_common_block_2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_2.f90 -o target_map_common_block_2.out
+
+echo "compiling target_map_common_block_3.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_3.f90 -o target_map_common_block_3.out
+
+echo "compiling target_map_common_block_4.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_4.f90 -o target_map_common_block_4.out
+
+echo "compiling target_map_common_block_5.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_5.f90 -o target_map_common_block_5.out
+
+echo "compiling target_map_common_block_6.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_6.f90 -o target_map_common_block_6.out
+
+echo "compiling target_map_common_block_7.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_7.f90 -o target_map_common_block_7.out
+
+echo "compiling target_map_common_block_8.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  target_map_common_block_8.f90 -o target_map_common_block_8.out
+
+echo "compiling allocatable-dtype-map-exp-member.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  allocatable-dtype-map-exp-member.f90 -o allocatable-dtype-map-exp-member.out
+
+echo "compiling instruction-replace-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  instruction-replace-test.f90 -o instruction-replace-test.out
+
+echo "compiling dtype-syntax-support.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-syntax-support.f90 -o dtype-syntax-support.out
+
+echo "compiling dtype-syntax-support-2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-syntax-support-2.f90 -o dtype-syntax-support-2.out
+
+echo "compiling dtype-allocatable-array3d-with-bounds-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-allocatable-array3d-with-bounds-map.f90 -o dtype-allocatable-array3d-with-bounds-map.out
+
+echo "compiling derived-type-map-from-alloca-issue.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  derived-type-map-from-alloca-issue.f90 -o derived-type-map-from-alloca-issue.out
+
+echo "compiling dtype-class-dummy-full-exp-imp-map.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-class-dummy-full-exp-imp-map.f90 -o dtype-class-dummy-full-exp-imp-map.out
+
+echo "compiling reproducer-for-471028.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  reproducer-for-471028.f90 -o reproducer-for-471028.out
+
+echo "compiling enter-exit-in-different-scopes.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  enter-exit-in-different-scopes.f90 -o enter-exit-in-different-scopes.out
+
+echo "compiling jean-example.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  jean-example.f90 -o jean-example.out
+
+echo "compiling parent-member-overlap-test-1.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  parent-member-overlap-test-1.f90 -o parent-member-overlap-test-1.out
+
+echo "compiling simple-declare-target-to-target.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  simple-declare-target-to-target.f90 -o simple-declare-target-to-target.out
+
+echo "compiling declare-target-allocatable-array.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  declare-target-allocatable-array.f90 -o declare-target-allocatable-array.out
+
+echo "compiling char-array-map-test-v1.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  char-array-map-test-v1.f90 -o char-array-map-test-v1.out
+
+echo "compiling char-array-map-test-v2.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  char-array-map-test-v2.f90 -o char-array-map-test-v2.out
+
+echo "compiling dtype-index-access-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  dtype-index-access-test.f90 -o dtype-index-access-test.out
+
+echo "compiling neg-bounds-alloca-test.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  neg-bounds-alloca-test.f90 -o neg-bounds-alloca-test.out
+
+echo "compiling swdev-561059.f90"
+
+$AOMP/bin/flang    --offload-arch=gfx90a -fopenmp  swdev-561059.f90 -o swdev-516059.out
+
+# these all depend on the fortran runtime compiled for offload
+
+echo "compiling large-nested-allocatable-map-test.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-nested-allocatable-map-test.f90 -o large-nested-allocatable-map-test.out
+
+echo "compiling multi-large-nested-dtype-multi-map-with-allocatables.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  multi-large-nested-dtype-multi-map-with-allocatables.f90 -o multi-large-nested-dtype-multi-map-with-allocatables.out
+
+echo "compiling allocatable-dtype-array-map-v1.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  allocatable-dtype-array-map-v1.f90 -o allocatable-dtype-array-map-v1.out
+
+echo "compiling large-mixed-nested-dtype-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-mixed-nested-dtype-map.f90 -o large-mixed-nested-dtype-map.out
+
+echo "compiling large-mixed-nested-dtype-map-2.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-mixed-nested-dtype-map-2.f90 -o large-mixed-nested-dtype-map-2.out
+
+echo "compiling large-allocatable-nested-dtype-multi-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-allocatable-nested-dtype-multi-map.f90 -o large-allocatable-nested-dtype-multi-map.out
+
+echo "compiling large-allocatable-nested-dtype-double-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-allocatable-nested-dtype-double-map.f90 -o large-allocatable-nested-dtype-double-map.out
+
+echo "compiling large-allocatable-nested-dtype-double-map-2.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-allocatable-nested-dtype-double-map-2.f90 -o large-allocatable-nested-dtype-double-map-2.out
+
+echo "compiling allocatable-dtype-allocatable-nest-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  allocatable-dtype-allocatable-nest-map.f90 -o allocatable-dtype-allocatable-nest-map.out
+
+echo "compiling large-nested-dtype-multi-map-with-allocatables.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  large-nested-dtype-multi-map-with-allocatables.f90 -o large-nested-dtype-multi-map-with-allocatables.out
+
+echo "compiling nested-dtype-double-allocatable.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  nested-dtype-double-allocatable.f90  -o nested-dtype-double-allocatable.out
+
+echo "compiling nested-dtype-scalar-allocatable.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  nested-dtype-scalar-allocatable.f90 -o nested-dtype-scalar-allocatable.out
+
+echo "compiling dtype-scalar-allocatable.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  dtype-scalar-allocatable.f90 -o dtype-scalar-allocatable.out
+
+echo "compiling dtype-double-allocatable.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  dtype-double-allocatable.f90  -o dtype-double-allocatable.out
+
+echo "compiling implicit-allocatable-write.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  implicit-allocatable-write.f90 -o imp-alloca-write.out
+
+echo "compiling single-value-alloca.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  single-value-alloca.f90 -o single-value-alloca.out
+
+echo "compiling implicit-single-value-alloca.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  implicit-single-value-alloca.f90 -o implicit-single-value-alloca.out
+
+echo "compiling nested-dtype-allocatable-scalar-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  nested-dtype-allocatable-scalar-map.f90 -o nested-dtype-allocatable-scalar-map.out
+
+echo "compiling single-value-alloca-loop.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  single-value-alloca-loop.f90 -o single-value-alloca-loop.out
+
+echo "compiling scalar-allocatable-block-map.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp  scalar-allocatable-block-map.f90 -o scalar-allocatable-block-map.out
+
+echo "compiling UMT-reproducer.f90"
+
+$AOMP/bin/flang --offload-arch=gfx90a -fopenmp  UMT-reproducer.f90 -o UMT-reproducer.out
+
+echo "compiling test_map_types_omp60.F90"
+
+$AOMP/bin/flang -fopenmp -fopenmp-version=60 --offload-arch=gfx90a test_map_types_omp60.F90 -o test_map_types_omp60.out
+
+# USM tests that need HSA_XNACK set
+
+echo "compiling declare-target-enter-usm.f90"
+
+$AOMP/bin/flang -L$OFFLOAD_RUNTIME_DIR --offload-arch=gfx90a -fopenmp-force-usm -fopenmp  declare-target-enter-usm.f90 -o declare-target-enter-usm.out
+
+echo "compiling UMT-reproducer-5.f90"
+
+$AOMP/bin/flang --offload-arch=gfx90a -fopenmp  UMT-reproducer-5.f90 -o UMT-reproducer-5.out
+
+echo "compiling UMT-reproducer-6.f90"
+
+$AOMP/bin/flang --offload-arch=gfx90a -fopenmp  UMT-reproducer-6.f90 -o UMT-reproducer-6.out
+
+echo "compiling reproducer-3-47779-v2.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-3-47779-v2.f90 -o reproducer-3-47779-v2.out
+
+echo "compiling reproducer-SWDEV-471201.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-SWDEV-471201.f90 -o reproducer-SWDEV-471201.out
+
+echo "compiling reproducer-476419.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-476419.f90 -o reproducer-476419.out
+
+echo "compiling reproducer-SWDEV-471201-v2.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-SWDEV-471201-v2.f90 -o reproducer-SWDEV-471201-v2.out
+
+echo "compiling reproducer-SWDEV-471201-v3.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-SWDEV-471201-v3.f90 -o reproducer-SWDEV-471201-v3.out
+
+echo "compiling pot3d-reproducer.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  pot3d-reproducer.f90 -o pot3d-reproducer.out
+
+echo "compiling seismic-reproducer.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  seismic-reproducer.f90 -o seismic-reproducer.out
+
+echo "compiling simplified-reproducer-497977.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  simplified-reproducer-497977.f90 -o simplified-reproducer-497977.out
+
+echo "compiling reproducer-497977.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-497977.f90 -o reproducer-497977.out
+
+echo "compiling simplified-SWDEV-498999-reproducer.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  simplified-SWDEV-498999-reproducer.f90 -o simplified-SWDEV-498999-reproducer.out
+
+echo "compiling simplified-SWDEV-498999-reproducer-v2.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  simplified-SWDEV-498999-reproducer-v2.f90 -o simplified-SWDEV-498999-reproducer-v2.out
+
+echo "compiling SWDEV-564425-simple.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-simple.f90 -o SWDEV-564425-simple.out
+
+echo "compiling SWDEV-564425.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425.f90 -o SWDEV-564425.out
+
+echo "compiling SWDEV-564425-v2.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v2.f90 -o SWDEV-564425-v2.out
+
+echo "compiling SWDEV-564425-v3.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v3.f90 -o SWDEV-564425-v3.out
+
+echo "compiling ref_ptr_ptee_test_1.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 -fopenmp --offload-arch=gfx90a ref_ptr_ptee_test_1.f90 -o ref_ptr_ptee_test_1.out
+
+echo "compiling ref_ptr_ptee_test_2.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 -fopenmp --offload-arch=gfx90a ref_ptr_ptee_test_2.f90 -o ref_ptr_ptee_test_2.out
+
+echo "compiling map_alloc_ref_ptr_ptee.f90"
+
+$AOMP/bin/flang -fno-defer-desc-map -fopenmp-version=60 -fopenmp --offload-arch=gfx90a map_alloc_ref_ptr_ptee.f90 -o map_alloc_ref_ptr_ptee.out
+
+echo "compiling map_static_ref_ptr_ptee.f90"
+
+$AOMP/bin/flang -fno-defer-desc-map -fopenmp-version=60 -fopenmp --offload-arch=gfx90a map_static_ref_ptr_ptee.f90 -o map_static_ref_ptr_ptee.out
+
+echo "compiling ref_ptr_ptee_struct_map-v1.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_struct_map-v1.f90 -o ref_ptr_ptee_struct_map-v1.out
+
+echo "compiling ref_ptr_ptee_struct_map-v2.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_struct_map-v2.f90 -o ref_ptr_ptee_struct_map-v2.out
+
+echo "compiling ref_ptr_ptee_alloca_struct_map-v1.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_alloca_struct_map-v1.f90 -o ref_ptr_ptee_alloca_struct_map-v1.out
+
+echo "compiling ref_ptr_ptee_alloca_struct_map-v2.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_alloca_struct_map-v2.f90 -o ref_ptr_ptee_alloca_struct_map-v2.out
+
+echo "compiling SWDEV-564425-v2-alloca-parent.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v2-alloca-parent.f90 -o SWDEV-564425-v2-alloca-parent.out
+
+echo "compiling SWDEV-564425-v3-alloca-parent.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v3-alloca-parent.f90 -o SWDEV-564425-v3-alloca-parent.out
+
+echo "compiling ref_ptr_ptee_alloca_struct_and-children_map-v1.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_alloca_struct_and-children_map-v1.f90 -o ref_ptr_ptee_alloca_struct_and-children_map-v1.out
+
+echo "compiling ref_ptr_ptee_alloca_struct_and-children_map-v2.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp ref_ptr_ptee_alloca_struct_and-children_map-v2.f90 -o ref_ptr_ptee_alloca_struct_and-children_map-v2.out
+
+echo "compiling SWDEV-564425-v2-alloca-parent-and-children.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v2-alloca-parent-and-children.f90 -o SWDEV-564425-v2-alloca-parent-and-children.out
+
+echo "compiling SWDEV-564425-v3-alloca-parent-and-children.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v3-alloca-parent-and-children.f90 -o SWDEV-564425-v3-alloca-parent-and-children.out
+
+echo "compiling SWDEV-564425-v4-alloca-parent-and-children.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v4-alloca-parent-and-children.f90 -o SWDEV-564425-v4-alloca-parent-and-children.out
+
+echo "compiling SWDEV-564425-v5-alloca-parent-and-children.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v5-alloca-parent-and-children.f90 -o SWDEV-564425-v5-alloca-parent-and-children.out
+
+echo "compiling SWDEV-564425-v4-alloca-parent.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v4-alloca-parent.f90 -o SWDEV-564425-v4-alloca-parent.out
+
+echo "compiling SWDEV-564425-v5-alloca-parent.f90"
+
+$AOMP/bin/flang -fopenmp-version=60 --offload-arch=gfx90a -fopenmp SWDEV-564425-v5-alloca-parent.f90 -o SWDEV-564425-v5-alloca-parent.out
+
+echo "compiling attach_always.f90"
+
+$AOMP/bin/flang -fopenmp-version=61 -fopenmp --offload-arch=gfx90a attach_always.f90 -o attach_always.out
+
+echo "compiling attach_never.f90"
+
+$AOMP/bin/flang -fopenmp-version=61 -fopenmp --offload-arch=gfx90a attach_never.f90 -o attach_never.out
+
+echo "compiling reproducer-SWDEV-483255.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-SWDEV-483255.f90 -o reproducer-SWDEV-483255.out
+
+echo "compiling reproducer-SWDEV-502486.f90"
+
+$AOMP/bin/flang  --offload-arch=gfx90a -fopenmp  reproducer-SWDEV-502486.f90 -o reproducer-SWDEV-502486.out
+
+echo "compiling SWDEV-579431.f90"
+
+$AOMP/bin/flang -fopenmp -fopenmp-version=60 --offload-arch=gfx90a SWDEV-579431.f90 -o SWDEV-579431.out
+
+echo "basic exp map"
+
+./basic-exp-map.out
+
+echo "basic example"
+
+./basic-example.out
+
+echo "basic example v2"
+
+./basic-example-v2.out
+
+echo "even basicer example"
+
+./even-basicer-example.out
+
+echo "main all"
+
+./main-all.out
+
+echo "main"
+
+./main.out
+
+echo "no write implicit cap"
+
+./no-write-implicit-cap.out
+
+echo "milestone 1 map syntax (1D range)"
+
+./milestone-1-map-syntax.out
+
+echo "exact milestone 1 map syntax (1D range)"
+
+./milestone-1-map-exact-syntax.out
+
+echo "double target call with same declare target map"
+
+./decltar-double-target-call.out
+
+echo "double target call with same basic map"
+
+./basic-double-target-call.out
+
+echo "Use of explicit constant index in target array"
+
+./constant-index-in-target.out
+
+echo "Use of from to to map arrays and transfer values"
+
+./from-to.out 
+
+echo "Use of complex value map from host to device"
+
+./complex.out
+
+echo "Complex array map from host to device"
+
+./complex-array.out
+
+echo "Constant array access and addition"
+
+./constant-array-access.out
+
+echo "Passing of basic struct in full"
+
+./simple-full-struct.out
+
+echo "Passing of basic struct in full, with individual member assignment"
+
+./simple-full-struct-2.out
+
+echo "Passing of basic implicit struct in full and write to other explicit struct"
+
+./simple-full-struct-implicit.out
+
+echo "Passing of basic implicit struct in full and write to other explicit struct, with individual member assignment"
+
+./simple-full-struct-implicit-2.out
+
+echo "Passing Fort pointer to Fort target and doing a simple loop assign"
+
+./pointer-target-map.out 
+
+echo "Passing Fort pointer and doing a simple loop assign"
+
+./pointer-map.out 
+
+echo "Passing Fort allocatable and doing a simple loop assign"
+
+./allocatable-map.out 
+
+echo "Check array section with upper bound (write off end of array on device)"
+
+./array-section-1d-upperbound.out 
+
+echo "N-D Bounds (3 dimensions) map syntax"
+
+./nd-bounds-map-syntax.out
+
+echo "1-D array runtime bounds"
+
+./array-section-runtime-bounds.out
+
+echo "1-D array section no LB specified with UB"
+
+./array-section-no-lower-bounds.out
+
+echo "3-D array full mapping, no bounds"
+
+./nd-array-full-map.out
+
+echo "1-D vec multiply in function with dummy assumed shape array arguments"
+
+./assumed-shape-array-vec-mul.out
+
+echo "1-D vec multiply in function with dummy assumed size array arguments"
+
+./assumed-size-array-vec-mul.out
+
+echo "1-D vec multiply in function with dummy assumed size array params with allocatable args"
+
+./assumed-size-array-vec-mul-allocatables.out
+
+echo "1-D vec multiply in function with dummy assumed shape array params with allocatable args"
+
+./assumed-shape-array-vec-mul-allocatables.out
+
+echo "Enter + Exit map used in conjunction with target to map an array and assign values"
+
+./target_enter_exit_milestone_3a.out
+
+echo "Enter + Exit map used in conjunction with target to map an allocatable array and assign values"
+
+./target_enter_exit_milestone_3b.out
+
+echo "Allocatable with Target utilising different variable scopes"
+
+./allocatable-map-scopes.out
+
+echo "Pointer with Target Region utilising different variable scopes"
+
+./pointer-map-scopes.out
+
+echo "Pointer+Target with Target Region utilising different variable scopes"
+
+./pointer-target-map-scopes.out
+
+echo "Allocatable with Target Region and Enter+Exit utilising different variable scopes"
+
+./allocatable-scopes-enter-exit-map.out
+
+echo "Pointer with Target Region and Enter+Exit utilising different variable scopes"
+
+./pointer-scopes-enter-exit-map.out
+
+echo "Pointer+Target with Target Region and Enter+Exit utilising different variable scopes"
+
+./pointer-target-scopes-enter-exit-map.out
+
+echo "3-D full Allocatable map with Target"
+
+./nd-allocatables-target-map.out
+
+echo "Regular Map Common Block and Utilise OMP builtin"
+
+./target_map_common_block_1.out
+
+echo "Regular Map Common Block and Assign Tmp"
+
+./target_map_common_block_2.out
+
+echo "1-D Allocatable Array sectioning "
+
+./allocatable-array-section-1d-upperbound.out
+
+echo "1-D Pointer Array sectioning "
+
+./pointer-array-section-1d-upperbound.out
+
+echo "1-D Pointer+Target Array sectioning "
+
+./pointer-target-array-section-1d-upperbound.out
+
+echo "1-D Allocatable Array with Array Sectioning in different scopes"
+
+./allocatable-map-scopes-bounds.out
+
+echo "1-D pointer Array with Array Sectioning in different scopes"
+
+./pointer-map-scopes-bounds.out
+
+echo "1-D pointer+target Array with Array Sectioning in different scopes"
+
+./pointer-target-map-scopes-bounds.out
+
+echo "3-D pointer map with bounds for target"
+
+./nd-pointer-bounds-map-syntax.out
+
+echo "3-D allocatables map with bounds for target"
+
+./nd-allocatables-bounds-map-syntax.out
+
+echo "Non-array integer allocatable map for target"
+
+./single-value-alloca.out
+
+echo "Non-array integer allocatable map for target with looped assignment/increment"
+
+./single-value-alloca-loop.out
+
+echo "Target Parallel do, teams distrbute, target and enter + exit"
+
+./target_enter_exit_milestone_3.out 
+
+echo "Target allocatable map with from "
+
+./target-alloca-from-map.out
+
+echo "Target allocatable map with enter+exit binding, remap of same variable and function invocation "
+
+./enter-exit-break-test.out 
+
+echo "Target allocatable map with enter+exit binding and re-map of same variable"
+
+./enter-exit-break-test-2.out 
+
+echo "Target in function with allocatable in parameter allocated then assigned to inside of function utilising target"
+
+./assumed-shape-array-vec-mul-allocatables-with-alloca-param.out
+
+echo "Mapping a single member of a derived type explicitly for a Target region"
+
+./individual-dtype-member-map.out
+
+echo "Mapping multiple members of a derived type explicitly for a Target region"
+
+./multiple-dtype-member-map.out
+
+echo "Mapping a single array member of a derived type explicitly for a Target region"
+
+./individual-dtype-array-member-map.out
+
+echo "Mapping two array members of a single derived type explicitly for a Target region"
+
+./dt-member-array-map.out
+
+echo "Mapping two 3-D array members of a single derived type explicitly for a Target region, with bounds defined"
+
+./dt-member-array-map-2.out
+
+echo "Mapping two 1-D array members of a single derived type explicitly for a Target region, with bounds defined"
+
+./dt-member-array-map-3.out
+
+echo "Mapping two 1-D array members of two derived types explicitly for a Target region, with bounds defined"
+
+./double-dtype-double-arr-map.out
+
+echo "Mapping a single scalar member from two derived types explicitly for a Target region"
+
+./double-dtype-individual-scalar-map.out
+
+echo "Mapping an individual array from a derived type with bounds to a Target region"
+
+./dtype-individual-array-map-with-bounds.out
+
+echo "Double derived type member map with one using explicit and other implicit"
+
+./dtype-exp-imp-member-map.out
+
+echo "Double derived type member array map with one using explicit bounds and other an implicit map"
+
+./dtype-exp-imp-member-map-bounds.out
+
+echo "Tests mapping of a regular 1-D array via enter and exit"
+
+./enter-exit-array-test.out
+
+echo "Tests mapping of a regular 1-D array with bounds via enter and exit"
+
+./enter-exit-array-bounds-test.out
+
+echo "Tests mapping of a regular scalar via enter and exit"
+
+./enter-exit-scalar-test.out
+
+echo "Tests derived type individual explicit member map for enter/exit"
+
+./dtype-enter-exit.out
+
+echo "Tests derived type individual explicit member map for enter/exit/update"
+
+./dtype-enter-exit-update.out
+
+echo "Test allocation of an array and then an always clause in combination with a tofrom map to get results"
+
+./always-map-test.out
+
+echo "Test two allocatable derived types being mapped with variables assigned"
+
+./allocatable-full-struct.out
+
+echo "Map double nested derived types with a scalar array by mapping the full top level derived type" 
+
+./full-dtype-map-with-contained-dtype.out
+
+echo "Implicit capture of declare target link (currently broken, Anchu should make a small PR for it)"
+
+./declare-target-link-implicit.out
+
+echo "Check if an implicit capture of an array allocatables is writeable"
+
+./imp-alloca-write-arr.out
+
+echo "Check if an implicit capture of an scalar allocatables is writeable"
+
+./imp-alloca-write-arr.out
+
+echo "Double dtype double nested array member mapping"
+
+./explicit-nested-array-map.out
+
+echo "Large nested derived type with multiple maps across all levels"
+
+./large-nested-dtype-multi-map.out
+
+echo "Large nested derived type with multiple maps across all levels including allocatable types"
+
+./large-nested-dtype-multi-map-with-allocatables.out
+
+echo "Double large nested derived type with multiple maps across all levels"
+
+./multi-large-nested-dtype-multi-map.out
+
+echo "Small nested derived type with mutiple maps across all levels"
+
+./small-nested-dtype-map.out
+
+echo "Small nested derived type with single nested map of array"
+
+./nested-dtype-single-map.out
+
+echo "Multi nested derived type with single nested map of array"
+
+./multi-nested-dtype-single-map.out
+
+echo "Multi nested derived type with single nested map of array with bounds"
+
+./multi-nested-dtype-single-map-bounds.out
+
+echo "Multi nested derived type with multi nested map of array with bounds"
+
+./multi-nested-dtype-multi-map-bounds.out
+
+echo "Nested derived type with a full nested struct map and other member maps"
+
+./nested-dtype-map-struct.out
+
+echo "Explicit member map of complex in a nested and non-nested dtype"
+
+./nested-dtype-complex-map.out
+
+echo "Explicit member map of scalar allocatable in a dtype"
+
+./dtype-scalar-allocatable.out
+
+echo "Explicit member map of scalar allocatable in a nested dtype"
+
+./nested-dtype-scalar-allocatable.out
+
+echo "Explicit member map of array allocatable in a dtype"
+
+./dtype-array-allocatable.out
+
+echo "Explicit member map of array allocatable in a nested dtype"
+
+./nested-dtype-array-allocatable.out
+
+echo "Explicit member map of array and scalar allocatable in a dtype at same time"
+
+./dtype-double-allocatable.out
+
+echo "Explicit member map of array and scalar allocatable in a nested dtype at same time"
+
+./nested-dtype-double-allocatable.out
+
+echo "Explicit member map of array allocatable and a regular scalar in a dtype at same time"
+
+./dtype-allocatable-scalar-map.out
+
+echo "Explicit member map of array allocatable and a regular scalar in a nested dtype at same time"
+
+./nested-dtype-allocatable-scalar-map.out
+
+echo "Explicit member map of array allocatable and a regular array in a dtype at same time"
+
+./dtype-allocatable-and-array-map.out
+
+echo "Explicit member map of array allocatable and a regular array in a nested dtype at same time"
+
+./nested-dtype-allocatable-and-array-map.out
+
+echo "Explicit member map of array allocatable and a dtype in a dtype at same time"
+
+./dtype-allocatable-and-dtype-map.out
+
+echo "Explicit member map of array allocatable and a dtype in a nested dtype at same time"
+
+./nested-dtype-allocatable-and-dtype-map.out
+
+echo "Explicit member map of array allocatable with bounds in a dtype"
+
+./dtype-allocatable-array-with-bounds-map.out
+
+echo "Explicit member map of array allocatable with bounds in a nested dtype"
+
+./nested-dtype-allocatable-array-with-bounds-map.out
+
+echo "Explicit map of allocatable dtype"
+
+./allocatable-dtype-map.out
+
+echo "Explicit member map of array of an allocatable dtype"
+
+./allocatable-dtype-nested-allocatable-map.out
+
+echo "Explicit member map of an allocatable dtype + allocatable array contained within"
+
+./allocatable-dtype-and-nested-allocatable-map.out
+
+echo "Explicit member map of an allocatable dtype + allocatable array contained within (arguments flipped)"
+
+./allocatable-dtype-and-nested-allocatable-map-v2.out
+
+echo "Allocatable derived type single explicit member map"
+
+./allocatable-dtype-map-exp-member.out
+
+echo "Derived type member map of an array of derived types"
+
+./dtype-array-of-dtype-member-map.out
+
+echo "Derived type member map of an array of derived types inside of allocatable dtype"
+
+./dtype-array-of-dtype-member-map-v2.out
+
+echo "Derived type member map of an allocatable array of derived types"
+
+./dtype-array-of-dtype-member-map-v3.out
+
+echo "Derived type member map of an allocatable array of derived types inside of allocatable dtype"
+
+./dtype-array-of-dtype-member-map-v4.out
+
+echo "Derived type member map with bounds of an allocatable array of derived types inside of allocatable dtype"
+
+./dtype-array-of-dtype-member-map-v5.out
+
+echo "Derived type member map with bounds of an array of derived types"
+
+./dtype-array-of-dtype-member-map-v6.out
+
+echo "Mapping of a single allocatable component of a nested allocatable derived type"
+
+./allocatable-dtype-allocatable-nest-map.out
+
+echo "Mapping two allocatable components of an nested allocatable derived type "
+
+./large-allocatable-nested-dtype-double-map.out
+
+echo "Mapping two allocatable components of an nested allocatable derived type, with multiple nested allocatable dtypes"
+
+./large-allocatable-nested-dtype-double-map-2.out
+
+echo "allocatable dtype with multiple maps of nested allocatable components"
+
+./large-allocatable-nested-dtype-multi-map.out
+
+echo "multiple allocatable dtype with multiple maps of nested allocatable components"
+
+./multi-large-nested-dtype-multi-map-with-allocatables.out
+
+echo "Map an dtype with allocatable array to device using enter/exit and then use a pointer to the array implicitly captured to write the data"
+
+export LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=1
+
+./dtype_pointer_to_member.out
+
+unset LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS
+
+echo "Map an allocatable array nested in allocatable dtype with bounds"
+
+./nested-allocatable-dtype-allocatable-array-with-bounds-map.out
+
+echo "Map an allocatable dtype with a mix of allocatable and non-allocatable members nested in other dtypes"
+
+./large-mixed-nested-dtype-map.out
+
+echo "Map a dtype with a mix of allocatable and non-allocatable members nested in other dtypes"
+
+./large-mixed-nested-dtype-map-2.out
+
+echo "Example from Michael, arrays specified with dimensions contained in derived types mapped to a target and then iterated over"
+
+./michael-map-example.out
+
+echo "Map of full common block over multiple subroutines"
+
+./target_map_common_block_3.out
+
+echo "Map of first variable of common block over multiple subroutines"
+
+./target_map_common_block_4.out
+
+echo "Map of second variable of common block over multiple subroutines"
+
+./target_map_common_block_5.out
+
+echo "Map of all variables of a common block over multiple subroutines"
+
+./target_map_common_block_6.out
+
+echo "A mix of implicit and explicit mapping of common block members alongside a full common block map across subroutines"
+
+./target_map_common_block_7.out
+
+echo "Use of declare target link on a common block alongside a mix of implicit and explicit mapping of common block members alongside a full common block map across subroutines"
+
+./target_map_common_block_8.out
+
+echo "Test new instruction replacement removal does not break anything when used across multiple kernels"
+
+./instruction-replace-test.out
+
+echo "Test a series of derived type member mapping syntax with a non-allocatable derived type"
+
+./dtype-syntax-support.out
+
+echo "Test a series of derived type member mapping syntax with an allocatable derived type"
+
+./dtype-syntax-support-2.out
+
+echo "A map of multiple allocatable components from two seperate (but the same type) allocatable derived types"
+
+./large-nested-allocatable-map-test.out
+
+echo "A map of an allocatable N-D array within a derived type with specified bounds"
+
+./dtype-allocatable-array3d-with-bounds-map.out
+
+echo "Tests that 'from' mappings of allocatables do not segfault or memory access error on device"
+
+./derived-type-map-from-alloca-issue.out
+
+echo "Tests a block inside of a target with an allocatable scalar loop being assigned to, previously a buggy case now works"
+
+./scalar-allocatable-block-map.out
+
+echo "Tests implicit capture of a scalar allocatable is mapped as tofrom as specification requires "
+
+./implicit-single-value-alloca.out
+
+echo "Map a full derived type captured as a class dummy argument in two functions, for both impicit and explicit mapping"
+
+./dtype-class-dummy-full-exp-imp-map.out
+
+echo "Test that no regression of bug with enter/exit mapping of locally scoped arrays occurs, provided there is a matching delete for each enter"
+
+./reproducer-for-471028.out
+
+echo "Check that enter, exit and updates of an array spread across different calls and scopes works reasonably"
+
+./enter-exit-in-different-scopes.out
+
+echo "Test that Jean provided, which checks that we end up with the appropriate lower bound information when using raw input as map values"
+
+./jean-example.out
+
+echo "Reproducer v2 for clvrleaf error checking we do not overwrite data we don't map"
+
+./reproducer-3-47779-v2.out
+
+echo "Declare target enter/to mapping tests where mapped to target, allocatable/array/scalar tested"
+
+./reproducer-SWDEV-471201.out
+
+echo "Declare target enter/to mapping tests where mapped to target data and then updated, allocatable tested"
+
+./reproducer-476419.out
+
+echo "SWDEV-461201 reproducer, check if we have release error on update from with declare target to, resulting in segfault"
+
+./reproducer-SWDEV-471201-v2.out
+
+echo "SWDEV-471201 reproducer, make sure that we are correctly passing the relevant descriptor information across allowing appropriate assignment of values on device to the correct index"
+
+./reproducer-SWDEV-471201-v3.out
+
+echo "Regular Derived Type Member Map Test Checking "hole" punching where we map the parent and then some members seperately with different map types"
+
+./parent-member-overlap-test-1.out
+
+echo "This tests that calling an enter mapping twice before using it on target, doesn't break due to mapping the descriptor imlpicitly with (always, to)"
+
+./pot3d-reproducer.out
+
+echo "test obscure mapping condition that seismic reproducer triggers, which can clash with pot3d reproducer"
+
+./seismic-reproducer.out
+
+echo "test a simplified reproducer of SWDEV-497977"
+
+./simplified-reproducer-497977.out
+
+echo "test reproducer of SWDEV-497977"
+
+./reproducer-497977.out
+
+echo "Check that we at least don't explode when using THREADPRIVATE in the same program as a target region"
+
+./simplified-SWDEV-498999-reproducer.out
+
+echo "Check that we at least don't explode when using THREADPRIVATE in the same program as a target parallel teams distribute region"
+
+./simplified-SWDEV-498999-reproducer-v2.out
+
+echo "Check a simple usage of declare target to with target and update from"
+
+./simple-declare-target-to-target.out
+
+echo "Check a simple declare target to allocatable map to/from using target region and target data"
+
+./declare-target-allocatable-array.out
+
+echo "UMT Reproducer 1: Map nullary pointer to device and set target and modify target data"
+
+./UMT-reproducer.out
+
+echo "UMT Reproducer 5, make sure data is appropriately passed across over multiple enters of the same structure"
+
+./UMT-reproducer-5.out
+
+echo "UMT Reproducer 6 map back re-associate bug"
+
+./UMT-reproducer-6.out
+
+echo "Test mapping of allocatable char array in derived type"
+
+./char-array-map-test-v1.out
+
+echo "Test mapping of char array in derived type"
+
+./char-array-map-test-v2.out
+
+echo "Test intermediate index accessing works reasonably"
+
+./dtype-index-access-test.out
+
+echo "Test if negative bounds provided to allocatable derived type array causes problems"
+
+./neg-bounds-alloca-test.out
+
+echo "Test allocatable array offset for array slices"
+
+./swdev-516059.out 100 100 1 1 30 100 31 60
+
+./swdev-516059.out 100 101 1 1 30 101 31 60
+
+./swdev-516059.out 50 101 2 1 30 100 31 60
+
+./swdev-516059.out 300 201 20 1 30 101 31 60
+
+./swdev-516059.out 300 201 20 10 50 141 41 90
+
+echo "test a basic ref_ptr + ref_ptee example, case 1 (not a fool proof test as need to use smoke-test trace check examples)"
+
+./ref_ptr_ptee_test_1.out
+
+echo "test a basic ref_ptr + ref_ptee example, case 2 (not a fool proof test as need to use smoke-test trace check examples)" 
+
+./ref_ptr_ptee_test_2.out
+
+echo "test that checks ref_ptr works appropriately and allows us to circumvent the descriptor mapping issue by mapping just the data, example 1"
+
+./map_alloc_ref_ptr_ptee.out
+
+echo "test that checks ref_ptr works appropriately and allows us to circumvent the descriptor mapping issue by mapping just the data, example 2"
+
+./map_static_ref_ptr_ptee.out
+
+echo "Check ability to map components of derived type with ref_ptr/ptee v1"
+
+./ref_ptr_ptee_struct_map-v1.out
+
+echo "Check ability to map components of derived type with ref_ptr/ptee v2"
+
+./ref_ptr_ptee_struct_map-v2.out
+
+echo "Test we can enter map a derived types components in a block using ref_ptr/ptee and then execute a target region on the data"
+
+./SWDEV-564425-v2.out
+
+echo "Test we can enter map a derived types components in a block using ref_ptr/ptee and then execute a target region on the data v2"
+
+./SWDEV-564425-v3.out
+
+echo "attach always map test"
+
+export LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0
+
+./attach_always.out
+
+unset LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS
+
+echo "attach never map test"
+
+LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0
+
+./attach_never.out
+
+unset LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS
+
+echo "Test deallocation of a pointer array using ref_ptr/ptee"
+
+./SWDEV-564425-simple.out
+
+echo "Test deallocation of a pointer array inside of a derived type using ref_ptr/ptee"
+
+./SWDEV-564425.out
+
+echo "Test deallocation of multiple pointer members inside of a derived type using ref_ptr/ptee"
+
+./SWDEV-564425-v2.out
+
+echo "ref_ptr_ptee_alloca_struct_map-v1"
+
+./ref_ptr_ptee_alloca_struct_map-v1.out
+
+echo "ref_ptr_ptee_alloca_struct_map-v2"
+
+./ref_ptr_ptee_alloca_struct_map-v2.out
+
+echo "SWDEV-564425-v2-alloca-parent"
+
+./SWDEV-564425-v2-alloca-parent.out
+
+echo "SWDEV-564425-v3-alloca-parent"
+
+./SWDEV-564425-v3-alloca-parent.out
+
+echo "ref_ptr_ptee_alloca_struct_and-children_map-v1"
+
+./ref_ptr_ptee_alloca_struct_and-children_map-v1.out
+
+echo "ref_ptr_ptee_alloca_struct_and-children_map-v2"
+
+./ref_ptr_ptee_alloca_struct_and-children_map-v2.out
+
+echo "SWDEV-564425-v2-alloca-parent-and-children"
+
+./SWDEV-564425-v2-alloca-parent-and-children.out
+
+echo "SWDEV-564425-v3-alloca-parent-and-children"
+
+./SWDEV-564425-v3-alloca-parent-and-children.out
+
+echo "SWDEV-564425-v4-alloca-parent-and-children"
+
+./SWDEV-564425-v4-alloca-parent-and-children.out
+
+echo "SWDEV-564425-v5-alloca-parent-and-children"
+
+./SWDEV-564425-v5-alloca-parent-and-children.out
+
+echo "SWDEV-564425-v4-alloca-parent"
+
+./SWDEV-564425-v4-alloca-parent.out
+
+echo "SWDEV-564425-v5-alloca-parent"
+
+export LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=1
+
+./SWDEV-564425-v5-alloca-parent.out
+
+unset LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS
+
+echo "Actually tests that derived type allcoatable storage is correctly released despite the name"
+
+./test_map_types_omp60.out
+
+# Tests that require XNACK/USM to pass
+
+echo "test declare target enter/to usm works reasonably in simple cases"
+
+export HSA_XNACK=1
+
+./declare-target-enter-usm.out
+
+unset HSA_XNACK
+
+echo "SWDEV-579431 write-back issue caused by inter-mixing of implicit declare mapper"
+
+./SWDEV-579431.out

--- a/test/fortran-map-tests/test_map_types_omp60.F90
+++ b/test/fortran-map-tests/test_map_types_omp60.F90
@@ -1,0 +1,69 @@
+! Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+! SPDX-License-Identifier:  MIT
+
+program prog_a
+  use omp_lib
+  use iso_c_binding, only: c_loc
+  implicit none
+
+  type :: dtype_a
+    integer :: var_a
+    integer, allocatable :: var_b(:)
+  end type dtype_a
+
+  type(dtype_a), target :: var_c
+  integer :: var_d
+
+  var_d = omp_get_default_device()
+  var_c%var_a = 10
+  allocate(var_c%var_b(var_c%var_a))
+  var_c%var_b = 1
+
+  print *, "=== STORAGE Bug Reproducer (OpenMP 6.0) ==="
+  print *, ""
+
+  ! Initial state - nothing on device
+  print *, "Initial:"
+  call sub_a(var_c, var_d, .false.)
+
+  !$omp target enter data map(to: var_c)
+  !$omp target enter data map(to: var_c%var_b)
+  print *, "After ENTER DATA (TO):"
+  call sub_a(var_c, var_d, .false.)
+
+  !$omp target exit data map(storage: var_c%var_b)
+  !$omp target exit data map(storage: var_c)
+  print *, "After EXIT DATA (STORAGE):"
+  call sub_a(var_c, var_d, .true.)
+  print *, ""
+
+  print*, "======= FORTRAN Test passed! ======="
+
+  print *, "If var_c:T above, the bug is present."
+
+  deallocate(var_c%var_b)
+
+contains
+
+  subroutine sub_a(var_e, var_f, var_g)
+    type(dtype_a), target :: var_e
+    logical :: var_g
+    integer :: var_f
+    print '(A,L1,A,L1)', "  var_c:", func_a(var_e%var_a,var_f), "  var_c%var_b:", func_a(var_e%var_b(1),var_f)
+
+    if ( var_g ) then
+      if (func_a(var_e%var_a, var_f) .NEQV. .false.) then
+        print*, "======= FORTRAN Test failed! ======="
+        stop 1
+      endif
+    endif
+  end subroutine
+
+  logical function func_a(var_h, var_f)
+    integer, target :: var_h
+    integer :: var_f
+    func_a = omp_target_is_present(c_loc(var_h), var_f) == 1
+  end function
+
+end program


### PR DESCRIPTION
This PR is aiming to upstream the local map tests I've accumulated over the past 3 years while working on Flang's mapping, some are self-made when developing features, others are JIRA reproducers or variations of them, and the occasional test is probably not even actually a map test! But they're what I use to keep track of breakages alongside check-*, smoke and our nightlies. And they've served me well picking up breakages, so I thought it's about time I spend some time trying to integrate them into aomp for archival reasons.