### PR TITLE
[TRUNK] cleanup trunk build scripts making them shellcheck clean. 

### DIFF
--- a/trunk/build_project.sh
+++ b/trunk/build_project.sh
@@ -3,95 +3,79 @@
 #  build_project.sh:  Script to build the trunk compiler. 
 #
 BUILD_TYPE=${BUILD_TYPE:-Release}
-
 # --- Start standard header to set AOMP environment variables ----
-realpath=`realpath $0`
-thisdir=`dirname $realpath`
-. $thisdir/trunk_common_vars
+realpath=$(realpath "$0")
+thisdir=$(dirname "$realpath")
+. "$thisdir/trunk_common_vars"
 # --- end standard header ----
 
-echo "LLVM PROJECTS TO BUILD:$TRUNK_PROJECTS_LIST"
-DO_TESTS=${DO_TESTS:-"-DLLVM_BUILD_TESTS=ON -DLLVM_INCLUDE_TESTS=ON -DCLANG_INCLUDE_TESTS=ON"}
+declare -a _qmathopt
+declare -a _amdflangrtopt
+# Enable AMD-specific Fortran runtime extensions if not skipped
+_amdflangrtopt=(-DFLANG_RT_INCLUDE_AMD=ON)
+# Enable support for real(kind=16) via libquadmath
+_qmathopt=(-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath)
 
-if [ "$AOMP_USE_NINJA" == 0 ] ; then
-    _set_ninja_gan=""
-else
-    _set_ninja_gan="-G Ninja"
-fi
+echo "LLVM PROJECTS TO BUILD:$TRUNK_PROJECTS_LIST"
+#DO_TESTS=${DO_TESTS:-"-DLLVM_BUILD_TESTS=ON -DLLVM_INCLUDE_TESTS=ON -DCLANG_INCLUDE_TESTS=ON"}
+
 if [ "$TRUNK_BUILD_CUDA" == 0 ] ; then
-   _cuda_plugin="-DLIBOMPTARGET_BUILD_CUDA_PLUGIN=OFF"
    _targets_to_build="-DLLVM_TARGETS_TO_BUILD='X86;AMDGPU;SPIRV'"
    _plugins_to_build="-DLIBOMPTARGET_PLUGINS_TO_BUILD='amdgpu;host'"
-   AOMP_NVPTX_CAPS_OPT=""
 else
-   _cuda_plugin="-DLIBOMPTARGET_BUILD_CUDA_PLUGIN=ON"
    _targets_to_build="-DLLVM_TARGETS_TO_BUILD='X86;AMDGPU;NVPTX;SPIRV'"
    _plugins_to_build="-DLIBOMPTARGET_PLUGINS_TO_BUILD='amdgpu;cuda;host'"
 fi
 
-#  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-#  -DFLANG_ENABLE_WERROR=ON \
-#  -DLLVM_VERSION_SUFFIX=_$TRUNK_VERSION_STRING \
-#  -DCLANG_VENDOR=AMD_TRUNK_$TRUNK_VERSION_STRING \
-
-# CMAKE options after LLVM_ENABLE_PROJECTS are NOT on build bot.
-MYCMAKEOPTS="\
--DCMAKE_INSTALL_PREFIX=$TRUNK_INSTALL_DIR \
--DCMAKE_BUILD_TYPE=$BUILD_TYPE \
--DCLANG_DEFAULT_LINKER=lld \
-$DO_TESTS \
-$_targets_to_build \
--DLLVM_ENABLE_ASSERTIONS=ON \
--DLLVM_ENABLE_RUNTIMES='compiler-rt;flang-rt;libunwind;libcxx;libcxxabi;openmp;offload' \
-$_plugins_to_build \
--DCOMPILER_RT_BUILD_ORC=OFF \
--DCOMPILER_RT_BUILD_XRAY=OFF \
--DCOMPILER_RT_BUILD_MEMPROF=OFF \
--DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
--DCOMPILER_RT_BUILD_SANITIZERS=ON \
-$AOMP_CCACHE_OPTS \
--DLLVM_ENABLE_PROJECTS='$TRUNK_PROJECTS_LIST' \
--DLLVM_INSTALL_UTILS=ON \
--DBUILD_SHARED_LIBS=ON \
--DCMAKE_CXX_STANDARD=17 \
-$_cuda_plugin \
--DCLANG_DEFAULT_PIE_ON_LINUX=OFF \
--DFLANG_RUNTIME_F128_MATH_LIB=libquadmath \
-$AOMP_GFXLIST_OPT \
-$AOMP_NVPTX_CAPS_OPT \
-$ENABLE_DEBUG_OPT \
-$LLVM_FORCE_VC_REVISION_OPT \
-$LLVM_FORCE_VC_REPOSITORY_OPT \
--DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
--DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;openmp;flang-rt' \
--DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
--DRUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES='$TRUNK_REPOS/$LLVMPROJECT/compiler-rt/cmake/caches/GPU.cmake;$TRUNK_REPOS/$LLVMPROJECT/libcxx/cmake/caches/AMDGPU.cmake' \
--DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBC_PROVIDER=llvm \
--DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBCXX_PROVIDER=llvm \
-"
-if [ "$TRUNK_BUILD_CUDA" == 0 ] ; then
-   MYCMAKEOPTS+="\
-    -DLLVM_RUNTIME_TARGETS='default;amdgcn-amd-amdhsa' \
-   "
+if [ "$AOMP_USE_NINJA" == 0 ] ; then
+    AOMP_SET_NINJA_GEN=()
 else
