### PR TITLE
[miniQMC] Fix where runlibs are found

### DIFF
--- a/bin/run_miniQMC.sh
+++ b/bin/run_miniQMC.sh
@@ -27,11 +27,15 @@ export PATH=$AOMP/bin:$PATH
 #export PATH=/home/janplehr/rocm/trunk/bin:$PATH
 
 # We export all these paths, so they will be picked-up in the CMake command.
-export hsaruntime64_DIR=${ROCM}/lib/cmake/hsa-runtime64/
+# For libraries that AOMP provides (hsa-runtime, hip, comgr, device-libs), use AOMP.
+# For libraries that only ROCm provides (rocblas, rocsolver, hipblas), use ROCm.
+export hsaruntime64_DIR=${AOMP}/lib/cmake/hsa-runtime64/
+export hip_DIR=${AOMP}/lib/cmake/hip
+export AMDDeviceLibs_DIR=${AOMP}/lib/cmake/AMDDeviceLibs/
+export amd_comgr_DIR=${AOMP}/lib/cmake/amd_comgr/
+
+# These are only in ROCm, not in AOMP
 export hipblas_DIR=${ROCM}/lib/cmake/hipblas/
-export hip_DIR=${ROCM}/lib/cmake/hip
-export AMDDeviceLibs_DIR=${ROCM}/lib/cmake/AMDDeviceLibs/
-export amd_comgr_DIR=${ROCM}/lib/cmake/amd_comgr/
 export rocblas_DIR=${ROCM}/lib/cmake/rocblas/
 export rocsolver_DIR=${ROCM}/lib/cmake/rocsolver/
 
@@ -55,7 +59,15 @@ fi
 rm -rf "${MQMC_BUILD_DIR}"
 # Note: We currently need the -fopenmp-assume-no-nested-parallelism to work around a call to malloc which probably should not be there.
 # In the case that we disable hostservices, the application crashes when trying to call malloc.
-CMAKE_PREFIX_PATH=${ROCM}/lib/cmake/ cmake -B "${MQMC_BUILD_DIR}" -S "${MQMC_SOURCE_DIR}" -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OFFLOAD=ON -DQMC_ENABLE_ROCM=ON -DCMAKE_CXX_FLAGS='-fopenmp-assume-no-nested-parallelism -DCUDART_VERSION=10000 -DcudaMemoryTypeManaged=hipMemoryTypeManaged ' -DAMDGPU_DISABLE_HOST_DEVMEM=ON -DCMAKE_VERBOSE_MAKEFILE=ON
+# Use AOMP cmake configs first, fall back to ROCm for libraries AOMP doesn't provide
+cmake -B "${MQMC_BUILD_DIR}" -S "${MQMC_SOURCE_DIR}" \
+  -DCMAKE_PREFIX_PATH="${AOMP}/lib/cmake;${ROCM}/lib/cmake" \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DENABLE_OFFLOAD=ON \
+  -DQMC_ENABLE_ROCM=ON \
+  -DCMAKE_CXX_FLAGS='-fopenmp-assume-no-nested-parallelism -DCUDART_VERSION=10000 -DcudaMemoryTypeManaged=hipMemoryTypeManaged ' \
+  -DAMDGPU_DISABLE_HOST_DEVMEM=ON \
+  -DCMAKE_VERBOSE_MAKEFILE=ON
 
 # Build miniqmc binaries
 #cmake --build ${MQMC_BUILD_DIR}  --clean-first -j ${MQMC_NUM_BUILD_PROCS}
@@ -65,6 +77,10 @@ make --output-sync -j "${MQMC_NUM_BUILD_PROCS}"
 popd || exit
 
 echo "Running Tests"
+
+# Ensure AOMP runtime libraries are found before /opt/rocm libraries to avoid ABI mismatches
+export LD_LIBRARY_PATH="${AOMP}/lib:${AOMP}/lib/llvm/lib:${LD_LIBRARY_PATH}"
+
 echo "OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} ${MQMC_BUILD_DIR}/bin/check_spo_batched_reduction -n 10"
 OMP_NUM_THREADS=${MQMC_OMP_NUM_THREADS} "${MQMC_BUILD_DIR}"/bin/check_spo_batched_reduction -n 10
 


### PR DESCRIPTION
It seems that we preferred the /opt/rocm libs for some components over the AOMP libs. This led to errors lately.
This PR fixes that behavior and should always prefer AOMP libraries if the particular component is shipped.
