### PR TITLE
Allow BabelStream OpenMP usage warnings

### DIFF
--- a/test/smoke-fort-dev/milestone-3-babel-drop-1/buildit.sh
+++ b/test/smoke-fort-dev/milestone-3-babel-drop-1/buildit.sh
@@ -6,7 +6,7 @@ FLANG=${FLANG:-flang}
 FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel
 
-FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+FFLAGS="-O3 -fopenmp --offload-arch=$AOMP_GPU"
 DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME -Dsimd="
 
 set -x

--- a/test/smoke-fort-dev/milestone-3-babel/buildit.sh
+++ b/test/smoke-fort-dev/milestone-3-babel/buildit.sh
@@ -6,7 +6,7 @@ FLANG=${FLANG:-flang}
 FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel
 
-FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+FFLAGS="-O3 -fopenmp --offload-arch=$AOMP_GPU"
 DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x

--- a/test/smoke-fort/milestone-3-babel-copy/buildit.sh
+++ b/test/smoke-fort/milestone-3-babel-copy/buildit.sh
@@ -6,7 +6,7 @@ FLANG=${FLANG:-flang}
 FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel
 
-FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+FFLAGS="-O3 -fopenmp --offload-arch=$AOMP_GPU"
 DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x

--- a/test/smoke-fort/milestone-3-babel-noteams/buildit.sh
+++ b/test/smoke-fort/milestone-3-babel-noteams/buildit.sh
@@ -6,7 +6,7 @@ FLANG=${FLANG:-flang}
 FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel-noteams
 
-FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+FFLAGS="-O3 -fopenmp --offload-arch=$AOMP_GPU"
 DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x

--- a/test/smoke-fort/milestone-3-babel-pdot/buildit.sh
+++ b/test/smoke-fort/milestone-3-babel-pdot/buildit.sh
@@ -6,7 +6,7 @@ FLANG=${FLANG:-flang}
 FC=${FC:-$AOMP/bin/$FLANG}
 EXE=milestone-3-babel
 
-FFLAGS="-O3 -Werror -fopenmp --offload-arch=$AOMP_GPU"
+FFLAGS="-O3 -fopenmp --offload-arch=$AOMP_GPU"
 DEFINES="-DVERSION_STRING=4.0 -DUSE_OPENMPTARGET -DUSE_OMP_GET_WTIME"
 
 set -x


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/201060 Introduces a new OpenMP warning, which conflicts with `-Werror` present in the following test cases: 

- test/smoke-fort/milestone-3-babel-copy
- test/smoke-fort/milestone-3-babel-noteams
- test/smoke-fort/milestone-3-babel-pdot
- test/smoke-fort-dev/milestone-3-babel
- test/smoke-fort-dev/milestone-3-babel-drop-1