-   MYCMAKEOPTS+="\
-    -DLLVM_RUNTIME_TARGETS='default;amdgcn-amd-amdhsa;nvptx64-nvidia-cuda' \
-    -DRUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_RUNTIMES="compiler-rt;libc;openmp;libcxx;libcxxabi;flang-rt" \
-    -DRUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON \
-    -DRUNTIMES_nvptx64-nvidia-cuda_CACHE_FILES='$TRUNK_REPOS/$LLVMPROJECT/compiler-rt/cmake/caches/GPU.cmake;$TRUNK_REPOS/$LLVMPROJECT/libcxx/cmake/caches/NVPTX.cmake' \
-    -DRUNTIMES_nvptx64-nvidia-cuda_FLANG_RT_LIBC_PROVIDER=llvm \
-    -DRUNTIMES_nvptx64-nvidia-cuda_FLANG_RT_LIBCXX_PROVIDER=llvm \
-   "
+    AOMP_SET_NINJA_GEN=(-G Ninja)
 fi
 
-# -DFLANG_RUNTIME_F128_MATH_LIB=libquadmath \
+MYCMAKEOPTS=(-DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+-DCMAKE_INSTALL_PREFIX="$TRUNK_INSTALL_DIR"
+-DCLANG_DEFAULT_LINKER=lld
+"${AOMP_SET_NINJA_GEN[@]}"
+"${_qmathopt[@]}"
+"${_amdflangrtopt[@]}"
+"$_targets_to_build"
+-DLLVM_ENABLE_ASSERTIONS=ON
+"$_plugins_to_build"
+"${AOMP_CCACHE_OPTS[@]}"
+-DLLVM_INCLUDE_TESTS=Off
+-DLLVM_INCLUDE_EXAMPLES=Off
+-DCOMPILER_RT_BUILD_ORC=Off
+-DCOMPILER_RT_BUILD_XRAY=Off
+-DCOMPILER_RT_BUILD_MEMPROF=Off
+-DCOMPILER_RT_BUILD_LIBFUZZER=Off
+-DLLVM_ENABLE_PROJECTS="$TRUNK_PROJECTS_LIST"
+-DLLVM_INSTALL_UTILS=ON
+-DBUILD_SHARED_LIBS=ON
+-DCMAKE_CXX_STANDARD=17
+-DCLANG_DEFAULT_PIE_ON_LINUX=Off
+-DFLANG_RUNTIME_F128_MATH_LIB=libquadmath
+-DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind;openmp;offload;compiler-rt;flang-rt'
+-DLIBCXX_ENABLE_STATIC=ON
+-DLIBCXXABI_ENABLE_STATIC=ON
+-DLLVM_RUNTIME_TARGETS='default;amdgcn-amd-amdhsa;nvptx64-nvidia-cuda'
+-DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
+-DRUNTIMES_amdgcn-amd-amdhsa_LLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;flang-rt;openmp'
+-DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBC_PROVIDER=llvm
+-DRUNTIMES_amdgcn-amd-amdhsa_FLANG_RT_LIBCXX_PROVIDER=llvm
+-DRUNTIMES_amdgcn-amd-amdhsa_CACHE_FILES="'$TRUNK_REPOS/${LLVMPROJECT}/compiler-rt/cmake/caches/GPU.cmake;$TRUNK_REPOS/${LLVMPROJECT}/libcxx/cmake/caches/AMDGPU.cmake'"
+-DRUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON
+-DRUNTIMES_nvptx64-nvidia-cuda_LLVM_ENABLE_RUNTIMES='compiler-rt;libc;libcxx;libcxxabi;flang-rt;openmp'
+-DRUNTIMES_nvptx64-nvidia-cuda_FLANG_RT_LIBC_PROVIDER=llvm
+-DRUNTIMES_nvptx64-nvidia-cuda_FLANG_RT_LIBCXX_PROVIDER=llvm
+-DRUNTIMES_nvptx64-nvidia-cuda_CACHE_FILES="'$TRUNK_REPOS/${LLVMPROJECT}/compiler-rt/cmake/caches/GPU.cmake;$TRUNK_REPOS/${LLVMPROJECT}/libcxx/cmake/caches/NVPTX.cmake'")
 
 if [ "$1" == "-h" ] || [ "$1" == "help" ] || [ "$1" == "-help" ] ; then 
   help_build_trunk
 fi
 
