### PR TITLE
[CI] Fix llama-cli hanging in conversation mode during benchmark

### DIFF
--- a/bin/run_llama.sh
+++ b/bin/run_llama.sh
@@ -124,8 +124,10 @@ if [ "${DoBenchmark}" == "yes" ]; then
   echo "Running benchmark..."
   cd "${LLAMA_BUILD_DIR}" || exit
   # Download model from HF (this will make it avail in local cache); bench call requires local model file
-  # llama-cli will turn on interactive mode, so echo /exit to it immediately
-  ./bin/llama-cli -hf ${LLAMA_BENCH_HF_ID} --prompt "/exit"
+  # Use -st (single-turn) to exit after the first response instead of blocking in
+  # conversation mode, which is auto-enabled for chat/instruction-tuned models.
+  # Redirect stdin from /dev/null as a safety net against interactive hangs.
+  ./bin/llama-cli -hf "${LLAMA_BENCH_HF_ID}" --prompt "/exit" -st < /dev/null
 
   # Get cache directory from llama-cli
   CacheListOutput=$(./bin/llama-cli --cache-list 2>&1)


### PR DESCRIPTION
Use -st (single-turn) and redirect stdin from /dev/null to prevent llama-cli from blocking indefinitely in auto-enabled conversation mode.

## Motivation

Observed possible hangs of `llama-cli` processes.

## Technical Details

The argument `single-turn` should force-exit the `llama-cli` process after the very first response.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ x ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
