### PR TITLE
[smoke-fort-dev] Add test which checks Flang-RT runtime

### DIFF
--- a/test/smoke-fort-dev/device_intrinsics_map/Makefile
+++ b/test/smoke-fort-dev/device_intrinsics_map/Makefile
@@ -1,0 +1,18 @@
+#NOOPT        = 1
+#NOOMP        = 1
+#OMP_FLAGS    = -fopenmp
+include ../../Makefile.defs
+
+TESTNAME     = device_intrinsics_map
+TESTSRC_MAIN = device_intrinsics_map.f90
+TESTSRC_AUX  =
+TESTSRC_ALL  = $(TESTSRC_MAIN) $(TESTSRC_AUX)
+
+FLANG        ?= flang
+OMP_BIN      = $(AOMP)/bin/$(FLANG)
+CC           = $(OMP_BIN) $(VERBOSE)
+CFLAGS       = $(FLANG_GPU_LINK_FLAGS)
+#-ccc-print-phases
+#"-\#\#\#"
+
+include ../Makefile.rules

--- a/test/smoke-fort-dev/device_intrinsics_map/device_intrinsics_map.f90
+++ b/test/smoke-fort-dev/device_intrinsics_map/device_intrinsics_map.f90
@@ -1,0 +1,48 @@
+!
+!Copyright © Advanced Micro Devices, Inc., or its affiliates.
+!
+!SPDX-License-Identifier:  MIT
+! 
+module mod
+    implicit none
+contains
+    subroutine assgn(a, ma, mi, ms)
+        implicit none
+        real, dimension(:), allocatable :: a
+        real :: ma, mi, ms
+        !$omp target map(tofrom: a,ma,mi,ms)
+            ma = maxval(a)
+            mi = minval(a)
+            ms = sum(a)
+        !$omp end target
+    end subroutine assgn
+end module mod
+
+program device_intrinsics
+    use mod
+    implicit none
+
+    integer, parameter :: n = 1024
+    integer :: i
+    real, dimension(:), allocatable :: a
+    real, dimension(:), allocatable :: b
+    real :: ma, mi, ms
+
+    allocate(a(n))
+    allocate(b(n))
+
+    a = [( real(i),i=1,n )]
+    b = [( real(i),i=1,n )]
+
+    !$omp target enter data map(to:a) map(alloc:ma,mi,ms)
+    call assgn(a, ma, mi, ms)
+    !$omp target exit data map(delete:a) map(from:ma,mi,ms)
+
+    if (mi /= minval(b) .or. ma /= maxval(b) .or. ms /= sum(b)) then
+        print '(a)', 'ERROR'
+        stop 1
+    end if
+    print '(a)', 'SUCCESS'
+
+    deallocate(a)
+end program device_intrinsics


### PR DESCRIPTION
Test checks Flang-RT for the GPU code and it uses explicit mapping for the target region.

## Motivation

Check if Flang-RT works with explicit mapping clauses

