### PR TITLE
[build_supp] add patch to rocmopenmpi sources and switch to openmpi 5…

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -394,6 +394,12 @@ function _buildopenmpi_impl(){
     FC=$LLVM_INSTALL_LOC/bin/${FLANG} \
     $_extra_configure_opts"
 
+  if [[ "$_version" == "5.0.10" ]] ; then
+    if [ -f "$thisdir/patches/ompi.patch" ] ; then
+       runcmdin "patch --merge -p1" "$thisdir/patches/ompi.patch"
+    fi
+  fi
+
   runcmd "make -j${AOMP_JOB_THREADS}"
   runcmd "make install"
   if [ -L "$_linkfrom" ] ; then
@@ -418,7 +424,7 @@ function buildopenmpi(){
 ################################################################################
 function buildrocmopenmpi(){
   _cname="rocmopenmpi"
-  _version=5.0.9
+  _version=5.0.10
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname
@@ -456,7 +462,7 @@ function buildrocmopenmpi(){
     "--disable-debug"
 
   # Configure default MCA parameters for UCX
-  local _installdir=$AOMP_SUPP_INSTALL/rocmopenmpi-5.0.9
+  local _installdir=$AOMP_SUPP_INSTALL/rocmopenmpi-5.0.10
   if [ -d "$_installdir/etc" ] ; then
     echo "# Setting UCX as default point-to-point and one-sided communication"
     {

--- a/bin/patches/ompi.patch
+++ b/bin/patches/ompi.patch
@@ -1,0 +1,21 @@
+diff -Naur openmpi-5.0.10.orig/oshmem/mca/memheap/base/memheap_base_mkey.c openmpi-5.0.10/oshmem/mca/memheap/base/memheap_base_mkey.c
+--- openmpi-5.0.10.orig/oshmem/mca/memheap/base/memheap_base_mkey.c	2026-02-23 14:21:11.043280469 -0600
++++ openmpi-5.0.10/oshmem/mca/memheap/base/memheap_base_mkey.c	2026-04-17 13:57:40.309512230 -0500
+@@ -444,7 +444,7 @@
+ 
+ static int send_buffer(int pe, pmix_data_buffer_t *msg)
+ {
+-    void *buffer;
++    char *buffer;
+     size_t size;
+     int rc;
+ 
+@@ -521,7 +521,7 @@
+     int j;
+     int nprocs, my_pe;
+     pmix_data_buffer_t *msg = NULL;
+-    void *send_buffer = NULL;
++    char *send_buffer = NULL;
+     char *rcv_buffer = NULL;
+     size_t size;
+     int *rcv_size = NULL;


### PR DESCRIPTION
….0.10, was 5.0.9

## Motivation
Compiler fails to build 5.0.10 because a defined void* can not be typecast to char* .  So we changed the buffer type to char*. 

