### PR TITLE
[smoke-dev] HipDevCov/OmpDevCov: assert real device counts, not just symbols

### DIFF
--- a/test/smoke-dev/HipDevCov/Makefile
+++ b/test/smoke-dev/HipDevCov/Makefile
@@ -21,10 +21,10 @@ LINK_FLAGS   = -L$(ROCM_PATH)/lib -lamdhip64 -Wl,-rpath,$(ROCM_PATH)/lib
 
 CC           = $(AOMP)/bin/clang $(VERBOSE)
 
-RUNCMD       = ./run_and_check.sh "$(AOMP)" "$(GPU_W_FEATURES)" "$(FILECHECK)" "$(ROCM_PATH)"
+RUNCMD       = ./run_and_check.sh "$(AOMP)" "$(GPU_W_FEATURES)" "$(ROCM_PATH)"
 
 include ../Makefile.rules
 
 clean::
 	rm -f mod.co builder builder.*.host-* builder.*.hip-amdgcn-amd-amdhsa--* \
-	      *.profraw merged.profdata
+	      *.profraw merged.profdata devcov-profile.txt DEVCOV-SKIPPED.txt

--- a/test/smoke-dev/HipDevCov/check.txt
+++ b/test/smoke-dev/HipDevCov/check.txt
@@ -1,6 +1,0 @@
-Both kernels must appear in the merged host+device profile. host_kernel is the
-host-shadow path; mod_kernel (from the hipModuleLoad'd code object, no host
-shadow) can only be present if the HSA-introspection drain collected it.
-
-CHECK-DAG: host_kernel
-CHECK-DAG: mod_kernel

--- a/test/smoke-dev/HipDevCov/run_and_check.sh
+++ b/test/smoke-dev/HipDevCov/run_and_check.sh
@@ -4,40 +4,50 @@
 # Args (passed from the Makefile):
 #   $1 = AOMP        (LLVM dir containing bin/clang, llvm-profdata, llvm-objdump)
 #   $2 = GPU arch    (e.g. gfx90a, may include :features)
-#   $3 = FILECHECK   (path to FileCheck)
-#   $4 = ROCM_PATH   (HIP/ROCm install for --rocm-path and libamdhip64)
+#   $3 = ROCM_PATH   (HIP/ROCm install for --rocm-path and libamdhip64)
 #
-# Returns 0 only if BOTH the host-shadow kernel and the module-only kernel are
-# present in the merged profile (the latter requires the HSA drain).
+# Proves the HSA-introspection drain captured device coverage that the HIP
+# host-shadow drain cannot see. Verifies, against the actual merged profile:
+#   * the HSA drain produced its own profraw (uniquely named *.hsa<N>.*.profraw),
+#   * mod_kernel (loaded via hipModuleLoad, no host shadow) is present with a
+#     NONZERO function count -- only possible via the HSA drain,
+#   * host_kernel (host-shadow path) is also present with a nonzero count.
+# The human-readable profile dump is left in devcov-profile.txt for inspection.
 
 set -u
-AOMP="$1"; ARCH="$2"; FILECHECK="$3"; ROCM="$4"
+AOMP="$1"; ARCH="$2"; ROCM="$3"
 CLANG="$AOMP/bin/clang"
 PROFDATA="$AOMP/bin/llvm-profdata"
 OBJDUMP="$AOMP/bin/llvm-objdump"
-COV="$AOMP/bin/llvm-cov"
 
 here="$(cd "$(dirname "$0")" && pwd)"
 cd "$here" || exit 1
 
