### PR TITLE
[SROCK] use ninja install instead of rsync from dist/rocm.   See list of other updates below

### DIFF
--- a/srock-bin/README
+++ b/srock-bin/README
@@ -35,13 +35,68 @@ testing based on AOMP environment variable will remain. The srock scripts
 and all support for srock will be managed in the srock-bin subdirectory of
 the aomp repo.
 
+Q:  Can you compare srock operation to aomp operation?
+
+                               AOMP                                    SROCK
+                               ----                                    -----
+REPOS env var                  AOMP_REPOS                              SROCK_REPOS
+
+Default value of
+Repo env var                   $HOME/git/aomp<VERSION>                 /work/$USER/git/srock-repos
+
+Number of RepoS                20+                                     2 (aomp,TheRock)
+
+llvm-project directory         $AOMP_REPOS/llvm-project                $SROCK_REPOS/TheRock/compiler/amd-llvm
+
+llvm-project build dir         $AOMP_REPOS/build/llvm-project          $SROCK_REPOS/build/compiler/amd-llvm/build
+
+How test scripts
+find the compiler               $AOMP                                   $AOMP
+
+setup/clone scripts             aomp/bin/clone_aomp.sh                  aomp/srock-bin/setup_srock.sh
+Build script                    aomp/bin/build_aomp.sh                  aomp/srock-bin/build_srock.sh
+common header script            aomp/bin/aomp_common_vars               aomp/srock-bin/srock_common_vars
+
+Install Dir                     $HOME/rocm/aomp_<VERSION x.y-z>         $HOME/rocm/srock_<VERSION x.y-z>
+Link to install dir             $HOME/rocm/aomp                         $HOME/rocm/srock
+Install env var                 $AOMP_INSTALL_DIR                       $SROCK_INSTALL_DIR
+
 Q: Can one rerun setup_srock.sh ?
 A: NO. If you want to start from scratch, completely remove SROCK_THEROCK_DIR
    which by default is /work/$USER/git/srock-repos/TheRock
 
-Q: Can one rerun post_setup_build_srock.sh ?
+Q: Can one rerun build_srock.sh ?
 A: YES.  This is useful if you have made development changes to any repository.
    Naturally, this is much faster the 2nd time following setup_srock.sh
+
+Q: Is there a more incremental and faster way to rebuild the compiler?
+A: YES.  One of the reasons build_srock.sh can be slow is that compiler changes
+   force a rebuild of rocgdb. To aovid this use ninja install, see step 8 and 9 below.
+
+Q: What is the compiler development flow with srock?
+A:
+1    cd $SROCK_REPOS/aomp/srock-bin
+2      ./setup_srock.sh
+3      ./build_srock.sh
+4    < cd to llvm-project repo >
+5    cd $SROCK_REPOS/TheRock/compiler/amd-llvm
+6    < make desired changes >
+7    < Try incremental compile and install>
+8    cd  $SROCK_REPOS/TheRock/build/compiler/amd-llvm/build
+9    ninja install
+10   < if build fails, go to step 4>
+11   < test your srock compiler. e.g.>
+12      export AOMP=$HOME/rocm/srock
+13      cd $SROCK_REPOS/aomp/test/smoke
+14      ./check_smoke.sh
+15   < if fail, go to step 4>
+16   < update all components including those that use the compiler>
+17   cd $SROCK_REPOS/aomp/srock-bin
+18      ./build_srock.sh
+19   < Prepare and test trunk or amd-staging PR >
+20      cd $SROCK_REPOS/TheRock/compiler/amd-llvm
+21      git diff >$HOME/my.patch
+22      < Apply my.patch to either trunk or downstream amd-staging branch >
 
 Q: Why not just change the submodule file to point compiler repos to amd-staging branch?
 A: TheRock has frequent changes including submodule updates. The setup_srock.sh