-if [ ! -L $TRUNK_LINK ] ; then 
-   if [ -d $TRUNK_LINK ] ; then 
+if [ ! -L "$TRUNK_LINK" ] ; then 
+   if [ -d "$TRUNK_LINK" ] ; then 
      echo "ERROR: Directory $TRUNK_LINK is a physical directory."
      echo "       It must be a symbolic link or not exist"
      exit 1
@@ -100,84 +84,100 @@ fi
 
 # Make sure we can update the install directory
 if [ "$1" == "install" ] ; then 
-   mkdir -p $TRUNK_INSTALL_DIR
-   touch $TRUNK_INSTALL_DIR/testfile
-   if [ $? != 0 ] ; then 
+   mkdir -p "$TRUNK_INSTALL_DIR"
+   if ! touch "$TRUNK_INSTALL_DIR/testfile" ; then
       echo "ERROR: No update access to $TRUNK_INSTALL_DIR"
       exit 1
-   else
-      echo "Successful No update access to $TRUNK_INSTALL_DIR"
    fi
-   rm $TRUNK_INSTALL_DIR/testfile
+   echo "Successful update access to $TRUNK_INSTALL_DIR"
+   rm "$TRUNK_INSTALL_DIR"/testfile
 fi
 
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo 
    echo "This is a FRESH START. ERASING any previous builds in $BUILD_TRUNK/build/$LLVMPROJECT"
    echo "Use ""$0 nocmake"" or ""$0 install"" to avoid FRESH START."
-   rm -rf $BUILD_TRUNK/build/$LLVMPROJECT
-   mkdir -p $BUILD_TRUNK/build/$LLVMPROJECT
+   rm -rf "$BUILD_TRUNK"/build/"$LLVMPROJECT"
+   mkdir -p "$BUILD_TRUNK"/build/"$LLVMPROJECT"
 else
-   if [ ! -d $BUILD_TRUNK/build/$LLVMPROJECT ] ; then
+   if [ ! -d "$BUILD_TRUNK/build/$LLVMPROJECT" ] ; then
       echo "ERROR: The build directory $BUILD_TRUNK/build/$LLVMPROJECT does not exist"
       echo "       run $0 without nocmake or install options. " 
       exit 1
    fi
 fi
 
-cd $BUILD_TRUNK/build/$LLVMPROJECT
+cd "$BUILD_TRUNK/build/$LLVMPROJECT" || exit 1
 
 if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
    echo
