### PR TITLE
[CK] Remove DPP kernel workaround

### DIFF
--- a/bin/run_composable-kernels.sh
+++ b/bin/run_composable-kernels.sh
@@ -318,13 +318,7 @@ else
 fi
 
 # For some reason, CK on gfx12 wants this set.
-CKCmakeCmd+="-DBUILD_DEV=On "
-
-# TODO: Remove this workaround when possible.
-# As of 2026-JUN-12 this is needed to bypass DPP-related build errors:
-#   error: cannot compile inline asm
-#   <inline asm>:2:33: error: not a valid operand.
-CKCmakeCmd+="-DDISABLE_DPP_KERNELS=ON"
+CKCmakeCmd+="-DBUILD_DEV=On"
 
 # Ensure CK build directory is cleaned.
 if [ "${ShouldRebuildCK}" == 'yes' ]; then


### PR DESCRIPTION
Currently, this is disabled by CK itself, see:
https://github.com/ROCm/rocm-libraries/pull/8501

This PR basically reverts: https://github.com/ROCm/aomp/pull/2256

## Motivation

Disabling DPP kernel build workaround is obsolete.

## Technical Details

Removed CMake argument: `-DDISABLE_DPP_KERNELS=ON`

## Test Plan

Manually checked CK build via CI script.

## Test Result

Build succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