--- a/srock-bin/patches/amd-staging/_TheRock.patch
+++ b/srock-bin/patches/amd-staging/_TheRock.patch
@@ -1,8 +1,8 @@
 diff --git a/cmake/therock_subproject.cmake b/cmake/therock_subproject.cmake
-index e8356406..d3373e56 100644
+index 3985c872..d5ebc862 100644
 --- a/cmake/therock_subproject.cmake
 +++ b/cmake/therock_subproject.cmake
-@@ -1410,6 +1410,7 @@ function(_therock_cmake_subproject_setup_toolchain
+@@ -1429,6 +1429,7 @@ function(_therock_cmake_subproject_setup_toolchain
      string(APPEND _toolchain_contents "set(AMDGPU_TARGETS @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
      string(APPEND _toolchain_contents "set(GPU_TARGETS @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
      string(APPEND _toolchain_contents "set(CMAKE_HIP_ARCHITECTURES @_filtered_gpu_targets@ CACHE STRING \"From super-project\" FORCE)\n")
@@ -11,10 +11,10 @@ index e8356406..d3373e56 100644
  
    # General settings applicable to all toolchains.
 diff --git a/compiler/CMakeLists.txt b/compiler/CMakeLists.txt
-index 9db31320..8552b77c 100644
+index eee0b5d5..dfabe601 100644
 --- a/compiler/CMakeLists.txt
 +++ b/compiler/CMakeLists.txt
-@@ -10,6 +10,10 @@ if(THEROCK_ENABLE_COMPILER)
+@@ -13,6 +13,10 @@ if(THEROCK_ENABLE_COMPILER)
    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
      list(APPEND _extra_llvm_cmake_args "-DLLVM_ENABLE_PEDANTIC=OFF")
    endif()
@@ -25,7 +25,7 @@ index 9db31320..8552b77c 100644
  
    # Building Flang is very memory-intensive on systems with many cores. Allow
    # users to specify the level of concurrency for these tasks so they can
-@@ -71,6 +75,9 @@ if(THEROCK_ENABLE_COMPILER)
+@@ -74,6 +78,9 @@ if(THEROCK_ENABLE_COMPILER)
  
        # Features
        -DLLVM_INCLUDE_TESTS=${THEROCK_ENABLE_LLVM_TESTS}
@@ -35,7 +35,7 @@ index 9db31320..8552b77c 100644
        -DLLVM_ENABLE_ZLIB=FORCE_ON
        -DLLVM_ENABLE_Z3_SOLVER=OFF
        -DLLVM_ENABLE_LIBXML2=OFF
-@@ -92,6 +99,9 @@ if(THEROCK_ENABLE_COMPILER)
+@@ -95,6 +102,9 @@ if(THEROCK_ENABLE_COMPILER)
        -DCLANG_ENABLE_CLANGD=OFF
        -DCLANG_TIDY_ENABLE_STATIC_ANALYZER=OFF
  
@@ -46,7 +46,7 @@ index 9db31320..8552b77c 100644
        -DCLANG_TOOL_OFFLOAD_ARCH_BUILD=${THEROCK_CONDITION_IS_NON_WINDOWS}
        -DOPENMP_ENABLE_LIBOMPTARGET=${THEROCK_CONDITION_IS_NON_WINDOWS}
 diff --git a/compiler/artifact-amd-llvm.toml b/compiler/artifact-amd-llvm.toml
-index b0645ebe..54755ad2 100644
+index 6b3ba876..54bc1b14 100644
 --- a/compiler/artifact-amd-llvm.toml
 +++ b/compiler/artifact-amd-llvm.toml
 @@ -7,6 +7,7 @@ unmatched_exclude = [
@@ -58,10 +58,10 @@ index b0645ebe..54755ad2 100644
  
  # LLVM deviates from the defaults in some key ways:
 diff --git a/compiler/pre_hook_amd-llvm.cmake b/compiler/pre_hook_amd-llvm.cmake
-index 48aa6a8b..20ea73f1 100644
+index f84f7f21..aa0af2c2 100644
 --- a/compiler/pre_hook_amd-llvm.cmake
 +++ b/compiler/pre_hook_amd-llvm.cmake
-@@ -121,9 +121,9 @@ set(LLVM_EXTERNAL_PROJECTS "rocm-device-libs;spirv-llvm-translator" CACHE STRING
+@@ -124,9 +124,9 @@ set(LLVM_EXTERNAL_PROJECTS "rocm-device-libs;spirv-llvm-translator" CACHE STRING
  # options to manage this transition but they require knowing the clange resource
  # dir. In order to avoid drift, we just fixate that too. This can all be
  # removed in a future version.
@@ -74,40 +74,3 @@ index 48aa6a8b..20ea73f1 100644
  
  # Setup the install rpath (let CMake handle build RPATH per usual):
  # * Executables and libraries can always search their adjacent lib directory
-diff --git a/profiler/CMakeLists.txt b/profiler/CMakeLists.txt
-index de446e14..af47ddad 100644
---- a/profiler/CMakeLists.txt
-+++ b/profiler/CMakeLists.txt
-@@ -82,11 +82,16 @@ endif(THEROCK_BUILD_TESTING)
-     EXTERNAL_SOURCE_DIR "${THEROCK_ROCM_SYSTEMS_SOURCE_DIR}/projects/rocprofiler-sdk"
-     BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/rocprofiler-sdk"
-     BACKGROUND_BUILD
-+    # INTERFACE_INCLUDE_DIRS not working as expected so add compiler flags
-     CMAKE_ARGS
-+      -DCMAKE_CXX_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-+      -DCMAKE_C_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-       -DHIP_PLATFORM=amd
-       -DROCPROFILER_PYTHON_VERSIONS:STRING="${_detected_python_versions_str}"
-     CMAKE_INCLUDES
-       therock_explicit_finders.cmake
-+    INTERFACE_INCLUDE_DIRS
-+      ${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-     COMPILER_TOOLCHAIN
-       amd-hip
-     RUNTIME_DEPS
-@@ -163,11 +168,15 @@ endif(THEROCK_BUILD_TESTING)
-       # Must build with the HIP compiler.
-       amd-hip
-     CMAKE_ARGS
-+      -DCMAKE_CXX_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-+      -DCMAKE_C_FLAGS=-I${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-       -DHIP_PLATFORM=amd
-     INTERFACE_INCLUDE_DIRS
-       # All old clients of roctx64 expect to just be able to find its include
-       # with no further qualification. Bad design, but also deprecated, so meh.
-       include
-+      # to include hip/* stuff
-+      ${THEROCK_SOURCE_DIR}/build/dist/rocm/include
-     INTERFACE_LINK_DIRS
-       # So that dependents can find the roctx library via find_library()
-       lib

--- a/srock-bin/post_setup_build_srock.sh
+++ b/srock-bin/post_setup_build_srock.sh
@@ -16,16 +16,6 @@ _curdir=$PWD
 _start_date=$(date)
 _start_secs=$(date +%s)
 
-# TWO QUICK CHECKS, MUST HAVE SROCK_REPOS and SROCK_THEROCK_DIR MUST EXIST
-mkdir -p "$SROCK_REPOS"
-if [ ! -d "$SROCK_REPOS" ] ; then
-   echo
-   echo "ERROR: $0 could not create directory $SROCK_REPOS"
-   echo "       Consider setting SROCK_REPOS to use a large fast fileystem."
-   echo "       or $HOME/git/srock-repos"
-   echo
-   exit 1
-fi
 if [ ! -d "$SROCK_THEROCK_DIR" ] ; then
    echo " ERROR:  $0 requires that $SROCK_THEROCK_DIR exist and has "
    echo "         been setup with $thisdir/setup_srock.sh. Please run"
@@ -34,54 +24,6 @@ if [ ! -d "$SROCK_THEROCK_DIR" ] ; then
    echo
    exit 1
 fi
-
-declare -a _cmake_enable
-_cmake_enable=()
-
-# This TheRock config is full build minus failing components
-if [ "$SROCK_CONFIG" == "all" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-      -DTHEROCK_ENABLE_ALL=ON
-      -DTHEROCK_ENABLE_MIOPEN=OFF
-      -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=OFF
-      -DTHEROCK_ENABLE_FFT=OFF
-   )
-fi
-
-# This is full build which could include failing components
-if [ "$SROCK_CONFIG" == "all-debug" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-           -DTHEROCK_ENABLE_ALL=ON )
-fi
-
-# Default is minimal for compiler developers
-if [ "$SROCK_CONFIG" == "minimal" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-      -DTHEROCK_ENABLE_ALL=OFF
-      -DTHEROCK_ENABLE_HIP=ON
-      -DTHEROCK_ENABLE_HIP_RUNTIME=ON
-      -DTHEROCK_ENABLE_HIPIFY=ON
-      -DTHEROCK_BUNDLE_SYSDEPS=ON
-      -DTHEROCK_ENABLE_COMPILER=ON
-   )
-fi
-
-_gfxsemicolons=$(echo "$GFXLIST" | tr ' ' ';')
-_gfamsemicolons=$(echo "$GFXFAM" | tr ' ' ';')
-
-declare -a _cmake_args
-_cmake_args=(-B build -GNinja
-   -DTHEROCK_AMDGPU_TARGETS=\'"$_gfxsemicolons"\'
-   -DTHEROCK_AMDGPU_FAMILIES=\'"$_gfamsemicolons"\'
-   -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=srock
-   -DTHEROCK_BACKGROUND_BUILD_JOBS=1
-   -DTHEROCK_ENABLE_LLVM_TESTS=1
-   "${_cmake_enable[@]}"
-   "$SROCK_THEROCK_DIR"
-)
-
-#  _cmake_enable and _cmake_args are not used in post_setup_build_srock.sh
-#  above is repeated from setup_srock.sh to make the start and end banner useful.
 
 # Print the start banner similar to DONE banner, useful if fails
 echo
@@ -113,33 +55,23 @@ $_cmd
 _rc=$? && [ "$_rc" != 0 ] && cd "$_curdir" && exit "$_rc"
 date
 
-# Usually nothing to do for therock-dist
-cd build || exit
-_cmd="ninja therock-dist"
-echo 
-echo "===== dist CMD: $_cmd"
+echo
+echo "===== Install into $SROCK_INSTALL_DIR"
+cd "$SROCK_THEROCK_DIR/build" || exit
+echo "mkdir -p $SROCK_INSTALL_DIR"
+mkdir -p "$SROCK_INSTALL_DIR"
+_cmd="ninja install"
 $_cmd
 _rc=$? && [ "$_rc" != 0 ] && cd "$_curdir" && exit "$_rc"
 date
 
-echo
-echo "===== copying ROCm build from $SROCK_THEROCK_DIR/build/dest/rocm to $SROCK_INSTALL_DIR" 
-# FIXME: instead of rsync --delete consider using artifact descriptors to copy files to installation
-cd "$SROCK_THEROCK_DIR/build" || exit
-echo "mkdir -p $SROCK_INSTALL_DIR"
-mkdir -p "$SROCK_INSTALL_DIR"
-echo "rsync -a --delete dist/rocm/ $SROCK_INSTALL_DIR/"
-rsync -a --delete dist/rocm/ "$SROCK_INSTALL_DIR"/
-# FileCheck binary not found in dist/rocm, so get it from amd-llvm build
-echo cp -p  ./compiler/amd-llvm/build/bin/FileCheck "$SROCK_INSTALL_DIR/lib/llvm/bin/FileCheck"
-cp -p  ./compiler/amd-llvm/build/bin/FileCheck "$SROCK_INSTALL_DIR/lib/llvm/bin/FileCheck"
-
+# TheRock does not yet build hipfort.
+# FIXME:  remove this stanza and the build_hipfort.sh script when it does
 if [ ! -d "${SROCK_REPOS}/hipfort/build" ] ; then 
    echo
    echo "===== Sourcing build_hipfort.sh to build and install hipfort"
    . "$thisdir/build_hipfort.sh"
 fi
-# FIXME: Add builds for rocdbgapi and rocgdb here 
 
 echo
 echo "===== Creating compiler cfg files "
@@ -180,10 +112,10 @@ echo "      TheRock branch:    $SROCK_THEROCK_BRANCH"
 echo "      Compiler branch:   $SROCK_COMPILER_BRANCH"
 echo "      SROCK config name: $SROCK_CONFIG"
 echo "      cmake command:     $SROCK_CMAKE"
-echo "      cmake args:        ${_cmake_args[*]}"
 echo "      Build time:        $_secs_to_build (seconds)"
 echo "      Files:             $_filecount"
 echo "      Size:              $_size"
+echo "      cmake args:        ${_cmake_args[*]}"
 echo
 echo "      For aomp testing, set AOMP=$SROCK_LINK"
 echo "         or AOMP=$SROCK_INSTALL_DIR"

--- a/srock-bin/prebuild_srock.sh
+++ b/srock-bin/prebuild_srock.sh
@@ -7,8 +7,6 @@
 #  prebuild_srock.sh: Source this file from build_srock.sh
 #     update the srock repo
 #     clone or update hipfort repo
-#     clone or update rocdbgapi repo 
-#     clone or update rocgdb repo 
 #     builds cmake if necessary in ~/local/cmake using
 #
 # --- Start standard header to set SROCK environment variables ----
@@ -60,35 +58,4 @@ echo "      git checkout $SROCK_HIPFORT_BRANCH"
 git checkout $SROCK_HIPFORT_BRANCH
 echo "      git pull"
 git pull
-
-cd $SROCK_REPOS
-echo "= 4 = Cloning or updating rocgdb repo"
-if [ -d $SROCK_REPOS/rocgdb ] ; then
-   echo "      Skipping rocgdb clone, $SROCK_REPOS/rocgdb already exists"
-else
-   echo "      git clone -b $SROCK_ROCGDB_BRANCH https://github.com/ROCm/rocgdb"
-   git clone -b $SROCK_ROCGDB_BRANCH https://github.com/ROCm/rocgdb 2>/dev/null >/dev/null
-fi
-echo "      cd $SROCK_REPOS/rocgdb"
-cd $SROCK_REPOS/rocgdb
-echo "      git checkout $SROCK_ROCGDB_BRANCH"
-git checkout $SROCK_ROCGDB_BRANCH
-echo "      git pull"
-git pull
-
-cd $SROCK_REPOS
-echo "= 5 = Cloning or updating rocdbgapi repo"
-if [ -d $SROCK_REPOS/rocdbgapi ] ; then
-   echo "      Skipping rocdbgapi clone, $SROCK_REPOS/rocdbgapi already exists"
-else
-   echo "      git clone -b $SROCK_ROCDBGAPI_BRANCH https://github.com/ROCm/rocdbgapi"
-   git clone -b $SROCK_ROCDBGAPI_BRANCH https://github.com/ROCm/rocdbgapi 2>/dev/null >/dev/null
-fi
-echo "      cd $SROCK_REPOS/rocdbgapi"
-cd $SROCK_REPOS/rocdbgapi
-echo "      git checkout $SROCK_ROCDBGAPI_BRANCH"
-git checkout $SROCK_ROCGDBGAPI_BRANCH
-echo "      git pull"
-git pull
-
 

--- a/srock-bin/setup_srock.sh
+++ b/srock-bin/setup_srock.sh
@@ -12,27 +12,8 @@ thisdir=$(dirname "$realpath")
 # shellcheck disable=1091
 . "$thisdir/srock_common_vars"
 # --- end standard header ----
-function test_apply_patch() {
-   if ! patch -p1 -t -N --merge --dry-run < "$_patch_file"  >/dev/null; then
-      echo "ERROR:  patch --dry-run failed.  Could not apply $_patch_file "
-      cd "$_curdir" || exit 1
-      exit 1
-   else
-      echo "patch -p1 --no-backup-if-mismatch --merge < $_patch_file"
-      patch -p1 --no-backup-if-mismatch --merge < "$_patch_file"
-   fi
-}
+#
 
-# TWO QUICK CHECKS, MUST HAVE SROCK_REPOS and SROCK_THEROCK_DIR MUST NOT EXIST
-mkdir -p "$SROCK_REPOS"
-if [ ! -d "$SROCK_REPOS" ] ; then
-   echo
-   echo "ERROR: $0 could not create directory $SROCK_REPOS"
-   echo "       Consider setting SROCK_REPOS to use a large fast fileystem."
-   echo "       or $HOME/git/srock-repos"
-   echo
-   exit 1
-fi
 if [ -d "$SROCK_THEROCK_DIR" ] ; then
    echo " ERROR:  $0 requires that $SROCK_THEROCK_DIR NOT exist"
    echo "         Delete or move that directory to run $0"
@@ -42,51 +23,6 @@ fi
 _curdir=$PWD
 _start_date=$(date)
 _start_secs=$(date +%s)
-
-declare -a _cmake_enable
-_cmake_enable=()
-
-# This TheRock config is full build minus failing components
-if [ "$SROCK_CONFIG" == "all" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-      -DTHEROCK_ENABLE_ALL=ON
-      -DTHEROCK_ENABLE_MIOPEN=OFF
-      -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=OFF
-      -DTHEROCK_ENABLE_FFT=OFF
-   )
-fi
-
-# This is full build which could include failing components
-if [ "$SROCK_CONFIG" == "all-debug" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-	   -DTHEROCK_ENABLE_ALL=ON )
-fi
-
-# Default is minimal for compiler developers
-if [ "$SROCK_CONFIG" == "minimal" ] ; then
-   _cmake_enable=("${_cmake_enable[@]}"
-      -DTHEROCK_ENABLE_ALL=OFF
-      -DTHEROCK_ENABLE_HIP=ON
-      -DTHEROCK_ENABLE_HIP_RUNTIME=ON
-      -DTHEROCK_ENABLE_HIPIFY=ON
-      -DTHEROCK_BUNDLE_SYSDEPS=ON
-      -DTHEROCK_ENABLE_COMPILER=ON
-   )
-fi
-
-_gfxsemicolons=$(echo "$GFXLIST" | tr ' ' ';')
-_gfamsemicolons=$(echo "$GFXFAM" | tr ' ' ';')
-
-declare -a _cmake_args
-_cmake_args=(-B build -GNinja
-   -DTHEROCK_AMDGPU_TARGETS=\'"$_gfxsemicolons"\'
-   -DTHEROCK_AMDGPU_FAMILIES=\'"$_gfamsemicolons"\'
-   -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=srock
-   -DTHEROCK_BACKGROUND_BUILD_JOBS=1
-   -DTHEROCK_ENABLE_LLVM_TESTS=1
-   "${_cmake_enable[@]}"
-   "$SROCK_THEROCK_DIR"
-)
 
 # Print the start banner similar to DONE banner, useful if fails
 echo
@@ -110,6 +46,12 @@ cd "$SROCK_REPOS" || exit
 echo
 echo "===== git clone https://github.com/ROCm/TheRock.git -b $SROCK_THEROCK_BRANCH TheRock"
 git clone https://github.com/ROCm/TheRock.git -b "$SROCK_THEROCK_BRANCH" TheRock
+if [ -f TheRock/version.json ] ; then 
+   _quoted=$(cat TheRock/version.json | grep rocm-version | cut -d: -f2)
+   _rocm_version=${_quoted//\"/}
+   echo " ROCm components version : $_rocm_version"
+   echo " SROCK_VERSION_STRING    :  $SROCK_VERSION_STRING (Compiler dev version)"
+fi
 
 cd "$SROCK_THEROCK_DIR" || exit
 
@@ -214,16 +156,18 @@ _secs_to_setup=$(( _setup_secs - _start_secs ))
 
 echo
 echo "===== DONE $0 on $_start_date"
-echo "      THEROCK targets:   $_gfxsemicolons"
-echo "      THEROCK families:  $_gfamsemicolons"
-echo "      ROCm install dir:  $SROCK_INSTALL_DIR"
-echo "      TheRock Dir:       $SROCK_THEROCK_DIR"
-echo "      TheRock branch:    $SROCK_THEROCK_BRANCH"
-echo "      Compiler branch:   $SROCK_COMPILER_BRANCH"
-echo "      SROCK config name: $SROCK_CONFIG"
-echo "      Setup time:        $_secs_to_setup (seconds)"
-echo "      cmake args:        ${_cmake_args[*]}"
+echo "   THEROCK targets:      $_gfxsemicolons"
+echo "   ROCm comp version:    $_rocm_version"
+echo "   SROCK_VERSION_STRING: $SROCK_VERSION_STRING (Compiler dev version)"
+echo "   THEROCK families:     $_gfamsemicolons"
+echo "   ROCm install dir:     $SROCK_INSTALL_DIR"
+echo "   TheRock Dir:          $SROCK_THEROCK_DIR"
+echo "   TheRock branch:       $SROCK_THEROCK_BRANCH"
+echo "   Compiler branch:      $SROCK_COMPILER_BRANCH"
+echo "   SROCK config name:    $SROCK_CONFIG"
+echo "   Setup time:           $_secs_to_setup (seconds)"
+echo "   cmake args:           ${_cmake_args[*]}"
 echo 
-echo " Next step, run: $thisdir/post_setup_build_srock.sh" 
+echo " Next step, run this command: $thisdir/build_srock.sh" 
 echo 
 

--- a/srock-bin/srock_common_vars
+++ b/srock-bin/srock_common_vars
@@ -14,6 +14,17 @@
 #  You should set SROCK_REPOS to an updateable high performance and
 #  large capacity (100GB+) directory 100GB+
 
+function test_apply_patch() {
+   if ! patch -p1 -t -N --merge --dry-run < "$_patch_file"  >/dev/null; then
+      echo "ERROR:  patch --dry-run failed.  Could not apply $_patch_file "
+      cd "$_curdir" || exit 1
+      exit 1
+   else
+      echo "patch -p1 --no-backup-if-mismatch --merge < $_patch_file"
+      patch -p1 --no-backup-if-mismatch --merge < "$_patch_file"
+   fi
+}
+
 SROCK="NEVER_USE_'\$SROCK'_ENV_VARIABLE" # Use SROCK_LINK
 
 #  SROCK_REPOS is the parent directory for TheRock and srock repos.  
@@ -23,8 +34,8 @@ if [ ! -d $SROCK_REPOS ] ; then
   [ $? != 0 ] && echo "ERROR: Could not create $SROCK_REPOS" && exit 1
 fi
 
-SROCK_VERSION=${SROCK_VERSION:-"23.0"}
-SROCK_VERSION_MOD=${SROCK_VERSION_MOD:-"3"}
+SROCK_VERSION=${SROCK_VERSION:-"7.13"}
+SROCK_VERSION_MOD=${SROCK_VERSION_MOD:-"0"}
 SROCK_VERSION_STRING=${SROCK_VERSION_STRING:-"$SROCK_VERSION-$SROCK_VERSION_MOD"}
 SROCK_MAJOR_VERSION=${SROCK_VERSION%.*}
 
@@ -116,3 +127,62 @@ if [ $_build_cmake == 1 ] ; then
    SROCK_CMAKE=$_cmake_local
 fi
 export SROCK_CMAKE
+
+# TWO QUICK CHECKS, MUST HAVE SROCK_REPOS and SROCK_THEROCK_DIR MUST NOT EXIST
+mkdir -p "$SROCK_REPOS"
+if [ ! -d "$SROCK_REPOS" ] ; then
+   echo
+   echo "ERROR: $0 could not create directory $SROCK_REPOS"
+   echo "       Consider setting SROCK_REPOS to use a large fast fileystem."
+   echo "       or $HOME/git/srock-repos"
+   echo
+   exit 1
+fi
+
+declare -a _cmake_enable
+_cmake_enable=()
+
+# This TheRock config is full build minus failing components
+if [ "$SROCK_CONFIG" == "all" ] ; then
+   _cmake_enable=("${_cmake_enable[@]}"
+      -DTHEROCK_ENABLE_ALL=ON
+      -DTHEROCK_ENABLE_MIOPEN=OFF
+      -DTHEROCK_ENABLE_COMPOSABLE_KERNEL=OFF
+      -DTHEROCK_ENABLE_FFT=OFF
+   )
+fi
+
+# This is full build which could include failing components
+if [ "$SROCK_CONFIG" == "all-debug" ] ; then
+   _cmake_enable=("${_cmake_enable[@]}"
+	   -DTHEROCK_ENABLE_ALL=ON )
+fi
+
+# Default is minimal for compiler developers
+if [ "$SROCK_CONFIG" == "minimal" ] ; then
+   _cmake_enable=("${_cmake_enable[@]}"
+      -DTHEROCK_ENABLE_ALL=OFF
+      -DTHEROCK_ENABLE_HIP_RUNTIME=ON
+      -DTHEROCK_ENABLE_HIPIFY=ON
+      -DTHEROCK_BUNDLE_SYSDEPS=ON
+      -DTHEROCK_ENABLE_COMPILER=ON
+      -DTHEROCK_ENABLE_AMD_DBGAPI=ON
+      -DTHEROCK_ENABLE_ROCGDB=ON
+   )
+fi
+
+_gfxsemicolons=$(echo "$GFXLIST" | tr ' ' ';')
+_gfamsemicolons=$(echo "$GFXFAM" | tr ' ' ';')
+
+declare -a _cmake_args
+_cmake_args=(-B build -GNinja
+   -DCMAKE_INSTALL_PREFIX="$SROCK_INSTALL_DIR"
+   -DTHEROCK_AMDGPU_TARGETS=\'"$_gfxsemicolons"\'
+   -DTHEROCK_AMDGPU_FAMILIES=\'"$_gfamsemicolons"\'
+   -DTHEROCK_AMDGPU_DIST_BUNDLE_NAME=srock
+   -DTHEROCK_BACKGROUND_BUILD_JOBS=1
+   -DTHEROCK_ENABLE_LLVM_TESTS=1
+   "${_cmake_enable[@]}"
+   "$SROCK_THEROCK_DIR"
+)
+


### PR DESCRIPTION
  - Replace rsync install with direct install by TheRock with -DCMAKE_INSTALL_PREFIX="$SROCK_INSTALL_DIR"
  - Removed patch to profiler/CMakeLists.txt
  - Moved SROCK_CONFIG settings to srock_common_vars
  - Removed -DTHEROCK_ENABLE_HIP
  - Removed special cloning of ROCGDB and ROCDGBAPI because they are now included with TheRock build
  - Added -DTHEROCK_ENABLE_AMD_DBGAPI=ON -DTHEROCK_ENABLE_ROCGDB=ON to the default "minimal" build. 
    Also removed build of amddbgapi and rocgdb in prebuild_srock.sh
  - Added a note in the log to show the ROCm version found in version.json as well as the SROCK_VERSION_STRING
  - Removed script copying of FileCheck because TheRock builds and installs it.
  - Improved the README to better compare AOMP to SROCK and documented the compiler development flow with srock.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