-   echo " -----Running cmake ---- " 
-   echo ${AOMP_CMAKE} $_set_ninja_gan $TRUNK_REPOS/$LLVMPROJECT/llvm -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_ENABLE_ASSERTIONS=ON '-DLLVM_LIT_ARGS=-vv --show-unsupported --show-xfail -j 16' $MYCMAKEOPTS
-   ${AOMP_CMAKE} $_set_ninja_gan $TRUNK_REPOS/$LLVMPROJECT/llvm -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DLLVM_ENABLE_ASSERTIONS=ON '-DLLVM_LIT_ARGS=-vv --show-unsupported --show-xfail -j 16' $MYCMAKEOPTS 2>&1
-   if [ $? != 0 ] ; then 
+   echo " -----Running cmake ---- "
+   MYLITOPTS=(-DLLVM_LIT_ARGS='-vv --show-unsupported --show-xfail -j 16')
+   echo "${AOMP_CMAKE}" "$(shquot "${MYLITOPTS[@]}")" \
+                        "$(shquot "${MYCMAKEOPTS[@]}")" \
+                        "$TRUNK_REPOS/${LLVMPROJECT}/llvm"
+
+   if ! ${AOMP_CMAKE} "${MYLITOPTS[@]}" \
+                      "${MYCMAKEOPTS[@]}" \
+                      "$TRUNK_REPOS/${LLVMPROJECT}/llvm" 2>&1; then
       echo "ERROR cmake failed. Cmake flags"
-      echo "      $MYCMAKEOPTS"
+      echo "      $(shquot "${MYCMAKEOPTS[@]}")"
       exit 1
    fi
 fi
 
-echo
-echo " -----Running $AOMP_NINJA_BIN ---- " 
-echo $AOMP_NINJA_BIN -j $AOMP_JOB_THREADS
-$AOMP_NINJA_BIN -j $AOMP_JOB_THREADS
-if [ $? != 0 ] ; then
-      echo "ERROR $AOMP_NINJA_BIN failed "
-      exit 1
+if [ "$1" = "cmake" ]; then
+   exit 0
+fi
+
+if [ "$AOMP_LIMIT_FLANG" == "1" ] ; then
+   # Required for building flang on memory limited systems.
+   echo "${AOMP_CMAKE} --build . -- -j $AOMP_JOB_THREADS clang lld compiler-rt"
+   ${AOMP_CMAKE} --build . -- -j "$AOMP_JOB_THREADS" clang lld compiler-rt
+
+   echo "${AOMP_CMAKE} --build . -- -j $AOMP_FLANG_THREADS flang"
+   ${AOMP_CMAKE} --build . -- -j "$AOMP_FLANG_THREADS" flang
+fi
+
+# Build llvm-project in one step
+echo " -----Running CMAKE in ${PWD} ---- "
+echo "${AOMP_CMAKE} --build . -j $AOMP_JOB_THREADS"
+if ! ${AOMP_CMAKE} --build . -j "$AOMP_JOB_THREADS"; then
+   echo "ERROR make -j $AOMP_JOB_THREADS failed"
+   exit 1
 fi
 
 if [ "$1" == "install" ] ; then
    echo " -----Installing to $TRUNK_INSTALL_DIR ---- "
-   $AOMP_NINJA_BIN -j $AOMP_JOB_THREADS install
-   if [ $? != 0 ] ; then
-      echo "ERROR $AOMP_NINJA_BIN install failed "
+   echo "$AOMP_CMAKE --install ."
+   if ! "$AOMP_CMAKE" --install . ; then
+      echo "ERROR make install failed "
       exit 1
    fi
-   echo "latest" > $TRUNK_INSTALL_DIR/bin/versionrc
+
+   echo "latest" > "$TRUNK_INSTALL_DIR"/bin/versionrc
    echo " "
    echo "------ Linking $TRUNK_INSTALL_DIR to $TRUNK -------"
-   if [ -L $TRUNK_LINK ] ; then 
-      rm $TRUNK_LINK
+   if [ -L "$TRUNK_LINK" ] ; then 
+      rm "$TRUNK_LINK"
    fi
-   ln -sf $TRUNK_INSTALL_DIR $TRUNK_LINK
+   ln -sf "$TRUNK_INSTALL_DIR" "$TRUNK_LINK"
    # Create binary configs to avoid need to set LD_LIBRARY_PATH