-# Capability gate: skip cleanly on toolchains that do not ship the device
-# profile runtime / HSA drain yet (so this does not red-fail CI before the
-# feature lands). A real, drain-capable toolchain has the amdgcn device profile
-# RT and the host drain symbol.
+fail() { echo "FAIL HipDevCov: $*"; exit 1; }
+
+# Function count for a front-end-instrumented function in the --counts dump.
+func_count() {
+  awk -v fn="$1" '
+    $0 ~ ("^[ \t]*" fn ":$") { inblk = 1; next }
+    inblk && /Function count:/ { print $3; exit }
+  ' "$2"
+}
+
+# Capability gate: skip cleanly only when the toolchain truly cannot do device
+# PGO (no amdgcn device profile runtime / no host HSA-drain runtime). Leaves a
+# marker so the skip is visible in archived results rather than a silent pass.
 resdir="$("$CLANG" -print-resource-dir 2>/dev/null)"
 devrt="$resdir/lib/amdgcn-amd-amdhsa/libclang_rt.profile.a"
-if [ ! -f "$devrt" ]; then
-  echo "SKIP HipDevCov: no device profile runtime at $devrt"
-  exit 0
-fi
-if ! ls "$resdir"/lib/*/libclang_rt.profile_rocm*.a >/dev/null 2>&1; then
-  echo "SKIP HipDevCov: no host profile_rocm runtime (HSA drain) in toolchain"
+rm -f DEVCOV-SKIPPED.txt
+if [ ! -f "$devrt" ] || ! ls "$resdir"/lib/*/libclang_rt.profile_rocm*.a >/dev/null 2>&1; then
+  echo "no device profile runtime / HSA-drain runtime in $resdir" > DEVCOV-SKIPPED.txt
+  echo "SKIP HipDevCov: $(cat DEVCOV-SKIPPED.txt)"
   exit 0
 fi
 
 set -e
