### PR TITLE
[Lint] Use shellcheck return code as action status

### DIFF
--- a/.github/workflows/aomp-shell.yml
+++ b/.github/workflows/aomp-shell.yml
@@ -28,14 +28,22 @@ jobs:
 
       - name: Run shellcheck
         run: |
+          shellcheck_status=0
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-            file_dir=$(dirname "$file")
-            file_name=$(basename "$file")
             if [[ $file == *.sh ]]; then
+              file_dir=$(dirname "$file")
+              file_name=$(basename "$file")
+
               echo "Running shellcheck on $file in directory $file_dir"
               pushd "$file_dir"
+
               shellcheck -x "$file_name"
+              if [ $? -ne 0 ]; then
+                shellcheck_status=1
+              fi
+
               popd
             fi
           done
+          exit $shellcheck_status
         shell: bash {0}

--- a/utils/kokkos_build-cgsolve.sh
+++ b/utils/kokkos_build-cgsolve.sh
@@ -53,7 +53,7 @@ KOKKOS_EXAMPLES_REPO=https://github.com/kokkos/kokkos-openmptarget-examples.git
 NUM_THREADS=${NUM_THREADS:-8}
 
 COMPILERNAME_TO_USE=${_COMPILER_TO_USE_:-clang++}
-AOMP_VERSION=$($AOMP/bin/${COMPILERNAME_TO_USE} --version | head -n 1)
+# AOMP_VERSION=$($AOMP/bin/${COMPILERNAME_TO_USE} --version | head -n 1)
 
 cd $GIT_DIR || exit 1
 


### PR DESCRIPTION
This makes the return code from shellcheck be reported as the status of the GitHub action, i.e., if shellcheck fails, the job should fail too.
