### PR TITLE
[NFC] Makefile.defs: Improve omptest search path building

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -387,8 +387,8 @@ else
 endif
 
 # ompTest: Set header include path + linker flag for corresponding OMPT tests
-CLANG_RESOURCE_DIR ?= $(shell $(AOMP)/bin/clang -print-resource-dir)
-OMPTEST            ?= -I$(CLANG_RESOURCE_DIR)/include/omptest -lomptest
+CLANG_RESOURCE_DIR := $(shell $(AOMP)/bin/clang -print-resource-dir)
+OMPTEST             = -I$(CLANG_RESOURCE_DIR)/include/omptest -lomptest
 
 # ompTest: Set and export CMake config path
 omptest_DIR = $(AOMP)/lib/cmake/openmp/omptest/

--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -387,8 +387,8 @@ else
 endif
 
 # ompTest: Set header include path + linker flag for corresponding OMPT tests
-CLANG_VERSION := $(lastword $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard $(AOMP)/lib/clang/*/))))))
-OMPTEST = -I$(AOMP)/lib/clang/$(CLANG_VERSION)/include/omptest -lomptest
+CLANG_RESOURCE_DIR ?= $(shell $(AOMP)/bin/clang -print-resource-dir)
+OMPTEST            ?= -I$(CLANG_RESOURCE_DIR)/include/omptest -lomptest
 
 # ompTest: Set and export CMake config path
 omptest_DIR = $(AOMP)/lib/cmake/openmp/omptest/


### PR DESCRIPTION
Use `clang -print-resource-dir` instead of manual path building
 - supported since at least version 18 of clang

## Motivation

Direct improvement.
Found out about the `-print-resource-dir` flag and current path building is somewhat error prone.

## Technical Details

This change should behave roughly as before with the difference of being maintained by upstream.

## Test Plan

Few manual runs with omptest-based smoke tests.

## Test Result

Headers were discovered as before.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
