### PR TITLE
[CK] Disable DPP kernels, address build fail: not a valid operand

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -318,7 +318,13 @@ else
 fi
 
 # For some reason, CK on gfx12 wants this set.
-CKCmakeCmd+="-DBUILD_DEV=On"
+CKCmakeCmd+="-DBUILD_DEV=On "
+
+# TODO: Remove this workaround when possible.
+# As of 2026-JUN-12 this is needed to bypass DPP-related build errors:
+#   error: cannot compile inline asm
+#   <inline asm>:2:33: error: not a valid operand.
+CKCmakeCmd+="-DDISABLE_DPP_KERNELS=ON"
 
 # Ensure CK build directory is cleaned.
 if [ "${ShouldRebuildCK}" == 'yes' ]; then


### PR DESCRIPTION
Workaround, disabling the corresponding kernels during build.

## Motivation

Observed CK build fails across multiple major architectures during nightly CI.

## Technical Details

Added CMake flag which disables the corresponding DPP kernels.

## Test Plan

Execute CK build with previously failing CK SHA and compiler.

## Test Result

Successful build via CI scripts.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
