### PR TITLE
[smoke-limbo] mix_hipmemset_omp: verify through a host copy

### DIFF
--- a/test/smoke-limbo/mix_hipmemset_omp/memset.cpp
+++ b/test/smoke-limbo/mix_hipmemset_omp/memset.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <omp.h>
 #include "hip_memset.h"
 
@@ -6,14 +7,29 @@
 
 int main() {
   int n = N;
-  int *a = (int *) omp_target_alloc(n * sizeof(int), omp_get_default_device());
+  int dev = omp_get_default_device();
+  int host = omp_get_initial_device();
+  int *a = (int *) omp_target_alloc(n * sizeof(int), dev);
   set_mem(a, n);
+
+  // a is device memory, so it cannot be read from host code. Whether such a
+  // read happens to work is decided by how much of the GPU memory the CPU can
+  // map, which varies from machine to machine.
+  int *b = (int *) malloc(n * sizeof(int));
+  if (omp_target_memcpy(b, a, n * sizeof(int), 0, 0, host, dev)) {
+    printf("omp_target_memcpy failed\n");
+    return 1;
+  }
+
   int err = 0;
   for(int i = 0; i < n; i++)
-    if (a[i] != 0) {
-      printf("Error at %d: a[%d] = %d\n", i, i, a[i]);
+    if (b[i] != 0) {
+      printf("Error at %d: a[%d] = %d\n", i, i, b[i]);
       err++;
       if (err > 10) break;
     }
+
+  free(b);
+  omp_target_free(a, dev);
   return err;
 }


### PR DESCRIPTION
The test read the omp_target_alloc'd buffer directly from host code, but that pointer refers to device memory. Whether such a read works depends on the PCIe Resizable BAR setting, so the test passed on machines where the CPU can map all of GPU memory and segfaulted where only the legacy 256MB window is visible. Two gfx1030 machines differing only in that setting disagreed, which is what surfaced it.

Copy the buffer back with omp_target_memcpy before checking it. The HIP side of the test is unchanged.

