### PR TITLE
[SMOKE] turn on -fuse-emissary-print so printf n format works

### DIFF
--- a/test/smoke/helloworld%n/Makefile
+++ b/test/smoke/helloworld%n/Makefile
@@ -5,6 +5,11 @@ TESTSRC_MAIN = helloworld.c
 TESTSRC_AUX  =
 TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
 
+# The %n printf format does not work with libc printf so force emissary printf
+ifeq ($(shell echo 'int main() { return 0; }' | $(CC) -fuse-emissary-print -xc - 2>/dev/null && echo true), true)
+  EXTRA_CFLAGS=-fuse-emissary-print
+endif
+
 CLANG        ?= clang
 OMP_BIN      = $(AOMP)/bin/$(CLANG)
 CC           = $(OMP_BIN) $(VERBOSE)


### PR DESCRIPTION
## Motivation

The printf in libc does not work with %n format specification.
But it does work with emissary printf.  In the new emissary support the default for printf and fprintf will be libc.
To use emissary print, user must opt in. 

## Technical Details

The option -fuse-emissary-print will be needed to opt-in. 

## Test Plan

The command line option -fuse-emissary-print is not the default so it must be turned on when that option exists.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
