### PR TITLE
[OpenMP][OMPT] Fix header search path for omptest-based tests

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -387,7 +387,8 @@ else
 endif
 
 # ompTest: Set header include path + linker flag for corresponding OMPT tests
-OMPTEST     = -I$(AOMP)/include/omptest -lomptest
+CLANG_VERSION := $(lastword $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(AOMP)/lib/clang/*/))))))
+OMPTEST = -I$(AOMP)/lib/clang/$(CLANG_VERSION)/include/omptest -lomptest
 
 # ompTest: Set and export CMake config path
 omptest_DIR = $(AOMP)/lib/cmake/openmp/omptest/


### PR DESCRIPTION
Fix libomptest's header search path

For now we assume that only one subdirectory is present within
`${AOMP}/lib/clang/` which is the `${CLANG_VERSION}`.

Note: the installation path for the library is already fixed

## Motivation

Upstream CMake changes had changed build and installation behavior.

## Test Plan

Checked some smoke-fails Make failures, which are fixed by this PR.
For example: `omptest-testsuite``(-emi)(-tracing)`