### PR TITLE
[lint] Run shellcheck in file's directory

### DIFF
--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             file_dir=$(dirname "$file")
+            file_name=$(basename "$file")
             if [[ $file == *.sh ]]; then
               echo "Running shellcheck on $file in directory $file_dir"
               pushd "$file_dir"
-              shellcheck -x "$file"
+              shellcheck -x "$file_name"
               popd
             fi
           done

--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -29,9 +29,12 @@ jobs:
       - name: Run shellcheck
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            file_dir=$(dirname "$file")
             if [[ $file == *.sh ]]; then
-              echo "Running shellcheck on $file"
+              echo "Running shellcheck on $file in directory $file_dir"
+              pushd "$file_dir"
               shellcheck -x "$file"
+              popd
             fi
           done
         shell: bash {0}

--- a/utils/kokkos_build-cgsolve.sh
+++ b/utils/kokkos_build-cgsolve.sh
@@ -41,7 +41,7 @@ function print_error() {
 
 AOMP="${AOMP:-_AOMP_INSTALL_DIR_}"
 
-if [ ! -d $AOMP ] ; then
+if [ ! -d "${AOMP}" ] ; then
    print_error "AOMP is not installed in ${AOMP}. Please set the environment variable."
    exit 1
 fi


### PR DESCRIPTION
To make shellcheck relative file paths without the `SCRIPTDIR` variable more meaningful.