### PR TITLE
[CK] Increase CK build parallelism

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -13,7 +13,7 @@ CKBenchmarkRepoBranchName='main'
 
 # We grab the total system memory and assume a requirement of 10GB per process
 # when building CK. This is likely a bit conservative.
-CKBuildParallelism=$(free -g | grep Mem | awk '{print int($2/10)}')
+CKBuildParallelism=$(free -g | grep Mem | awk '{print int($2/8)}')
 
 # Check if the user overrode number of parallel build jobs
 # via env var


### PR DESCRIPTION
We used to conservatively estimate 10GB per process for a CK build. In practice it turns out that this is overly conservative and we thus decrease this estimate to 8GB. In turn, this will use more processes to build CK.
