### PR TITLE
[smoke] omp_target_is: 28943 , test missing mi350 ifdef

### DIFF
--- a/test/smoke/omp_target_is/omp_target_is.cpp
+++ b/test/smoke/omp_target_is/omp_target_is.cpp
@@ -3,7 +3,7 @@
 
 // The test is meant to run in both USM and non-USM mode.
 
-#if defined(__OFFLOAD_ARCH_gfx90a__) || defined(__OFFLOAD_ARCH_gfx90c__) || defined(__OFFLOAD_ARCH_gfx940__) || defined(__OFFLOAD_ARCH_gfx941__) || defined(__OFFLOAD_ARCH_gfx942__) || defined(__OFFLOAD_ARCH_gfx1010__) || defined(__OFFLOAD_ARCH_gfx1011__) || defined(__OFFLOAD_ARCH_gfx1012__) || defined(__OFFLOAD_ARCH_gfx1013__)
+#if defined(__OFFLOAD_ARCH_gfx90a__) || defined(__OFFLOAD_ARCH_gfx90c__) || defined(__OFFLOAD_ARCH_gfx940__) || defined(__OFFLOAD_ARCH_gfx941__) || defined(__OFFLOAD_ARCH_gfx942__) || defined(__OFFLOAD_ARCH_gfx1010__) || defined(__OFFLOAD_ARCH_gfx1011__) || defined(__OFFLOAD_ARCH_gfx1012__) || defined(__OFFLOAD_ARCH_gfx1013__) || defined(__OFFLOAD_ARCH_gfx950__) || defined(__OFFLOAD_ARCH_gfx1250__) || defined(__OFFLOAD_ARCH_gfx1251__)
 #define IS_USM 1
 #else
 #define IS_USM 0


### PR DESCRIPTION
 a followup PR will clean up the mi450 makefile issue where xnack+ cannot be specified.
noticed during testing 