### PR TITLE
[Buildbot] Publish manylinux-based dockerfile

### DIFF
--- a/upstream-buildbots/manylinux-build-only/Dockerfile
+++ b/upstream-buildbots/manylinux-build-only/Dockerfile
@@ -1,0 +1,24 @@
+# Based on TheRock manylinux.
+# To use this dockerfile, please first build the base image as localhost/manyliunx:base 
+# from the following dockerfile:
+# https://github.com/ROCm/TheRock/blob/main/dockerfiles/build_manylinux_x86_64.Dockerfile
+FROM localhost/manylinux:base
+
+# Add ROCm repository.
+COPY rocm.repo /etc/yum.repos.d/rocm.repo
+RUN yum clean packages && yum clean all
+
+# Install minimal ROCm components for buildbot.
+RUN yum install -y \
+    rocm-device-libs \
+    rocm-core \
+    rocminfo \
+    hsa-rocr-devel7.1.1 \
+    && yum clean all && \
+    rm -rf /var/cache/yum
+
+# Update render group GID to match host for GPU access.
+RUN groupmod -g 109 render
+
+# ROCm library path for offload execution.
+ENV LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH

--- a/upstream-buildbots/manylinux-build-only/rocm.repo
+++ b/upstream-buildbots/manylinux-build-only/rocm.repo
@@ -1,0 +1,7 @@
+[rocm]
+name=ROCm 7.1.1 repository
+baseurl=https://repo.radeon.com/rocm/el8/7.1.1/main
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key


### PR DESCRIPTION
Published the manylinux-based dockerfile that we are currently using for the upstream buildbot (https://lab.llvm.org/buildbot/#/builders/226) so that developers can use for reproducing issues and debugging. 