### PR TITLE
[FNew-flang-273284] Update to new --offload-arch syntax

### DIFF
--- a/test/smoke-fails/FNew-flang-273284/Makefile
+++ b/test/smoke-fails/FNew-flang-273284/Makefile
@@ -5,7 +5,7 @@ TESTSRC_MAIN = flang-273284.f90
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
-TARGET       = -fopenmp -O0 -g -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=$(AOMP_GPU)$(AOMP_TARGET_FEATURES)
+TARGET       = -fopenmp -O0 -g --offload-arch=$(AOMP_GPU)$(AOMP_TARGET_FEATURES)
 
 FLANG        ?= flang
 OMP_BIN      = $(AOMP)/bin/$(FLANG)


### PR DESCRIPTION
Replace deprecated -fopenmp-targets=amdgcn-amd-amdhsa and -Xopenmp-target=amdgcn-amd-amdhsa -march= flags with the new --offload-arch= syntax for Fortran compilation.