-rm -f ./*.profraw mod.co merged.profdata builder builder.*.host-* \
-      builder.*.hip-amdgcn-amd-amdhsa--* 2>/dev/null || true
+rm -f ./*.profraw mod.co merged.profdata devcov-profile.txt builder \
+      builder.*.host-* builder.*.hip-amdgcn-amd-amdhsa--* 2>/dev/null || true
 
 # 1. Build mod.hip as a full executable so the device link gets the device
 #    profile RT, then extract its device code object as the loadable mod.co.
@@ -47,35 +57,38 @@ rm -f ./*.profraw mod.co merged.profdata builder builder.*.host-* \
 "$OBJDUMP" --offloading builder >/dev/null 2>&1 || true
 shopt -s nullglob
 extracted=(builder*.hip-amdgcn-amd-amdhsa--*gfx*)
-if [ ${#extracted[@]} -eq 0 ]; then
-  echo "FAIL HipDevCov: could not extract device code object from builder"
-  exit 1
-fi
+[ ${#extracted[@]} -gt 0 ] || fail "could not extract device code object from builder"
 cp "${extracted[0]}" mod.co
 
-# 2. main is built by the smoke harness (TESTNAME=main). Build it here too if it
-#    is missing, so the script also works when run standalone.
+# 2. main is built by the harness (TESTNAME=main); build it here if missing.
 if [ ! -x ./main ]; then
   "$CLANG" -x hip --offload-arch="$ARCH" -fno-gpu-rdc \
     -fprofile-instr-generate -fcoverage-mapping --rocm-path="$ROCM" \
     main.hip -o main -L"$ROCM/lib" -lamdhip64 -Wl,-rpath,"$ROCM/lib"
 fi
 
-# 3. Run. Device .profraw files are written to CWD (arch-prefixed for the
-#    host-shadow drain, arch.hsa<N>-prefixed for the HSA drain); the host one
-#    goes to LLVM_PROFILE_FILE.
+# 3. Run with mod.co in CWD.
 rm -f ./*.profraw
 LLVM_PROFILE_FILE="$here/host.profraw" \
   LD_LIBRARY_PATH="$ROCM/lib:${LD_LIBRARY_PATH:-}" \
   ./main
 
-# 4. Merge host + all device profraws and assert both kernels are present.
+# 4. The HSA-introspection drain writes its own, uniquely-named profraw
+#    (<arch>.hsa<N>.<file>.profraw). Its presence is a direct fingerprint that
+#    the HSA pass ran (the host-shadow drain names files <arch>[:feat].<file>).
+hsa=(*.hsa[0-9]*.profraw)
+[ ${#hsa[@]} -gt 0 ] || fail "no HSA-drain profraw (*.hsa<N>.*.profraw) produced"
+echo "HipDevCov: HSA-drain profraw(s): ${hsa[*]}"
+
+# 5. Merge and verify real counts from the dump.
 "$PROFDATA" merge -sparse -o merged.profdata ./*.profraw
-"$PROFDATA" show --all-functions merged.profdata | "$FILECHECK" check.txt
+"$PROFDATA" show --all-functions --counts merged.profdata > devcov-profile.txt
 
-# 5. Sanity (non-fatal): llvm-cov can consume the merged device+host profile.
-#    main's covmap only describes host_kernel/main, so llvm-cov warns about the
-#    module-only function; that is expected, hence non-fatal.
-"$COV" report ./main -instr-profile=merged.profdata >/dev/null 2>&1 || true
+mc="$(func_count mod_kernel devcov-profile.txt)"
+hc="$(func_count _Z11host_kernelPii devcov-profile.txt)"
+[ -n "$mc" ] || fail "mod_kernel absent from merged profile (HSA drain did not capture it)"
+[ -n "$hc" ] || fail "host_kernel absent from merged profile"
+[ "$mc" -gt 0 ] 2>/dev/null || fail "mod_kernel function count is '$mc' (expected > 0)"
+[ "$hc" -gt 0 ] 2>/dev/null || fail "host_kernel function count is '$hc' (expected > 0)"
 
-echo "HipDevCov PASSED"
+echo "HipDevCov PASSED (mod_kernel=$mc via HSA drain, host_kernel=$hc)"

--- a/test/smoke-dev/OmpDevCov/Makefile
+++ b/test/smoke-dev/OmpDevCov/Makefile
@@ -18,9 +18,9 @@ LINK_FLAGS   = -Wl,-rpath,$(AOMP)/lib
 
 CC           = $(AOMP)/bin/clang $(VERBOSE)
 
-RUNCMD       = ./run_and_check.sh "$(AOMP)" "$(GPU_W_FEATURES)" "$(FILECHECK)"
+RUNCMD       = ./run_and_check.sh "$(AOMP)" "$(GPU_W_FEATURES)"
 
 include ../Makefile.rules
 
 clean::
-	rm -f omp_pgo omp_pgo_use *.profraw merged.profdata
+	rm -f omp_pgo omp_pgo_use *.profraw merged.profdata devcov-profile.txt DEVCOV-SKIPPED.txt

--- a/test/smoke-dev/OmpDevCov/check.txt
+++ b/test/smoke-dev/OmpDevCov/check.txt
@@ -1,6 +1,0 @@
-The merged profile must contain device-side counters that could only have been
-collected via the HSA-introspection drain (OpenMP offload has no host-shadow
-drain). The device offload entry and the device function classify both appear.
-
-CHECK-DAG: __omp_offloading_
-CHECK-DAG: classify

--- a/test/smoke-dev/OmpDevCov/run_and_check.sh
+++ b/test/smoke-dev/OmpDevCov/run_and_check.sh
@@ -4,73 +4,82 @@
 # Args (passed from the Makefile):
 #   $1 = AOMP       (LLVM dir containing bin/clang, llvm-profdata)
 #   $2 = GPU arch   (e.g. gfx90a, may include :features)
-#   $3 = FILECHECK  (path to FileCheck)
 #
-# omp_pgo (the -fprofile-generate binary) is built by the harness. Here we:
-#   1. run it -> host default.profraw + device amdgcn-amd-amdhsa.*.profraw
-#      (the device file is produced ONLY by the HSA drain),
-#   2. assert a device profraw was produced and merge,
-#   3. FileCheck the merged profile for the device offload function,
-#   4. rebuild with -fprofile-use and assert it consumes cleanly (no profile
-#      mismatch / out-of-date diagnostics) and runs.
+# OpenMP offload has no host-shadow drain, so device counters can only reach the
+# profile through the HSA-introspection drain. omp_pgo (the -fprofile-generate
+# binary) is built by the harness. Here we verify, against the actual merged
+# profile, that:
+#   * the HSA drain produced a device profraw (amdgcn-amd-amdhsa.*.profraw),
+#   * the device function classify has NONZERO counts on BOTH branches of its
+#     data-dependent if/else -- real device PGO data, not just a present symbol,
+#   * -fprofile-use consumes the merged profile cleanly and runs.
+# The human-readable profile dump is left in devcov-profile.txt for inspection.
 
 set -u
-AOMP="$1"; ARCH="$2"; FILECHECK="$3"
+AOMP="$1"; ARCH="$2"
 CLANG="$AOMP/bin/clang"
 PROFDATA="$AOMP/bin/llvm-profdata"
 
 here="$(cd "$(dirname "$0")" && pwd)"
 cd "$here" || exit 1
 
-# Capability gate: skip cleanly if the toolchain has no amdgcn device profile
-# runtime (i.e. no device PGO / HSA drain yet), so CI is not red before the
-# feature lands.
+fail() { echo "FAIL OmpDevCov: $*"; exit 1; }
+run_env() { LD_LIBRARY_PATH="$AOMP/lib:${LD_LIBRARY_PATH:-}" "$@"; }
+
+# Capability gate: skip cleanly only when there is no amdgcn device profile
+# runtime (no device PGO possible). Leave a marker so the skip is visible.
 resdir="$("$CLANG" -print-resource-dir 2>/dev/null)"
+rm -f DEVCOV-SKIPPED.txt
 if [ ! -f "$resdir/lib/amdgcn-amd-amdhsa/libclang_rt.profile.a" ]; then
-  echo "SKIP OmpDevCov: no amdgcn device profile runtime in toolchain"
+  echo "no amdgcn device profile runtime in $resdir" > DEVCOV-SKIPPED.txt
+  echo "SKIP OmpDevCov: $(cat DEVCOV-SKIPPED.txt)"
   exit 0
 fi
 
 set -e
-rm -f ./*.profraw merged.profdata omp_pgo_use 2>/dev/null || true
+rm -f ./*.profraw merged.profdata devcov-profile.txt omp_pgo_use 2>/dev/null || true
 
-run_env() { LD_LIBRARY_PATH="$AOMP/lib:${LD_LIBRARY_PATH:-}" "$@"; }
-
-# 1. Run the generate binary (built by the harness as ./omp_pgo). Build it here
-#    too if missing, so the script also works standalone.
+# 1. Run the generate binary (built by the harness as ./omp_pgo).
 if [ ! -x ./omp_pgo ]; then
   "$CLANG" -fopenmp --offload-arch="$ARCH" -fprofile-generate \
     omp_pgo.c -o omp_pgo -Wl,-rpath,"$AOMP/lib"
 fi
 run_env ./omp_pgo
 
-# 2. The HSA drain must have produced at least one device profraw.
+# 2. The HSA drain must have produced a device profraw.
 shopt -s nullglob
 dev=(amdgcn-amd-amdhsa*.profraw)
-if [ ${#dev[@]} -eq 0 ]; then
-  echo "FAIL OmpDevCov: no device (amdgcn-amd-amdhsa) profraw -- HSA drain did not fire"
-  ls -1 ./*.profraw 2>/dev/null || true
-  exit 1
-fi
+[ ${#dev[@]} -gt 0 ] || fail "no device (amdgcn-amd-amdhsa) profraw -- HSA drain did not fire"
 echo "OmpDevCov: device profraw(s): ${dev[*]}"
 
+# 3. Merge and verify real device counts: classify must have both branches
+#    exercised on-device (nonzero, nonzero).
 "$PROFDATA" merge -o merged.profdata ./*.profraw
+"$PROFDATA" show --all-functions --counts merged.profdata > devcov-profile.txt
 
-# 3. The merged profile must carry the device offload function counters.
-"$PROFDATA" show --all-functions merged.profdata | "$FILECHECK" check.txt
+# Pull classify's "Block counts: [a, b, ...]" line and require every counter > 0.
+bc="$(awk '/[;:]classify:$/ {f=1; next} f && /Block counts:/ {print; exit}' devcov-profile.txt)"
+[ -n "$bc" ] || fail "device function classify absent from merged profile (HSA drain did not capture it)"
+nums="$(printf '%s\n' "$bc" | grep -oE '[0-9]+')"
+[ -n "$nums" ] || fail "could not parse classify block counts from: $bc"
+for n in $nums; do
+  [ "$n" -gt 0 ] 2>/dev/null || fail "classify has a zero block count ($bc) -- device branch not profiled"
+done
+echo "OmpDevCov: classify $bc (all branches nonzero)"
 
 # 4. -fprofile-use round trip: must consume the profile without a mismatch /
 #    out-of-date diagnostic, then run.
 use_log="$(mktemp)"
 "$CLANG" -fopenmp --offload-arch="$ARCH" -fprofile-use=merged.profdata \
   omp_pgo.c -o omp_pgo_use -Wl,-rpath,"$AOMP/lib" 2> "$use_log" || {
-    echo "FAIL OmpDevCov: -fprofile-use build failed"; cat "$use_log"; rm -f "$use_log"; exit 1; }
+    echo "--- profile-use build log ---"; cat "$use_log"; rm -f "$use_log"
+    fail "-fprofile-use build failed"; }
 if grep -Eiq "out of date|profile data may be out of date|no profile data available|mismatch" "$use_log"; then
-  echo "FAIL OmpDevCov: -fprofile-use reported stale/mismatched profile"
-  cat "$use_log"; rm -f "$use_log"; exit 1
+  echo "--- profile-use build log ---"; cat "$use_log"; rm -f "$use_log"
+  fail "-fprofile-use reported a stale/mismatched profile"
 fi
 rm -f "$use_log"
 
 run_env ./omp_pgo_use
 
-echo "OmpDevCov PASSED"
+echo "OmpDevCov PASSED (classify branches profiled on device, -fprofile-use round trip clean)"


### PR DESCRIPTION
## Summary
Follow-up to #2311. The original `HipDevCov`/`OmpDevCov` only checked that a symbol was present in the merged profile, and `check_smoke_dev.sh` runs `make check > /dev/null` so that output was discarded — meaning a pass didn't actually prove the HSA drain collected anything. This makes the checks meaningful.

- **HipDevCov** now:
  - requires the HSA-introspection drain's uniquely-named profraw (`*.hsa<N>.*.profraw`) — a direct fingerprint that the HSA pass ran (host-shadow names files `<arch>[:feat].<file>.profraw`);
  - asserts `mod_kernel` (loaded via `hipModuleLoad`, no host shadow) **and** `host_kernel` are present with **nonzero function counts** — `mod_kernel` can only be there via the HSA drain.
- **OmpDevCov** now asserts the device function `classify` has **nonzero counts on both branches** of its data-dependent `if/else` (real device PGO data, e.g. `Block counts: [2048, 2048]`), in addition to the device profraw and the `-fprofile-use` round trip.

Both dump the merged profile to `devcov-profile.txt` (kept for inspection / archived with results) and leave a `DEVCOV-SKIPPED.txt` marker when a toolchain genuinely lacks the device profile runtime, so a skip is visible rather than a silent pass. The FileCheck symbol-presence files (`check.txt`) are removed in favor of explicit, well-messaged assertions.

## Test plan
- [x] `make check` → `TEST_STATUS=0` for both on gfx90a (MI210): `HipDevCov PASSED (mod_kernel=64 via HSA drain, host_kernel=64)`, `OmpDevCov PASSED (classify [2048, 2048] all branches nonzero)`.
- [x] Negative-tested the count logic: zero counts and missing function both FAIL.
- [x] shellcheck clean (passes `aomp-lint`).

Made with [Cursor](https://cursor.com)