### PR TITLE
[smoke-fort] Fix flang-535416* tests

### DIFF
--- a/test/smoke-fort-fails/flang-535416-O0/Makefile
+++ b/test/smoke-fort-fails/flang-535416-O0/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -O0 $(FLANG_GPU_LINK_FLAGS)
+CFLAGS       = -O0 $(FLANG_GPU_LINK_FLAGS) -mmlir --enable-gpu-heap-alloc
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535416-O0/test.f90
+++ b/test/smoke-fort-fails/flang-535416-O0/test.f90
@@ -46,6 +46,7 @@ MODULE rep
 
   IF(ANY(ABS(b-2.0_8)>1.0e-9_8)) THEN
     WRITE(*,*) "failed",b(1,1,1), b(2,1,1)
+    STOP 1
   ELSE
     WRITE(*,*) "success"
   END IF

--- a/test/smoke-fort-fails/flang-535416-O2/Makefile
+++ b/test/smoke-fort-fails/flang-535416-O2/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -O2 $(FLANG_GPU_LINK_FLAGS)
+CFLAGS       = -O2 $(FLANG_GPU_LINK_FLAGS) -mmlir --enable-gpu-heap-alloc
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535416-O2/test.f90
+++ b/test/smoke-fort-fails/flang-535416-O2/test.f90
@@ -46,6 +46,7 @@ MODULE rep
 
   IF(ANY(ABS(b-2.0_8)>1.0e-9_8)) THEN
     WRITE(*,*) "failed",b(1,1,1), b(2,1,1)
+    STOP 1
   ELSE
     WRITE(*,*) "success"
   END IF

--- a/test/smoke-fort-fails/flang-535416-no-aassign/Makefile
+++ b/test/smoke-fort-fails/flang-535416-no-aassign/Makefile
@@ -9,7 +9,7 @@ TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
 FLANG        = flang
-CFLAGS       = -O2
+CFLAGS       = -O2 -mmlir -enable-gpu-heap-alloc
 OMP_BIN      = $(AOMP)/bin/$(FLANG)
 CC           = $(OMP_BIN) $(VERBOSE)
 #-ccc-print-phases

--- a/test/smoke-fort-fails/flang-535416-no-aassign/test.f90
+++ b/test/smoke-fort-fails/flang-535416-no-aassign/test.f90
@@ -48,6 +48,7 @@ MODULE rep
 
   IF(ANY(ABS(b-2.0_8)>1.0e-9_8)) THEN
     WRITE(*,*) "failed",b(1,1,1), b(2,1,1)
+    STOP 1
   ELSE
     WRITE(*,*) "success"
   END IF


### PR DESCRIPTION
Scope of changes:

1. Improved error checking. Added stop statements if the result is wrong
2. Enabled dynamic memory allocation for private adjustable arrays.