### PR TITLE
[CI] Add semaphore isolation helper to avoid hangs

### DIFF
--- a/bin/semaphore_isolation.src
+++ b/bin/semaphore_isolation.src
@@ -1,0 +1,33 @@
+# shellcheck shell=bash
+#
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier:  MIT
+#
+# semaphore_isolation.src - shared helper for GNU parallel's "sem" semaphore.
+#
+# Source this file and call isolate_semaphore before any "sem" use. It gives
+# "sem" a private, self-cleaning semaphore namespace (its own PARALLEL_HOME) so
+# that a leaked/stale token can neither deadlock a run nor leak across runs, and
+# optionally bounds a stuck semaphore with a timeout.
+#
+# Background: on hosts whose name contains uppercase letters, GNU parallel's
+# dead-lock reaper (remove_dead_locks) never matches its own token files, so a
+# token left behind by an unclean death is never reclaimed and every later
+# "sem --wait" deadlocks. A per-run private namespace sidesteps this entirely.
+#
+# Design:
+#   - No-op when PARALLEL_HOME is already set, so an outer caller never collides.
+#   - AOMP_SEMAPHORE_TIMEOUT (seconds), if set, is passed to every "sem" call as
+#     --semaphoretimeout: a wedged sem/sem --wait then steals and proceeds
+#     instead of hanging. Left unset => pure isolation, no timeout.
+
+isolate_semaphore() {
+  [ -n "${PARALLEL_HOME:-}" ] && return 0
+  _semaphore_home=$(mktemp -d "${TMPDIR:-/tmp}/aomp-sem.XXXXXX") || return 0
+  export PARALLEL_HOME="$_semaphore_home"
+  if [ -n "${AOMP_SEMAPHORE_TIMEOUT:-}" ]; then
+    export PARALLEL="--semaphoretimeout ${AOMP_SEMAPHORE_TIMEOUT}${PARALLEL:+ $PARALLEL}"
+  fi
+  trap 'rm -rf "$_semaphore_home"' EXIT
+}

--- a/test/smoke/check_smoke.sh
+++ b/test/smoke/check_smoke.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 #
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier:  MIT
+#
 # Checks all tests in smoke directory using make check. Programs return 0 for success or a number > 0 for failure.
 # Tests that need to be visually inspected: devices, stream
 #
@@ -228,6 +232,10 @@ if [ "${AOMP_PARALLEL_SMOKE}" == 1 ]; then
     export AOMP_NO_PREREQ=1     # disable prereq target so builds can be reused
   fi
   if sem --help > /dev/null; then
+    # Give "sem" a private, self-cleaning semaphore namespace (no-op if the
+    # caller already set PARALLEL_HOME). Prevents stale-token deadlocks/leaks.
+    # shellcheck source=/dev/null
+    source "${path}/../../bin/semaphore_isolation.src" 2>/dev/null && isolate_semaphore
     COMP_THREADS=1
     if [ -n "$(which getconf)" ]; then
        COMP_THREADS=$(getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
## Motivation

Observed hangs during smoke suite on CI machine (with hostname being all uppercase letters).
Traced issue to stale semaphores created by previous run's `parallel` invocation.
Probable cause could be a reboot of the machine during run or `TERM` / `KILL` of corresponding process(es).

## Technical Details

Semaphores including hostnames, which in turn include uppercase letters, are not reaped correctly.
Stale semaphores can block indefinitely, until cleaned (e.g. manually).

Approach avoids hanging of CI runs by:
 - isolating semaphores per test run
 - stealing semaphores after timeout (default: 30m)

Very recent parallel versions 20260522 and newer handle this case by converting hostname to lowercase:
https://cgit.git.savannah.gnu.org/cgit/parallel.git/tree/src/parallel?h=20260522#n7565

## Test Plan

Ran corresponding CI script for smoke tests.

## Test Result

No hangs observed, no stealing (since nothing was aborted).
Run completed successfully.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
