### PR TITLE
[build] - Remove old offload standalone build in favor of runtimes build

### DIFF
--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -98,7 +98,7 @@ echo
 components="$AOMP_COMPONENT_LIST"
 
 if [ "$AOMP_STANDALONE_BUILD" == 1 ] ; then
-  components="$components rocprofiler-register rocr llvm_runtimes_standalone offload extras comgr rocminfo rocm_smi_lib amdsmi"
+  components="$components rocprofiler-register rocr llvm_runtimes_standalone extras comgr rocminfo rocm_smi_lib amdsmi"
   _hostarch=$(uname -m)
   # The rocclr architecture is very x86 centric so it will not build on ppc64. Without
   # rocclr, we have no HIP or OpenCL for ppc64 :-( However, rocr works for ppc64 so AOMP works.

--- a/bin/build_aomp.sh
+++ b/bin/build_aomp.sh
@@ -132,7 +132,7 @@ else
   # libdevice, project, comgr, rocminfo, hipamd, rocdbgapi, rocgdb,
   # roctracer, rocprofiler, rocm_smi_lib, and amdsmi should be found
   # in ROCM in /opt/rocm.  The ROCM build only needs these components:
-  components="llvm_runtimes_standalone offload"
+  components="llvm_runtimes_standalone"
   if [ "$AOMP_SKIP_FLANG" == 0 ] ; then
     if [ "$SANITIZER" == 1 ] && [ -f "$AOMP/bin/flang-classic" ] ; then
       components="$components pgmath flang flang_runtime"

--- a/bin/build_llvm_runtimes_standalone.sh
+++ b/bin/build_llvm_runtimes_standalone.sh
@@ -79,7 +79,7 @@ COMMON_CMAKE_OPTS=("${AOMP_SET_NINJA_GEN[@]}" -DOPENMP_ENABLE_LIBOMPTARGET=1
                    -DLLVM_DIR="$LLVM_DIR"
                    -DLIBOMPTEST_BUILD_STANDALONE=1 -DLIBOMPTARGET_BUILD_DEVICE_FORTRT=On)
 
-LLVM_RUNTIMES="openmp"
+LLVM_RUNTIMES="openmp;offload"
 if [ "$OPENMP_BUILD_DEVICERTL" -eq 1 ]; then
   if [ -f "$AOMP_REPOS/$AOMP_PROJECT_REPO_NAME/openmp/device/CMakeLists.txt" ]; then
     LLVM_RUNTIMES=openmp
@@ -526,8 +526,8 @@ fi # end of install block
 
 # We have to build the deviceRTL by itself as it requires a different target
 if [ "$1" != "install" ] && [ "$OPENMP_BUILD_DEVICERTL" == 0 ] ; then
-  RUNTIMES_BUILD_DIR="llvm_runtimes_standalone-devicertl" OPENMP_BUILD_DEVICERTL=1 $thisdir/build_llvm_runtimes_standalone.sh
+  RUNTIMES_BUILD_DIR="llvm_runtimes_standalone-devicertl" OPENMP_BUILD_DEVICERTL=1 "$thisdir"/build_llvm_runtimes_standalone.sh
 fi
 if [ "$1" == "install" ] && [ "$OPENMP_BUILD_DEVICERTL" == 0 ]; then
-  RUNTIMES_BUILD_DIR="llvm_runtimes_standalone-devicertl" OPENMP_BUILD_DEVICERTL=1 $thisdir/build_llvm_runtimes_standalone.sh install
+  RUNTIMES_BUILD_DIR="llvm_runtimes_standalone-devicertl" OPENMP_BUILD_DEVICERTL=1 "$thisdir"/build_llvm_runtimes_standalone.sh install
 fi


### PR DESCRIPTION
This deprecates build_offload.sh and adds offload to the LLVM_ENABLE_RUNTIMES list in build build_llvm_runtimes_standalone.sh. OPENMP_STANDALONE_BUILD has been removed upstream for both openmp and offload.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
