### PR TITLE
[test] Add gfx1250/gfx1251 support and strip xnack target features

### DIFF
--- a/test/Makefile.defs
+++ b/test/Makefile.defs
@@ -37,7 +37,9 @@ else
                 gfx1010, gfx1010:xnack+\
                 gfx1011, gfx1011:xnack+\
                 gfx1012, gfx1012:xnack+\
-                gfx1013, gfx1013:xnack+
+                gfx1013, gfx1013:xnack+\
+                gfx1250,\
+                gfx1251
 endif
 
 
@@ -274,6 +276,18 @@ ifeq ($(AOMP_SANITIZER),1)
   #ASan requires xnack+ by default
   AOMP_TARGET_FEATURES = :xnack+
   ASAN_UNSUPPORTED = ASAN_COMPILE ASAN_RUNTIME
+endif
+
+# gfx1250 and gfx1251 always operate with xnack enabled and the compiler
+# rejects an explicit xnack target feature (e.g. :xnack+) on these
+# architectures. Drop any requested xnack feature so tests that hard-code
+# AOMP_TARGET_FEATURES still build and run. All other architectures keep the
+# existing behavior.
+ifneq (,$(findstring gfx1250,$(AOMP_GPU)))
+  AOMP_TARGET_FEATURES := $(subst :xnack-,,$(subst :xnack+,,$(AOMP_TARGET_FEATURES)))
+endif
+ifneq (,$(findstring gfx1251,$(AOMP_GPU)))
+  AOMP_TARGET_FEATURES := $(subst :xnack-,,$(subst :xnack+,,$(AOMP_TARGET_FEATURES)))
 endif
 
 ifeq ($(AOMP_TARGET_FEATURES),)

--- a/test/smoke/Makefile.rules
+++ b/test/smoke/Makefile.rules
@@ -28,6 +28,19 @@ prerequisites:
 	@echo ">>> $(SCRIPT_INIT) >>>"
 endif
 
+# gfx1250 and gfx1251 always operate with xnack enabled and the compiler
+# rejects an explicit xnack target feature (e.g. :xnack+) on these
+# architectures. Individual tests set AOMP_TARGET_FEATURES after including
+# Makefile.defs, so strip any requested xnack feature here (Makefile.rules is
+# included last) to keep it off the compile line and out of the SUPPORTED
+# matching. All other architectures keep the existing behavior.
+ifneq (,$(findstring gfx1250,$(AOMP_GPU)))
+  AOMP_TARGET_FEATURES := $(subst :xnack-,,$(subst :xnack+,,$(AOMP_TARGET_FEATURES)))
+endif
+ifneq (,$(findstring gfx1251,$(AOMP_GPU)))
+  AOMP_TARGET_FEATURES := $(subst :xnack-,,$(subst :xnack+,,$(AOMP_TARGET_FEATURES)))
+endif
+
 # ----- If SUPPORTED is empty then it means that there is no
 # restriction for the test and the test can be compiled and run
 # on the current GPU architecture.


### PR DESCRIPTION
## Motivation

gfx1250 and gfx1251 always operate with xnack enabled and the compiler rejects explicit :xnack+/:xnack- target features. Add these GPUs to the supported list and remove any requested xnack feature from AOMP_TARGET_FEATURES in both Makefile.defs and Makefile.rules so tests that hard-code features still build and run.

## Technical Details

Sustitute AOMP_TARGET_FEATURES with empty string if AOMP_GPU is gfx1250/gfx1251.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