-   cat <<EOD > ${TRUNK_INSTALL_DIR}/bin/rpath.cfg
+   cat <<EOD > "${TRUNK_INSTALL_DIR}"/bin/rpath.cfg
 -Wl,-rpath=<CFGDIR>/../lib
 -Wl,-rpath=<CFGDIR>/../lib/x86_64-unknown-linux-gnu
 -L<CFGDIR>/../lib
 -L<CFGDIR>/../lib/x86_64-unknown-linux-gnu
 EOD
-   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang++.cfg
-   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/clang.cfg
-   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang.cfg
+   ln -sf rpath.cfg "${TRUNK_INSTALL_DIR}"/bin/clang++.cfg
+   ln -sf rpath.cfg "${TRUNK_INSTALL_DIR}"/bin/clang.cfg
+   ln -sf rpath.cfg "${TRUNK_INSTALL_DIR}"/bin/flang.cfg
    # flang-new also appears to be reading flang.cfg
-   ln -sf rpath.cfg ${TRUNK_INSTALL_DIR}/bin/flang-new.cfg
+   ln -sf rpath.cfg "${TRUNK_INSTALL_DIR}"/bin/flang-new.cfg
    (
    # workaround for issue with triple subdir and shared builds
    # problem with libomptarget.so finding dependent libLLVM* libs
-   cd ${TRUNK_INSTALL_DIR}/lib
+   cd "${TRUNK_INSTALL_DIR}"/lib || exit 1
    ln -sf x86_64-unknown-linux-gnu/*{.bc,.so,git} .
    )
    echo

--- a/trunk/trunk_common_vars
+++ b/trunk/trunk_common_vars
@@ -15,7 +15,9 @@ export TRUNK_VERSION_STRING TRUNK_VERSION TRUNK_VERSION_MOD
 
 # Set the install directory TRUNK_INSTALL_DIR
 # TRUNK will be a symbolic link to TRUNK_INSTALL_DIR which has the version number
+#shellcheck disable=SC2034
 TRUNK_LINK=${TRUNK_LINK:-$HOME/rocm/trunk}
+#shellcheck disable=SC2034
 TRUNK_INSTALL_DIR=${TRUNK_LINK}_${TRUNK_VERSION_STRING}
 
 TRUNK_MAJOR_VERSION=${TRUNK_VERSION%.*}
@@ -24,9 +26,11 @@ export TRUNK_MAJOR_VERSION
 LLVM_FORCE_VC_REVISION_OPT=""
 LLVM_FORCE_VC_REPOSITORY_OPT=""
 if [ -n "$LLVM_FORCE_VC_REVISION" ] ; then
+#shellcheck disable=SC2034
    LLVM_FORCE_VC_REVISION_OPT="-DLLVM_FORCE_VC_REVISION=$LLVM_FORCE_VC_REVISION"
 fi
 if [ -n "$LLVM_FORCE_VC_REPOSITORY" ] ; then
+#shellcheck disable=SC2034
    LLVM_FORCE_VC_REPOSITORY_OPT="-DLLVM_FORCE_VC_REPOSITORY=$LLVM_FORCE_VC_REPOSITORY"
 fi
 
@@ -37,12 +41,37 @@ LLVMPROJECT=${LLVMPROJECT:-llvm-project}
 # Set the directory location where all local TRUNK git repos are stored.
 TRUNK_REPOS=${TRUNK_REPOS:-${HOME}/git/trunk${TRUNK_VERSION}}
 
-# The patch control file 
-TRUNK_PATCH_CONTROL_FILE="${TRUNK_REPOS}/aomp/trunk/patches/patch-control-file_$TRUNK_VERSION.txt"
-
 # The cmake and make builds are done in $BUILD_TRUNK/build/<component>, not in the repos.
 # The default for BUILD_TRUNK is TRUNK_REPOS.
 BUILD_TRUNK=${BUILD_TRUNK:-$TRUNK_REPOS}
+
+# Quote argument list suitable for passing as a single (string) argument to
+# cmake.  Result can be used within a double-quoted string, i.e. using
+# "$(cmquot ...)".
+function cmquot() {
+   local escaped_flags
+   local escaped_flag
+   local flag
+   escaped_flags=()
+   for flag in "$@"; do
+      escaped_flag=$(printf "%s" "$flag" | sed 's/\\/\\\\/g; s/\$/\\$/g; s/ /\\ /g; s/"/\\"/g')
+      escaped_flags+=("$escaped_flag")
+   done
+   echo "${escaped_flags[*]}"
+}
+
+# Quote argument list suitable for passing back to the shell as a string.
+# Useful for e.g. dumping argument lists in such a way that they can be safely
+# copy & pasted into the user's terminal.  Output should not be further quoted.
+function shquot() {
+  local -a output
+  output=()
+  for arg in "$@"; do
+#shellcheck disable=SC2206
+    output+=(\'${arg//\'/\'\\\'\'}\')
+  done
+  printf '%s' "${output[*]}"
+}
 
 # We uses RPATH (not) RUNPATH to enforce isolation of this install from other LLVM installs.
 # Also, we consider LD_LIBRARY_PATH is a user feature for user lib development. 
@@ -52,6 +81,7 @@ BUILD_TRUNK=${BUILD_TRUNK:-$TRUNK_REPOS}
 # compiler runtimes, this policy enforces replacement of installed compiler
 # runtime for testing instead of path manipulation. We use $ORIGIN in the
 # RPATH to allow relocation of the installation.
+#shellcheck disable=SC2034
 TRUNK_ORIGIN_RPATH="-DCMAKE_SHARED_LINKER_FLAGS='-Wl,--disable-new-dtags' -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_RPATH='\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../lib64'"
 
 CUDA=${CUDA:-/usr/local/cuda}
@@ -65,7 +95,7 @@ AOMP_USE_NINJA=${AOMP_USE_NINJA:-1}
 if [ "$AOMP_USE_NINJA" == 0 ] ; then
   AOMP_NINJA_BIN="make"
 else
-  AOMP_NINJA_BIN=`which ninja`
+  AOMP_NINJA_BIN=$(which ninja)
   if [ "$AOMP_NINJA_BIN" == "" ] ; then
     AOMP_NINJA_BIN="$AOMP_SUPP/ninja/bin/ninja"
     if [ ! -f "$AOMP_NINJA_BIN" ] ; then
@@ -82,23 +112,25 @@ fi
 
 AOMP_USE_CCACHE=${AOMP_USE_CCACHE:-1}
 if [ "$AOMP_USE_CCACHE" == 0 ] ; then
-  AOMP_CCACHE_OPTS=""
+	AOMP_CCACHE_OPTS=()
 else
-  _ccache_bin=`which ccache`
+  _ccache_bin=$(which ccache)
   if [ "$_ccache_bin" == "" ] ; then
     echo "ERROR: AOMP_USE_CCACHE is $AOMP_USE_CCACHE but no ccache bin found in PATH"
     echo "       Either install ccache or set AOMP_USE_CCACHE=0"
     echo
     exit 1
   fi
-  AOMP_CCACHE_OPTS="-DCMAKE_C_COMPILER_LAUNCHER=$_ccache_bin -DCMAKE_CXX_COMPILER_LAUNCHER=$_ccache_bin"
+#shellcheck disable=SC2034
+  AOMP_CCACHE_OPTS=(-DCMAKE_C_COMPILER_LAUNCHER="$_ccache_bin"
+                    -DCMAKE_CXX_COMPILER_LAUNCHER="$_ccache_bin")
 fi
 
 TRUNK_SKIP_FLANG=${TRUNK_SKIP_FLANG:-0}
 if [ "$TRUNK_SKIP_FLANG" == 1 ] ; then
    TRUNK_PROJECTS_LIST=${TRUNK_PROJECTS_LIST:-"clang;lld;llvm"}
 else
-   TRUNK_PROJECTS_LIST=${TRUNK_PROJECTS_LIST:-"clang;flang;mlir;clang-tools-extra;lld"}
+   TRUNK_PROJECTS_LIST=${TRUNK_PROJECTS_LIST:-"llvm;clang;lld;clang-tools-extra;flang"}
 fi
 TRUNK_COMPONENT_LIST=${TRUNK_COMPONENT_LIST:-"prereq project"}
 
@@ -129,14 +161,14 @@ AOMP_SUPP_BUILD=${AOMP_SUPP_BUILD:-$AOMP_SUPP/build}
 AOMP_SUPP_INSTALL=${AOMP_SUPP_INSTALL:-$AOMP_SUPP/install}
 
 
-if [ -d $AOMP_SUPP/cmake/bin ] ; then 
-   AOMP_CMAKE=${AOMP_CMAKE:-$AOMP_SUPP/cmake/bin/cmake}
+if [ -d "$AOMP_SUPP"/cmake/bin ] ; then 
+   AOMP_CMAKE=${AOMP_CMAKE:-"$AOMP_SUPP"/cmake/bin/cmake}
 else
    AOMP_CMAKE=${AOMP_CMAKE:-cmake}
 fi
 
-GCC=`which gcc`
-GCCXX=`which g++`
+GCC=$(which gcc)
+GCCXX=$(which g++)
 TRUNK_CC_COMPILER=${TRUNK_CC_COMPILER:-$GCC}
 TRUNK_CXX_COMPILER=${TRUNK_CXX_COMPILER:-$GCCXX}
 
@@ -147,145 +179,28 @@ if [ ! -d "$CUDABIN" ] ; then
    TRUNK_BUILD_CUDA=0
 fi
 
-if [ -z $NVPTXGPUS ] ; then
-   AOMP_NVPTX_CAPS_OPT=""
-else
-   AOMP_NVPTX_CAPS_OPT="-DLIBOMPTARGET_NVPTX_COMPUTE_CAPABILITIES='${NVPTXGPUS}'"
-fi
-
 # Set list of default amdgcn subarchitectures to build
 # Developers may override GFXLIST to shorten build time.
 if [ -z "$GFXLIST"  ] ; then
    AOMP_GFXLIST_OPT=""
 else
-   GFXSEMICOLONS=`echo $GFXLIST | tr ' ' ';' `
+   GFXSEMICOLONS=$(echo "$GFXLIST" | tr ' ' ';' )
+#shellcheck disable=SC2034
    AOMP_GFXLIST_OPT="-DLIBOMPTARGET_AMDGCN_GFXLIST='${GFXSEMICOLONS}'"
 fi
 
-# FIXME:
-# Default for LIBOMP_OMPT_SUPPORT is ON. Then, OMPT is supposed to only be
-# enabled when user defines function ompt_start_tool. But that is not the case
-# currently. So we are turning off LIBOMP_OMPT_SUPPORT for build_trunk.sh
-# till resolved by Michael and Dhurva. This eliminates OMPT banner diagnostics
-# from trace when ENABLE_DEBUG is on.
-TRUNK_BUILD_DEBUG=${TRUNK_BUILD_DEBUG:-0}
-if [ "$TRUNK_BUILD_DEBUG" == 0 ] ; then
-  ENABLE_DEBUG_OPT="-DLIBOMP_OMPT_SUPPORT=OFF"
-else
-  ENABLE_DEBUG_OPT="-DLIBOMPTARGET_ENABLE_DEBUG=ON -DLIBOMP_OMPT_SUPPORT=OFF"
-fi
+# build_project.sh for trunk does not use ENABLE_DEBUG_OPT
 
 # Calculate the number of threads to use for make
 NUM_THREADS=
-if [ ! -z `which "getconf"` ]; then
-   NUM_THREADS=$(`which "getconf"` _NPROCESSORS_ONLN)
+if [[ -n $(which "getconf") ]] ; then
+   NUM_THREADS=$(getconf _NPROCESSORS_ONLN)
    NUM_THREADS=$(echo "$NUM_THREADS / 2.75" | bc)
+   echo " ------- Setting AOMP_JOB_THREADS to $NUM_THREADS"
 fi
 AOMP_JOB_THREADS=${AOMP_JOB_THREADS:-$NUM_THREADS}
 
-# These are the web sites where the TRUNK git repos are pulled from
-GITROC="https://github.com/radeonopencompute"
-GITROCLIB="https://github.com/AMDComputeLibraries"
-GITKHRONOS="https://github.com/KhronosGroup"
-
-TRUNK_APPLY_PATCHES=${TRUNK_APPLY_PATCHES:-1}
-
-#  TO use this function set variables patchdir and patchfile
-function patchrepo(){
-patchdir=$1
-if [ "$TRUNK_APPLY_PATCHES" == 1 ] && [ -d "$patchdir" ] ; then
-   patches=""
-   cd $patchdir
-   if [[ "$2" =~ "postinstall" ]]; then
-     getpatchlist $2
-   else
-     getpatchlist
-   fi
-
-   #loop through list of patches to apply
-   if [ "$patches" != "" ] ; then
-   patchloc=${TRUNK_PATCH_CONTROL_FILE%/*}
-   echo patchloc=$patchloc
-   for patch in $patches; do
-     patchfile=$patchloc/$patch
-     echo "Testing patch $patchfile to $patchdir"
-
-     applypatch="yes"
-     patch -p1 -t -N --dry-run <$patchfile >/dev/null
-     if [ $? != 0 ] ; then
-        applypatch="no"
-        # Check to see if reverse patch applies cleanly
-        patch -p1 -R --dry-run -t <$patchfile >/dev/null
-        if [ $? == 0 ] ; then
-           echo "patch $patchfile was already applied to $patchdir"
-        else
-           echo
-           echo "ERROR: Patch $patchfile will not apply"
-           echo "       cleanly to directory $patchdir"
-           echo "       Check if it was already applied."
-           echo
-           exit 1
-        fi
-     fi
-     if [ "$applypatch" == "yes" ] ; then
-        echo "Applying patch $patchfile to $patchdir"
-        patch -p1 --no-backup-if-mismatch <$patchfile
-     fi
-   done
-   fi
-fi
-
-}
-
-function removepatch(){
-patchdir=$1
-if [ "$TRUNK_APPLY_PATCHES" == 1 ] && [ -d "$patchdir" ] ; then
-   patches=""
-   cd $patchdir
-   getpatchlist
-   if [ "$patches" != "" ] ; then
-      echo "Patchdir $patchdir"
-      echo "PATCHES TO REMOVE: $patches"
-   fi
-   patchloc=${TRUNK_PATCH_CONTROL_FILE%/*}
-   if [ "$patches" != "" ] ; then
-   for patch in $patches; do
-     patchfile=$patchloc/$patch
-     echo "Testing reverse patch $patchfile to $patchdir"
-     reversepatch="yes"
-     # Check to see if reverse patch applies cleanly
-     patch -p1 -R --dry-run -f <$patchfile  >/dev/null
-     if [ $? != 0 ] ; then
-        echo "patch $patchfile was NOT applied $patchdir, no patch to reverse"
-        reversepatch="no"
-     fi
-     if [ "$reversepatch" == "yes" ] ; then
-        echo "Reversing patch $patchfile to $patchdir"
-        patch -p1 -R -f --no-backup-if-mismatch <$patchfile
-     fi
-   done
-   fi
-fi
-}
-
-function getpatchlist(){
-   currdir=$(pwd)
-   basedir=$(basename $currdir)
-   if [[ "$1" =~ "postinstall" ]]; then
-     reporegex="(^$1:\s)"
-   else
-     reporegex="(^$basedir:\s)"
-   fi
-   #read patch control file and look for correct patches
-   while read -r line; do
-   if [[ "$line" =~ $reporegex ]]; then
-     #remove basename from list of patches
-     patches=${line/"${BASH_REMATCH[1]}"}
-     echo "patches: $patches"
-     break
-   fi
-   done < "$TRUNK_PATCH_CONTROL_FILE"
-}
+# NOTE:build_trunk.sh and build_project.sh do not do any patching
 
 function help_build_trunk(){
    /bin/cat 2>&1 <<"EOF"


### PR DESCRIPTION
This also deletes a lot of stuff not used by a trunk build.  The best example is patch support and DEBUG builds.  
The new Cmake args here sets up builds for both the amdgcn and nvptx64 target runtimes. 
The two scripts trunk_common_vars and build_project.sh (called by build_trunk.sh) 
are now shellcheck clean. 
These have only been tested on a machine with both amdgcn and nvptx cards. 

Testing on an amdgcn only system without cuda is necessary before merging this. 

This PR will only affect people doing trunk builds. 