### PR TITLE
[CI] run_composable-kernels.sh: Add printing of repo branch / SHA

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -292,9 +292,9 @@ elif [ "${ShouldUpdateCKRepo}" == 'yes' ]; then
 fi
 
 # Print branch and SHA of the rocm-libraries repository, followed by CK's SHA
-echo "rocm-libraries branch:     $(git -C ${CK_REPO} branch --show-current)"
-echo "rocm-libraries repo SHA:   $(git -C ${CK_REPO} rev-parse HEAD)"
-echo "composablekernel repo SHA: $(git -C ${CK_SRC} log -1 --format=%H -- .)"
+echo "rocm-libraries branch:     $(git -C "${CK_REPO}" branch --show-current)"
+echo "rocm-libraries repo SHA:   $(git -C "${CK_REPO}" rev-parse HEAD)"
+echo "composablekernel repo SHA: $(git -C "${CK_SRC}" log -1 --format=%H -- .)"
 
 CKBuildTool='make'
 DashKArg='-k'

--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -288,10 +288,13 @@ elif [ "${ShouldUpdateCKRepo}" == 'yes' ]; then
   pushd "${CK_REPO}" || exit 1
   git reset --hard origin/${CKRepoBranchName}
   git pull
-  # TODO: Write current SHA to somewhere such that it is known which SHA
-  #       was tested in this nightly run.
   popd || exit 1
 fi
+
+# Print branch and SHA of the rocm-libraries repository, followed by CK's SHA
+echo "rocm-libraries branch:     $(git -C ${CK_REPO} branch --show-current)"
+echo "rocm-libraries repo SHA:   $(git -C ${CK_REPO} rev-parse HEAD)"
+echo "composablekernel repo SHA: $(git -C ${CK_SRC} log -1 --format=%H -- .)"
 
 CKBuildTool='make'
 DashKArg='-k'


### PR DESCRIPTION
## Motivation

Address `TODO` / improve traceability of errors in (CI) runs.

## Technical Details

Added current repo branch print.
Added two SHA prints which report the parent (rocm-libraries) as well as the CK subdirectory.

## Test Plan

Checked out rocm-libraries at a SHA where the subdir of CK was modified by a previous commit.
Verified SHAs.

## Test Result

SHAs were reported with the expected values.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
