### PR TITLE
[Flang] Test for THREADPRIVATE variables in EQUIVALENCE statement

### DIFF
--- a/test/smoke-fort-dev/llvm-180493/Makefile
+++ b/test/smoke-fort-dev/llvm-180493/Makefile
@@ -1,0 +1,19 @@
+#NOOPT        = 1
+#NOOMP        = 1
+#OMP_FLAGS    = -DNO_OMP
+include ../../Makefile.defs
+
+TESTNAME     = equiv
+TESTSRC_MAIN = equiv.f90
+TESTSRC_ALL  = $(TESTSRC_MAIN)
+
+FLANG        = flang
+CFLAGS       = -fopenmp
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+#-ccc-print-phases
+#"-\#\#\#"
+
+RUNCMD       = ./equiv
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/llvm-180493/Makefile
+++ b/test/smoke-fort-dev/llvm-180493/Makefile
@@ -7,7 +7,7 @@ TESTNAME     = equiv
 TESTSRC_MAIN = equiv.f90
 TESTSRC_ALL  = $(TESTSRC_MAIN)
 
-FLANG        = flang
+FLANG        ?= amdflang
 CFLAGS       = -fopenmp
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)

--- a/test/smoke-fort-dev/llvm-180493/equiv.f90
+++ b/test/smoke-fort-dev/llvm-180493/equiv.f90
@@ -18,7 +18,7 @@ program equiv
 
     failed = .false.
 
-    !$omp parallel num_threads(nthreads) shared(failed) private(chk)
+    !$omp parallel num_threads(nthreads) shared(failed) private(i,chk)
         x = 21
         chk = 21
         !$omp masked filter(1)

--- a/test/smoke-fort-dev/llvm-180493/equiv.f90
+++ b/test/smoke-fort-dev/llvm-180493/equiv.f90
@@ -1,0 +1,49 @@
+program equiv
+    use omp_lib
+    implicit none
+    common/ba/ a,b,c
+    integer :: a,b,c
+    integer :: x,y,z
+
+    integer, parameter :: nthreads = 4
+    integer :: i
+    integer :: chk
+
+    logical :: failed
+
+    !$omp threadprivate(/ba/)
+
+    equivalence (x,a)
+    equivalence (y,a)
+
+    failed = .false.
+
+    !$omp parallel num_threads(nthreads) shared(failed) private(chk)
+        x = 21
+        chk = 21
+        !$omp masked filter(1)
+            x = 42
+            chk = 42
+        !$omp end masked
+
+        !$omp barrier
+
+        a = a + omp_get_thread_num()
+        chk = chk + omp_get_thread_num()
+
+        !$omp barrier
+        do i = 0, nthreads-1
+            if (omp_get_thread_num() == i) then
+                print '(I3,I5)', omp_get_thread_num(), a
+                if (chk /= a) then
+                    failed = .true.
+                end if
+            end if
+            !$omp barrier
+        end do
+    !$omp end parallel
+
+    if (failed) then
+        stop 1
+    end if
+end program equiv

--- a/test/smoke-fort-dev/llvm-180493/equiv.f90
+++ b/test/smoke-fort-dev/llvm-180493/equiv.f90
@@ -26,6 +26,11 @@ program equiv
             chk = 42
         !$omp end masked
 
+        !$omp masked filter(2)
+            y = 10
+            chk = 10
+        !$omp end masked
+
         !$omp barrier
 
         a = a + omp_get_thread_num()


### PR DESCRIPTION
Adds smoke test to check if THREADPRIVATE variables in an EQUIVALENCE statement have THREADPRIVATE semantics.  Needs https://github.com/llvm/llvm-project/pull/186696 to land before the test can successfully execute.