### PR TITLE
[CI] run_llama.sh: Replace llama-cli usage with llama-bench

### DIFF
--- a/bin/run_llama.sh
+++ b/bin/run_llama.sh
@@ -124,43 +124,44 @@ fi
 if [ "${DoBenchmark}" == "yes" ]; then
   echo "Running benchmark..."
   cd "${LLAMA_BUILD_DIR}" || exit
-  # Download model from HF (this will make it avail in local cache); bench call requires local model file
-  # Use -st (single-turn) to exit after the first response instead of blocking in
-  # conversation mode, which is auto-enabled for chat/instruction-tuned models.
-  # Redirect stdin from /dev/null as a safety net against interactive hangs.
-  ./bin/llama-cli -hf "${LLAMA_BENCH_HF_ID}" --prompt "/exit" -st < /dev/null
 
-  # Get cache directory from llama-cli
-  CacheListOutput=$(./bin/llama-cli --cache-list 2>&1)
+  # Get cache directory from llama-cli if supported by the local build.
+  CacheListOutput=$(./bin/llama-cli --cache-list 2>&1 || true)
   CacheDir=$(echo "${CacheListOutput}" | grep "model cache directory:" | sed 's/.*: //')
   : "${CacheDir:=${LLAMA_CACHE}}"
 
   # Find requested model by converting HF ID to filename pattern (user/model -> user_model)
   SearchPattern="${LLAMA_BENCH_HF_ID//\//_}"
-  LlamaModelPath=$(find "${CacheDir}" -maxdepth 1 -type f -name "${SearchPattern}*.gguf" 2>/dev/null | head -1)
+  LlamaModelPath=$(find "${CacheDir}" \( -type f -o -xtype f \) -name "${SearchPattern}*.gguf" 2>/dev/null | head -1)
 
   # Fallback: use all available .gguf files in cache
   if [ -z "${LlamaModelPath}" ]; then
     echo "Requested model not found, using all cached models"
-    mapfile -t ModelPaths < <(find "${CacheDir}" -maxdepth 1 -type f -name "*.gguf" 2>/dev/null)
+    mapfile -t ModelPaths < <(find "${CacheDir}" \( -type f -o -xtype f \) -name "*.gguf" 2>/dev/null)
   else
     ModelPaths=("${LlamaModelPath}")
-  fi
-
-  if [ ${#ModelPaths[@]} -eq 0 ]; then
-    echo "ERROR: No model files found in cache directory: ${CacheDir}"
-    ls -la "${CacheDir}" 2>/dev/null || echo "Directory does not exist"
-    exit 1
   fi
 
   # Marker for external scripts
   echo "LLAMA_BENCHMARK_BEGIN" | tee "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
 
-  # Run benchmark for each model
-  for LlamaModelPath in "${ModelPaths[@]}"; do
-    echo "Benchmarking: ${LlamaModelPath}"
-    ./bin/llama-bench -ngl 999 -fa 1 -ub 2048 -m "${LlamaModelPath}" 2>&1 | tee -a "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
-  done
+  if [ ${#ModelPaths[@]} -eq 0 ] && ./bin/llama-bench --help 2>&1 | grep -q -- "--hf-repo"; then
+    # Let llama-bench resolve/download the HF model directly.  Using llama-cli as
+    # a prefetch step can hang in ROCm/KFD waits on cold cache.
+    ./bin/llama-bench -hf "${LLAMA_BENCH_HF_ID}" -ngl 999 -fa 1 -ub 2048 \
+      2>&1 | tee -a "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
+  else
+    if [ ${#ModelPaths[@]} -eq 0 ]; then
+      echo "ERROR: No model files found in cache directory: ${CacheDir}"
+      exit 1
+    fi
+
+    # Run benchmark for each model
+    for LlamaModelPath in "${ModelPaths[@]}"; do
+      echo "Benchmarking: ${LlamaModelPath}" | tee -a "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
+      ./bin/llama-bench -ngl 999 -fa 1 -ub 2048 -m "${LlamaModelPath}" 2>&1 | tee -a "${LLAMA_TESTS_LOG_LOCATION}/llama-bench.log"
+    done
+  fi
 fi
 
 popd || exit


### PR DESCRIPTION
llama-cli has a tendency to hang during prefetch/load step llama-bench can handle this step in a more robust manner
 - Note: cold and warm caches provide the same perf results

Fixed current / changed cache directory structure conformity Support fallback as before

## Motivation

Intermittent hangs of `llama-cli` processes during prefetch step.

## Technical Details

This avoids the `llamacpp-perf` hang by removing the normal-path `llama-cli -hf ... --prompt /exit -st` prefetch step.
Modern `llama-bench` supports `-hf` directly, so when no cached GGUF is available the script now lets `llama-bench` resolve/download and benchmark the requested HF model itself.
The existing cached-model behavior is preserved: if cached GGUF files are found, the script still benchmarks them through the existing `llama-bench -m` loop. The fallback also handles the current HF cache layout by finding symlinked snapshot GGUFs.

## Test Plan

Run script with [warm, cold] cache x [with, without] fix; 100 times each.
Document hangs/timeouts and reported performance results.

Sporadic runs of the nightly scripts.

## Test Result

Tested on `gfx950`:
| Cache state | Path | Runs | Successes | Timeouts | pp512 avg t/s | tg128 avg t/s |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| warm | with fix | 100 | 100 | 0 | 41566.36 | 358.97 |
| warm | without fix | 100 | 84 | 16 | 41645.86 | 359.22 |
| cold | with fix | 100 | 99 | 1 | 40369.79 | 359.90 |
| cold | without fix | 100 | 75 | 25 | 41833.08 | 359.30 |

Without the fix, timeouts stopped in `llama-cli -hf ... --prompt /exit -st` at `Loading model...`, before benchmark rows were emitted. With the fix, that prefetch path is avoided while successful benchmark output remains in the same format and has roughly equivalent performance.

The single "cold-fix" timeout seems to have had slow download speed (chose a rather narrow timeout setting of 42s).
The returncode was `-15` while the other hanging returncodes were all `-9`.

All manual nightly script runs (10) returned results in the expected time and range.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
