### PR TITLE
[build_prereq.sh]  Change to cmake version 3.31.11

### DIFF
--- a/bin/build_supp.sh
+++ b/bin/build_supp.sh
@@ -688,7 +688,7 @@ function buildfftw(){
 
 function buildcmake(){
   _cname="cmake"
-  _version=3.25.2
+  _version=3.31.11
   _installdir=$AOMP_SUPP_INSTALL/$_cname-$_version
   _linkfrom=$AOMP_SUPP/$_cname
   _builddir=$AOMP_SUPP_BUILD/$_cname 


### PR DESCRIPTION
## Motivation

Future release of upstream llvm-project will not work with current cmake 3.26.1 .  This PR will force the build of 3.31.11 for aomp. 

I tested full build_aomp.sh with 3.31.11 and no problems.  The warning message about future change when away.