### PR TITLE
[AOMP] fix build_rocminfo.sh so that it gets hsa includes from aomp i…

### DIFF
--- a/bin/build_rocminfo.sh
+++ b/bin/build_rocminfo.sh
@@ -81,6 +81,7 @@ if [ "$1" != "nocmake" ] && [ "$1" != "install" ] ; then
 
   MYCMAKEOPTS=("${AOMP_ORIGIN_RPATH[@]}" -DCMAKE_BUILD_TYPE="$BUILDTYPE"
                -DCMAKE_INSTALL_PREFIX="$INSTALL_RINFO"
+               -DROCMINFO_CXX_FLAGS="-I$INSTALL_RINFO/include"
                -DROCRTST_BLD_TYPE="$BUILDTYPE"
                -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
                -DCMAKE_INSTALL_RPATH="\$ORIGIN/../lib"


### PR DESCRIPTION
…nstallation instead of /opt/rocm

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
