### PR TITLE
[run_rocm_test] add rocm/bin to end of path, systems are being config…

### DIFF
--- a/bin/run_rocm_test.sh
+++ b/bin/run_rocm_test.sh
@@ -139,6 +139,10 @@ else
   echo "       Note that AOMP needs the llvm or lib/llvm path suffix."
   exit 1
 fi
+
+echo ROCMDIR=$ROCMDIR/bin
+export PATH=$PATH:$ROCMDIR/bin
+
 export AOMP
 echo "AOMP = $AOMP"
 export REAL_AOMP=`realpath $AOMP`


### PR DESCRIPTION
 systems are more frequently not having /opt/rocm*/bin in patch