### PR TITLE
[CK][CI][NFCI] Make CK run script shellcheck-conformant

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -19,16 +19,16 @@ MaxParallelismMem=$(free -g | grep Mem | awk '{print int($2/8)}')
 CKBuildParallelism=$((MaxParallelismMem > MaxParallelismCpu ? \
                       MaxParallelismCpu : MaxParallelismMem))
 
-# Check if the user overrode number of parallel build jobs
-# via env var
-if [ ! -z ${CK_BUILD_PARALLELISM} ]; then
+# Check if the user overrode number of parallel build jobs via env var
+if [ -n "${CK_BUILD_PARALLELISM}" ]; then
   CKBuildParallelism=${CK_BUILD_PARALLELISM}
 fi
 
-realpath=$(realpath $0)
-thisdir=$(dirname $realpath)
+realpath=$(realpath "$0")
+thisdir=$(dirname "$realpath")
 
-. $thisdir/aomp_common_vars
+# shellcheck disable=SC1091
+. "$thisdir"/aomp_common_vars
 
 export PATH=$AOMP/bin:$PATH
 
@@ -59,11 +59,13 @@ function getIndexListByTargetArch {
   # First, get a detailed list of all available and visible GPUs.
   # Then match lines containing the target arch and capture the bracketed index.
   # Finally, we use xargs to format the results into a tidy, single-line list.
-  OnlyVisibleDevices=""
-  if [ ! -z "${ROCR_VISIBLE_DEVICES}" ]; then
-    OnlyVisibleDevices="$(echo "-d ${ROCR_VISIBLE_DEVICES}" | tr ',' ' ')"
+  OnlyVisibleDevices=()
+  if [ -n "${ROCR_VISIBLE_DEVICES}" ]; then
+    IFS=',' read -ra RocrDevices <<< "${ROCR_VISIBLE_DEVICES}"
+    OnlyVisibleDevices=("-d" "${RocrDevices[@]}")
   fi
-  GPUList="$(rocm-smi --showproductname ${OnlyVisibleDevices})"
+  # FIXME: Transition to 'amd-smi static' at some point
+  GPUList="$(rocm-smi --showproductname "${OnlyVisibleDevices[@]}")"
   GPURegex="s/^GPU\[([0-9]+)\].*${TargetArch}$/\1/p"
   TargetArchIndexList=$(echo "${GPUList}" | sed -En "${GPURegex}" | xargs echo)
 
@@ -78,7 +80,7 @@ function distributeWorkToGPUs {
 
   # Sanity checks
   if [ "${#WorkItems[@]}" -eq 0 ] ||
-    ([ "${#WorkItems[@]}" -eq 1 ] && [ -z "${WorkItems[@]}" ]); then
+    { [ "${#WorkItems[@]}" -eq 1 ] && [ -z "${WorkItems[0]}" ]; }; then
     echo "Error: Received empty list of commands"
     exit 1
   fi
@@ -86,7 +88,7 @@ function distributeWorkToGPUs {
   # Get and count available GPUs (as list)
   GPUList="$(getIndexListByTargetArch "${CK_GPU_TARGETS}")"
   GPUCount=$(echo "${GPUList}" | wc -w)
-  if [ ${GPUCount} -le 0 ]; then
+  if [ "${GPUCount}" -le 0 ]; then
     echo "No target GPUs available"
     exit 1
   fi
@@ -97,7 +99,7 @@ function distributeWorkToGPUs {
   # Run the work items, using GNU parallel
   # Note: {%} provides the job slot (thread) index, {#} the job sequence index
   echo "Running ${#WorkItems[@]} work items in parallel, using ${GPUCount} GPUs"
-  parallel -j ${GPUCount} --line-buffer \
+  parallel -j "${GPUCount}" --line-buffer \
     ' read -ra AvailableGPUs <<< "${GPUList}"
       GPUIndex=$(({%} - 1))
       SelectedGPU=${AvailableGPUs[GPUIndex]}
@@ -230,34 +232,34 @@ while getopts "j:hilrubs:t:" opt; do
 done
 
 # Set the default build prefix, i.e., build-top-level
-: ${CK_TOP:=$AOMP_REPOS_TEST/composable-kernels}
-: ${CK_REPO:=$CK_TOP/rocm-libraries}
-: ${CK_SRC:=$CK_REPO/projects/composablekernel}
-: ${CK_BUILD:=$CK_TOP/ck-build}
-: ${CK_BENCHMARK_REPO:=$CK_TOP/ck-benchmark}
+: "${CK_TOP:=$AOMP_REPOS_TEST/composable-kernels}"
+: "${CK_REPO:=$CK_TOP/rocm-libraries}"
+: "${CK_SRC:=$CK_REPO/projects/composablekernel}"
+: "${CK_BUILD:=$CK_TOP/ck-build}"
+: "${CK_BENCHMARK_REPO:=$CK_TOP/ck-benchmark}"
 # Move this to its own place, to avoid potential permission conflicts with certain setups.
-: ${CK_BENCHMARK_RESULT:=$CK_TOP/ck-benchmark-result}
-: ${CK_INSTALL:=$CK_TOP/ck-install}
-: ${CK_CLIENT_EXAMPLES_SOURCE:=$CK_SRC/client_example}
-: ${CK_CLIENT_EXAMPLES_BUILD:=$CK_TOP/ck-client-examples-build}
+: "${CK_BENCHMARK_RESULT:=$CK_TOP/ck-benchmark-result}"
+: "${CK_INSTALL:=$CK_TOP/ck-install}"
+: "${CK_CLIENT_EXAMPLES_SOURCE:=$CK_SRC/client_example}"
+: "${CK_CLIENT_EXAMPLES_BUILD:=$CK_TOP/ck-client-examples-build}"
 # Run regular and client examples on multiple GPUs (if present)
-: ${CK_EXAMPLES_PARALLEL:='yes'}
-: ${CK_EXAMPLES_PREFIX:='example_'}
-: ${CK_EXAMPLES_LOG_LOCATION:=$CK_TOP/ck-examples-logs}
-: ${CK_TESTS_LOG_LOCATION:=$CK_TOP/ck-tests-logs}
+: "${CK_EXAMPLES_PARALLEL:="yes"}"
+: "${CK_EXAMPLES_PREFIX:="example_"}"
+: "${CK_EXAMPLES_LOG_LOCATION:=$CK_TOP/ck-examples-logs}"
+: "${CK_TESTS_LOG_LOCATION:=$CK_TOP/ck-tests-logs}"
 
 # Some client-examples may take long, override this to skip tests
 # e.g. CK_CLIENT_EXAMPLES_TO_EXCLUDE=("10_grouped_convnd_bwd_data" "24_grouped_conv_activation")
-: ${CK_CLIENT_EXAMPLES_TO_EXCLUDE:=""}
+: "${CK_CLIENT_EXAMPLES_TO_EXCLUDE:=""}"
 
 # Get some info on the system
-: ${ROCM_PATH:=/opt/rocm}
-: ${CK_GPU_TARGETS:=''}
-: ${AOMP_LIB_PATH:="${AOMP}/.."}
+: "${ROCM_PATH:=/opt/rocm}"
+: "${CK_GPU_TARGETS:=""}"
+: "${AOMP_LIB_PATH:="${AOMP}/.."}"
 
-if [ -z ${CK_GPU_TARGETS} ]; then
+if [ -z "${CK_GPU_TARGETS}" ]; then
   NumGpuArchs=$(amdgpu-arch | sort | uniq | wc -l)
-  if [ ${NumGpuArchs} -gt 1 ]; then
+  if [ "${NumGpuArchs}" -gt 1 ]; then
     echo "Error: More than one GPU architecture detected. This may cause issues."
     echo "       Please set the CK_GPU_TARGETS variable to the desired GPU arch."
     exit 1
@@ -270,18 +272,18 @@ fi
 echo "Building for ${CK_GPU_TARGETS}"
 
 # Check if user overrode number of parallel build jobs
-if [ ! -z ${CK_BUILD_PARALLELISM} ]; then
+if [ -n "${CK_BUILD_PARALLELISM}" ]; then
   CKBuildParallelism=${CK_BUILD_PARALLELISM}
 fi
 
-if [ ! -d ${CK_TOP} ]; then
-  mkdir -p ${CK_TOP} || exit 1
+if [ ! -d "${CK_TOP}" ]; then
+  mkdir -p "${CK_TOP}" || exit 1
 fi
 
-if [ ! -d ${CK_REPO} ]; then
-  git clone --single-branch --depth 1 ${CKRepoURL} ${CK_REPO}
+if [ ! -d "${CK_REPO}" ]; then
+  git clone --single-branch --depth 1 ${CKRepoURL} "${CK_REPO}"
 elif [ "${ShouldUpdateCKRepo}" == 'yes' ]; then
-  pushd ${CK_REPO} || exit 1
+  pushd "${CK_REPO}" || exit 1
   git reset --hard origin/${CKRepoBranchName}
   git pull
   # TODO: Write current SHA to somewhere such that it is known which SHA
@@ -314,33 +316,27 @@ CKCmakeCmd+="-DBUILD_DEV=On"
 # Ensure CK build directory is cleaned.
 if [ "${ShouldRebuildCK}" == 'yes' ]; then
   echo "Rebuilding the CK repo w/ ${CKBuildParallelism} parallel jobs."
-  rm -rf ${CK_BUILD} || exit 1
+  rm -rf "${CK_BUILD}" || exit 1
 
   echo "CMake Config Command:"
   echo "${CKCmakeCmd}"
+  ${CKCmakeCmd} || exit 1
 
-  ${CKCmakeCmd}
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
 fi
 
 # Ensure CK install directory is cleaned.
 if [ "${ShouldInstallCK}" == 'yes' ]; then
   echo "Purging previous CK installation directory."
-  rm -rf ${CK_INSTALL} || exit 1
+  rm -rf "${CK_INSTALL}" || exit 1
 fi
 
 # Perform (incremental) CK build
 if [ "${ShouldRebuildCK}" == 'yes' ] || [ "${ShouldInstallCK}" == 'yes' ]; then
-  pushd ${CK_BUILD} || exit 1
+  pushd "${CK_BUILD}" || exit 1
 
   # -k parameter avoids stopping at first error
   # ckProfiler target seems to depend on all library targets, which we want to build first
-  /usr/bin/time -o build-times.tlog ${CKBuildTool} -j ${CKBuildParallelism} -k 0 ckProfiler
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
+  /usr/bin/time -o build-times.tlog ${CKBuildTool} -j "${CKBuildParallelism}" -k 0 ckProfiler || exit 1
 
   # Find build success in the build log
   echo "CK-BUILD-SUCCESS"
@@ -350,13 +346,10 @@ fi
 
 # Perform CK installation
 if [ "${ShouldInstallCK}" == 'yes' ]; then
-  pushd ${CK_BUILD} || exit 1
+  pushd "${CK_BUILD}" || exit 1
 
   # TODO: Check parallelism. This may use all available threads.
-  /usr/bin/time -o install-times.tlog ${CKBuildTool} -k 0 install
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
+  /usr/bin/time -o install-times.tlog ${CKBuildTool} -k 0 install || exit 1
 
   # Find install success in the log
   echo "CK-INSTALL-SUCCESS"
@@ -368,10 +361,10 @@ echo "Run suite: ${SelectedSuite}"
 
 # Check if parallel execution is requested and possible
 UseParallel=0
-if ([ "${SelectedSuite}" == 'client-examples' ] ||
-  [ "${SelectedSuite}" == 'examples' ]) &&
+if { [ "${SelectedSuite}" == 'client-examples' ] ||
+  [ "${SelectedSuite}" == 'examples' ]; } &&
   [ "${CK_EXAMPLES_PARALLEL}" == 'yes' ]; then
-  if [ ! -z "$(command -v parallel)" ]; then
+  if [ -n "$(command -v parallel)" ]; then
     UseParallel=1
   else
     echo "Warning: Parallel execution requested, but 'parallel' is not available"
@@ -383,8 +376,8 @@ if [ "${SelectedSuite}" == 'smoke' ]; then
   if [ ! -d "${CK_TESTS_LOG_LOCATION}" ]; then
     mkdir -p "${CK_TESTS_LOG_LOCATION}" || exit 1
   fi
-  pushd ${CK_BUILD} || exit 1
-  ${CKBuildTool} -j ${CKBuildParallelism} smoke 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/smoke_tests.log"
+  pushd "${CK_BUILD}" || exit 1
+  ${CKBuildTool} -j "${CKBuildParallelism}" smoke 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/smoke_tests.log"
   echo "Log at ${CK_TESTS_LOG_LOCATION}/smoke_tests.log"
   popd || exit 1
 fi
@@ -394,8 +387,8 @@ if [ "${SelectedSuite}" == 'regression' ]; then
   if [ ! -d "${CK_TESTS_LOG_LOCATION}" ]; then
     mkdir -p "${CK_TESTS_LOG_LOCATION}" || exit 1
   fi
-  pushd ${CK_BUILD} || exit 1
-  ${CKBuildTool} -j ${CKBuildParallelism} regression 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/regression_tests.log"
+  pushd "${CK_BUILD}" || exit 1
+  ${CKBuildTool} -j "${CKBuildParallelism}" regression 2>&1 | tee "${CK_TESTS_LOG_LOCATION}/regression_tests.log"
   echo "Log at ${CK_TESTS_LOG_LOCATION}/regression_tests.log"
   popd || exit 1
 fi
@@ -404,25 +397,25 @@ fi
 if [ "${SelectedSuite}" == 'benchmarks' ]; then
   # The CK benchmarks repo appears to be private (for the time being).
 
-  if [ ! -d ${CK_BENCHMARK_REPO} ]; then
+  if [ ! -d "${CK_BENCHMARK_REPO}" ]; then
     echo "CK Benchmarks repo not found. This is a private repo."
     echo "Please clone with your preferred method into ${CK_BENCHMARK_REPO}"
     exit 1
   elif [ "${ShouldUpdateCKBenchmarks}" == 'yes' ]; then
-    pushd ${CK_BENCHMARK_REPO} || exit 1
+    pushd "${CK_BENCHMARK_REPO}" || exit 1
     git reset --hard origin/${CKBenchmarkRepoBranchName}
     git pull
     # TODO: Dump SHA somewhere
     popd || exit 1
   fi
 
-  if [ ! -d ${CK_BENCHMARK_RESULT} ]; then
-    mkdir -p ${CK_BENCHMARK_RESULT} || exit 1
+  if [ ! -d "${CK_BENCHMARK_RESULT}" ]; then
+    mkdir -p "${CK_BENCHMARK_RESULT}" || exit 1
   fi
 
   # Check if a specific test was requested
   # If yes: check if it exists
-  if [ ! -z ${SelectedTest} ]; then
+  if [ -n "${SelectedTest}" ]; then
     if [ ! -f "${CK_BENCHMARK_REPO}/benchmarks/${SelectedTest}" ]; then
       echo "Error: Selected benchmark does not exist:"
       echo "       ${CK_BENCHMARK_REPO}/benchmarks/${SelectedTest}"
@@ -437,14 +430,14 @@ if [ "${SelectedSuite}" == 'benchmarks' ]; then
   # This is the command. It requires the envar CK_PROFILER_DIR to be set to the directory
   # in the CK build tree that contains the CkProfiler binary.
   CKBenchmarkTest="../benchmarks/${SelectedTest}"
-  CKBenchmarkName=$(basename ${CKBenchmarkTest})
+  CKBenchmarkName=$(basename "${CKBenchmarkTest}")
   CKBenchmarkResultOutput="${CK_BENCHMARK_RESULT}/${CKBenchmarkName}.output"
   CKBenchmarkBackend='ck'
   CKBenchmarkCmd="./run_gemm.py ${CKBenchmarkBackend} ${CKBenchmarkTest} --output ${CKBenchmarkResultOutput}"
   CKBenchmarkProfilerExport="export CK_PROFILER_DIR=${CK_BUILD}/bin"
   CKBenchmarkLDLibraryPathExport=$(getLDLibraryPathExportCmd)
 
-  pushd ${CK_BENCHMARK_REPO}/scripts || exit 1
+  pushd "${CK_BENCHMARK_REPO}"/scripts || exit 1
 
   echo "Benchmark Command: ${CKBenchmarkProfilerExport} ; ${CKBenchmarkCmd}"
   ${CKBenchmarkLDLibraryPathExport}
@@ -475,22 +468,14 @@ if [ "${SelectedSuite}" == 'client-examples' ]; then
   fi
 
   echo "Rebuilding the CK client-examples"
-  rm -rf ${CK_CLIENT_EXAMPLES_BUILD} || exit 1
+  rm -rf "${CK_CLIENT_EXAMPLES_BUILD}" || exit 1
 
   echo "CMake Config Command:"
   echo "${CKCmakeCmd}"
+  ${CKCmakeCmd} || exit 1
 
-  ${CKCmakeCmd}
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
-
-  pushd ${CK_CLIENT_EXAMPLES_BUILD} || exit 1
-
-  ${CKBuildTool}
-  if [ $? -ne 0 ]; then
-    exit 1
-  fi
+  pushd "${CK_CLIENT_EXAMPLES_BUILD}" || exit 1
+  ${CKBuildTool} || exit 1
 
   # Process directories to exclude
   # Usage of here-string to avoid sub-shell and removal of potential parentheses
@@ -511,7 +496,7 @@ if [ "${SelectedSuite}" == 'client-examples' ]; then
   # Also, we always want to prune "./CMakeFiles" from the results
   FindArgs+=(-path "*CMakeFiles*" \) -prune -o)
   # If requested, filter the selected tests
-  if [ ! -z ${SelectedTest} ]; then
+  if [ -n "${SelectedTest}" ]; then
     echo "Filtering client-example paths: ./${SelectedTest}"
     FindArgs+=(-path "./${SelectedTest}")
   fi
@@ -541,7 +526,7 @@ if [ "${SelectedSuite}" == 'client-examples' ]; then
 
   NumJobs=${#ExampleRunCmds[@]}
   echo "Found ${NumJobs} client-examples to run"
-  if [ ${NumJobs} == 0 ]; then
+  if [ "${NumJobs}" == 0 ]; then
     # When running this script, we should expect to run something
     # Exit silently, but indicate error via returncode
     exit 1
@@ -576,7 +561,7 @@ if [ "${SelectedSuite}" == 'examples' ]; then
 
   # Build argument list for find
   FindArgs=(. -mindepth 1 -maxdepth 1 -type f)
-  if [ -z ${SelectedTest} ]; then
+  if [ -z "${SelectedTest}" ]; then
     # No filtering requested: select all "*" tests
     SelectedTest="*"
   else
@@ -609,7 +594,7 @@ if [ "${SelectedSuite}" == 'examples' ]; then
 
   NumJobs=${#ExampleRunCmds[@]}
   echo "Found ${NumJobs} examples to run"
-  if [ ${NumJobs} == 0 ]; then
+  if [ "${NumJobs}" == 0 ]; then
     # When running this script, we should expect to run something
     # Exit silently, but indicate error via returncode
     exit 1
@@ -617,8 +602,8 @@ if [ "${SelectedSuite}" == 'examples' ]; then
 
   # Avoid picking up stale logs
   echo "Purging CK examples logs"
-  rm -rf ${CK_EXAMPLES_LOG_LOCATION} || exit 1
-  mkdir -p ${CK_EXAMPLES_LOG_LOCATION} || exit 1
+  rm -rf "${CK_EXAMPLES_LOG_LOCATION}" || exit 1
+  mkdir -p "${CK_EXAMPLES_LOG_LOCATION}" || exit 1
 
   # Run each example
   if [ ${UseParallel} == 1 ]; then


### PR DESCRIPTION
## Motivation

Achieve `shellcheck` compliance across our CI scripts.

## Technical Details

Essentially implemented all `shellcheck` suggestions.

## Test Plan

Ran our CK CI scripts, which are dependent on this run-script.

## Test Result

Generally successful; uncovered a bug unrelated to this change but rather the transition from rocm-smi to amd-smi.
(To be addressed in another PR.)