### PR TITLE
[aomp][gfx125x]  smoke and examples: do not specify xnack- or xnack+ on target gpu

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -34,6 +34,8 @@ else
                 gfx941, gfx941:xnack+,\
                 gfx942, gfx942:xnack+,\
                 gfx950, gfx950:xnack+,\
+                gfx1250, gfx1250:xnack+,\
+                gfx1251, gfx1251:xnack+,\
                 gfx1010, gfx1010:xnack+\
                 gfx1011, gfx1011:xnack+\
                 gfx1012, gfx1012:xnack+\
@@ -272,7 +274,14 @@ ifeq ($(AOMP_SANITIZER),1)
   HSA_XNACK = 1
   ASAN_FLAGS = -fsanitize=address -shared-libasan -g
   #ASan requires xnack+ by default
-  AOMP_TARGET_FEATURES = :xnack+
+  ifeq ("$(AOMP_GPU)","gfx1250")
+    AOMP_TARGET_FEATURES =
+  else ifeq ("$(AOMP_GPU)","gfx1251")
+    AOMP_TARGET_FEATURES =
+  else
+    AOMP_TARGET_FEATURES = :xnack+
+  endif
+
   ASAN_UNSUPPORTED = ASAN_COMPILE ASAN_RUNTIME
 endif
 

--- a/test/smoke-dev/leopold-devicePtr/Makefile
+++ b/test/smoke-dev/leopold-devicePtr/Makefile
@@ -1,6 +1,13 @@
 include ../../Makefile.defs
 HSA_XNACK    ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
+
 
 TESTNAME     = leopold-devicePtr
 TESTSRC_MAIN = leopold-devicePtr.cpp

--- a/test/smoke-fails/FNew-flang-usm/Makefile
+++ b/test/smoke-fails/FNew-flang-usm/Makefile
@@ -1,7 +1,13 @@
 include ../../Makefile.defs
 USE_OFFLOAD_ARCH = 1
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = flang-usm
 TESTSRC_MAIN = flang-usm.f90

--- a/test/smoke-fails/flang-usm-235/Makefile
+++ b/test/smoke-fails/flang-usm-235/Makefile
@@ -1,5 +1,12 @@
 USE_OFFLOAD_ARCH = 1
-AOMP_TARGET_FEATURES=:xnack-
+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack-
+endif
 
 include ../../Makefile.defs
 

--- a/test/smoke-fails/flang-usm1/Makefile
+++ b/test/smoke-fails/flang-usm1/Makefile
@@ -1,5 +1,11 @@
 USE_OFFLOAD_ARCH = 1
-AOMP_TARGET_FEATURES=:xnack-
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack-
+endif
 
 include ../../Makefile.defs
 

--- a/test/smoke-fails/flang-usm2/Makefile
+++ b/test/smoke-fails/flang-usm2/Makefile
@@ -1,5 +1,11 @@
 USE_OFFLOAD_ARCH = 1
-AOMP_TARGET_FEATURES=:xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 include ../../Makefile.defs
 

--- a/test/smoke-fails/get_mapped_ptr/Makefile
+++ b/test/smoke-fails/get_mapped_ptr/Makefile
@@ -1,6 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = get_mapped_ptr
 TESTSRC_MAIN = get_mapped_ptr.cpp

--- a/test/smoke/clang-274983/Makefile
+++ b/test/smoke/clang-274983/Makefile
@@ -1,6 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = clang-274983
 TESTSRC_MAIN = clang-274983.cpp

--- a/test/smoke/managed_memory/Makefile
+++ b/test/smoke/managed_memory/Makefile
@@ -1,6 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = managed_memory
 TESTSRC_MAIN = managed_memory.cpp

--- a/test/smoke/omp_target_is/Makefile
+++ b/test/smoke/omp_target_is/Makefile
@@ -1,7 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
-
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 TESTNAME     = omp_target_is
 TESTSRC_MAIN = omp_target_is.cpp
 TESTSRC_AUX  =

--- a/test/smoke/requires_usm/Makefile
+++ b/test/smoke/requires_usm/Makefile
@@ -1,6 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = requires_usm
 TESTSRC_MAIN = requires_usm.cpp

--- a/test/smoke/usm1/Makefile
+++ b/test/smoke/usm1/Makefile
@@ -1,6 +1,12 @@
 include ../../Makefile.defs
 HSA_XNACK        ?= 1
-AOMP_TARGET_FEATURES = :xnack+
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack+
+endif
 
 TESTNAME     = usm1
 TESTSRC_MAIN = usm1.cpp

--- a/test/usm/flang-off-arch-xnack/Makefile
+++ b/test/usm/flang-off-arch-xnack/Makefile
@@ -1,5 +1,11 @@
 USE_OFFLOAD_ARCH = 1
-AOMP_TARGET_FEATURES=:xnack-
+ifeq ("$(AOMP_GPU)","gfx1250")
+  AOMP_TARGET_FEATURES =
+else ifeq ("$(AOMP_GPU)","gfx1251")
+  AOMP_TARGET_FEATURES =
+else
+  AOMP_TARGET_FEATURES = :xnack-
+endif
 
 include ../../Makefile.defs
 


### PR DESCRIPTION
gfx1250 and gfx1251 does not allow a :xnack setting 
removing these from tests.
